### PR TITLE
Clarify energy swirl-related mappings

### DIFF
--- a/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/unmapped/C_nayragwg net/minecraft/client/render/entity/feature/ConditionalOverlayOwner
+	METHOD m_qkiwsozo isOverlayConditionMet ()Z
+		COMMENT Returns whenever the entity's condition has been met to render its overlay.
+		COMMENT
+		COMMENT <p>This method is present on the server but without implementing this client-sided interface,
+		COMMENT and may be used in the overlay owner's internal logic in order to get the condition state.
+		COMMENT
+		COMMENT @return {@code true} if the condition behind overlay rendering is met, {@code false} otherwise.

--- a/mappings/net/minecraft/client/render/entity/feature/EnergySwirlOverlayFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/EnergySwirlOverlayFeatureRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/unmapped/C_foabjgnh net/minecraft/client/render/entity/feature/EnergySwirlOverlayFeatureRenderer
 	METHOD m_azwgkwpf getEnergySwirlModel ()Lnet/minecraft/unmapped/C_yqrqvuof;
 	METHOD m_dfsprcxp getEnergySwirlTexture ()Lnet/minecraft/unmapped/C_acfwypcn;
-	METHOD m_zjyrvvxx getEnergySwirlX (F)F
+	METHOD m_zjyrvvxx getEnergySwirlOffsetX (F)F
 		ARG 1 partialAge

--- a/mappings/net/minecraft/client/render/entity/feature/SkinOverlayOwner.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/SkinOverlayOwner.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_nayragwg net/minecraft/client/render/entity/feature/SkinOverlayOwner
-	METHOD m_qkiwsozo shouldRenderOverlay ()Z


### PR DESCRIPTION
The main confusing ones being `SkinOverlayOwner` and its only method, `shouldRenderOverlay`, which have been respectively renamed to `ConditionalOverlayOwner` and `isOverlayConditionMet` in this PR

Why? Because `SkinOverlayOwner` and `shouldRenderOverlay` are both non-descriptive names.
`SkinOverlayOwner` is not used by entities who have something that can be called a skin (ex: players, zombies, etc.) and is only used by two entities with one thing in common: they both have an energy swirl overlay (charged creeper's charge and the wither's armor) which are rendered when a specific condition is met (if a creeper is charged or if the wither has half of full health), and so, `SkinOverlayOwner` became `ConditionalOverlayOwner`.

`shouldRenderOverlay`, on another hand, appears to be doing a good job, and it is used in order to know if the overlay should be rendered or not. However, there's an important detail that the name fails to acknowledge: this method is also used by the overlay owners for their own internal logic (by creepers in order to do charged creeper things like increased explosion radius; and by the wither in order to make the armor block projectiles) since despite the interface not being implemented on server-side, the methods are still present on it, and so, I added a Javadoc in order to explain that it may be used for such cases and renamed it to `isOverlayConditionMet`, which hopefully makes the method's purpose more clear.

As a misc thing, I renamed `getEnergySwirlX` to `getEnergySwirlOffsetX`, since just having `X` is not enough to explain it and since it's used as the overlay's offset, it has been renamed in order to make the method more clear. I wanted to apply this same change to more areas, but I feel like it would perhaps be better done in a bigger rendering-related PR (and thinking about it, now I feel like this probably should be cut from this PR for now? I don't know)