### PR TITLE
Rename FoxEntity's EatSweetBerriesGoal to PickBerriesGoal

### DIFF
--- a/mappings/net/minecraft/entity/passive/FoxEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FoxEntity.mapping
@@ -143,9 +143,9 @@ CLASS net/minecraft/unmapped/C_nsuhnixa net/minecraft/entity/passive/FoxEntity
 			ARG 4 checkCanNavigate
 			ARG 5 targetPredicate
 	CLASS C_svticulc FoxLookControl
-	CLASS C_szdcjydj EatSweetBerriesGoal
+	CLASS C_szdcjydj PickBerriesGoal
 		FIELD f_connxjos timer I
-		FIELD f_fxmrekfc EATING_TIME I
+		FIELD f_fxmrekfc PICKING_TIME I
 		METHOD <init> (Lnet/minecraft/unmapped/C_nsuhnixa;DII)V
 			ARG 2 speed
 			ARG 4 range
@@ -154,7 +154,7 @@ CLASS net/minecraft/unmapped/C_nsuhnixa net/minecraft/entity/passive/FoxEntity
 			ARG 1 state
 		METHOD m_fiyjroer pickGlowBerries (Lnet/minecraft/unmapped/C_pmeibtxt;)V
 			ARG 1 state
-		METHOD m_mnhaxxlo eatSweetBerry ()V
+		METHOD m_mnhaxxlo pickFromTargetBlock ()V
 	CLASS C_umelfski FoxData
 		FIELD f_eivjvpvv type Lnet/minecraft/unmapped/C_nsuhnixa$C_zktzgceq;
 		METHOD <init> (Lnet/minecraft/unmapped/C_nsuhnixa$C_zktzgceq;)V


### PR DESCRIPTION
This is another mapping that on a glance seems to be right but on a closer look, isn't
The goal currently named `EatSweetBerriesGoal` only makes foxes pick berries from either sweet berry bushes or from cave vines, but it doesn't make the fox eat it. In comparison, rabbits have the goal named `EatCarrotCropGoal`, which does make rabbits directly eat from carrots crops
Another thing is that the old names only acknowledges sweet berries, while 1.17 had introduced glow berries, which are also picked by foxes with this goal
This PR renames it to `PickBerriesGoal`, renames the `eatSweetBerry` method to `pickFromTargetBlock` and the `EATING_TIME` field to `PICKING_TIME`