### PR TITLE
Fix hashed names in package info mappings

### DIFF
--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaadzuzno.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaadzuzno.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aadzuzno net/minecraft/unused/packageinfo/PackageInfoaadzuzno
+CLASS net/minecraft/unmapped/C_aadzuzno net/minecraft/unused/packageinfo/PackageInfoaadzuzno

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoabchfxkm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoabchfxkm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_abchfxkm net/minecraft/unused/packageinfo/PackageInfoabchfxkm
+CLASS net/minecraft/unmapped/C_abchfxkm net/minecraft/unused/packageinfo/PackageInfoabchfxkm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoabyuoort.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoabyuoort.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_abyuoort net/minecraft/unused/packageinfo/PackageInfoabyuoort
+CLASS net/minecraft/unmapped/C_abyuoort net/minecraft/unused/packageinfo/PackageInfoabyuoort

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoacqrzjvg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoacqrzjvg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_acqrzjvg net/minecraft/unused/packageinfo/PackageInfoacqrzjvg
+CLASS net/minecraft/unmapped/C_acqrzjvg net/minecraft/unused/packageinfo/PackageInfoacqrzjvg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaczhhbks.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaczhhbks.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aczhhbks net/minecraft/unused/packageinfo/PackageInfoaczhhbks
+CLASS net/minecraft/unmapped/C_aczhhbks net/minecraft/unused/packageinfo/PackageInfoaczhhbks

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoadsbtesx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoadsbtesx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_adsbtesx net/minecraft/unused/packageinfo/PackageInfoadsbtesx
+CLASS net/minecraft/unmapped/C_adsbtesx net/minecraft/unused/packageinfo/PackageInfoadsbtesx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoahirncwh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoahirncwh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ahirncwh net/minecraft/unused/packageinfo/PackageInfoahirncwh
+CLASS net/minecraft/unmapped/C_ahirncwh net/minecraft/unused/packageinfo/PackageInfoahirncwh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoajlgkyss.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoajlgkyss.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ajlgkyss net/minecraft/unused/packageinfo/PackageInfoajlgkyss
+CLASS net/minecraft/unmapped/C_ajlgkyss net/minecraft/unused/packageinfo/PackageInfoajlgkyss

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoajshnjjn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoajshnjjn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ajshnjjn net/minecraft/unused/packageinfo/PackageInfoajshnjjn
+CLASS net/minecraft/unmapped/C_ajshnjjn net/minecraft/unused/packageinfo/PackageInfoajshnjjn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoammzdejz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoammzdejz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ammzdejz net/minecraft/unused/packageinfo/PackageInfoammzdejz
+CLASS net/minecraft/unmapped/C_ammzdejz net/minecraft/unused/packageinfo/PackageInfoammzdejz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoamxhrnqg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoamxhrnqg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_amxhrnqg net/minecraft/unused/packageinfo/PackageInfoamxhrnqg
+CLASS net/minecraft/unmapped/C_amxhrnqg net/minecraft/unused/packageinfo/PackageInfoamxhrnqg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaoawmvnt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaoawmvnt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aoawmvnt net/minecraft/unused/packageinfo/PackageInfoaoawmvnt
+CLASS net/minecraft/unmapped/C_aoawmvnt net/minecraft/unused/packageinfo/PackageInfoaoawmvnt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaomxqure.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaomxqure.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aomxqure net/minecraft/unused/packageinfo/PackageInfoaomxqure
+CLASS net/minecraft/unmapped/C_aomxqure net/minecraft/unused/packageinfo/PackageInfoaomxqure

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaotcmgoj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaotcmgoj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aotcmgoj net/minecraft/unused/packageinfo/PackageInfoaotcmgoj
+CLASS net/minecraft/unmapped/C_aotcmgoj net/minecraft/unused/packageinfo/PackageInfoaotcmgoj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoarxatcmd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoarxatcmd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_arxatcmd net/minecraft/unused/packageinfo/PackageInfoarxatcmd
+CLASS net/minecraft/unmapped/C_arxatcmd net/minecraft/unused/packageinfo/PackageInfoarxatcmd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoawwqlanb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoawwqlanb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_awwqlanb net/minecraft/unused/packageinfo/PackageInfoawwqlanb
+CLASS net/minecraft/unmapped/C_awwqlanb net/minecraft/unused/packageinfo/PackageInfoawwqlanb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoaypjlfrq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoaypjlfrq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_aypjlfrq net/minecraft/unused/packageinfo/PackageInfoaypjlfrq
+CLASS net/minecraft/unmapped/C_aypjlfrq net/minecraft/unused/packageinfo/PackageInfoaypjlfrq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfobhmwnquq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfobhmwnquq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_bhmwnquq net/minecraft/unused/packageinfo/PackageInfobhmwnquq
+CLASS net/minecraft/unmapped/C_bhmwnquq net/minecraft/unused/packageinfo/PackageInfobhmwnquq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoblvtgozr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoblvtgozr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_blvtgozr net/minecraft/unused/packageinfo/PackageInfoblvtgozr
+CLASS net/minecraft/unmapped/C_blvtgozr net/minecraft/unused/packageinfo/PackageInfoblvtgozr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfobosphlsk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfobosphlsk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_bosphlsk net/minecraft/unused/packageinfo/PackageInfobosphlsk
+CLASS net/minecraft/unmapped/C_bosphlsk net/minecraft/unused/packageinfo/PackageInfobosphlsk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfobsiykbrx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfobsiykbrx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_bsiykbrx net/minecraft/unused/packageinfo/PackageInfobsiykbrx
+CLASS net/minecraft/unmapped/C_bsiykbrx net/minecraft/unused/packageinfo/PackageInfobsiykbrx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocbelpwzz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocbelpwzz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cbelpwzz net/minecraft/unused/packageinfo/PackageInfocbelpwzz
+CLASS net/minecraft/unmapped/C_cbelpwzz net/minecraft/unused/packageinfo/PackageInfocbelpwzz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocgusjcac.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocgusjcac.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cgusjcac net/minecraft/unused/packageinfo/PackageInfocgusjcac
+CLASS net/minecraft/unmapped/C_cgusjcac net/minecraft/unused/packageinfo/PackageInfocgusjcac

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocpnfmnnl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocpnfmnnl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cpnfmnnl net/minecraft/unused/packageinfo/PackageInfocpnfmnnl
+CLASS net/minecraft/unmapped/C_cpnfmnnl net/minecraft/unused/packageinfo/PackageInfocpnfmnnl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocroijyci.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocroijyci.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_croijyci net/minecraft/unused/packageinfo/PackageInfocroijyci
+CLASS net/minecraft/unmapped/C_croijyci net/minecraft/unused/packageinfo/PackageInfocroijyci

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocrqhwhvl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocrqhwhvl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_crqhwhvl net/minecraft/unused/packageinfo/PackageInfocrqhwhvl
+CLASS net/minecraft/unmapped/C_crqhwhvl net/minecraft/unused/packageinfo/PackageInfocrqhwhvl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocssrugqr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocssrugqr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cssrugqr net/minecraft/unused/packageinfo/PackageInfocssrugqr
+CLASS net/minecraft/unmapped/C_cssrugqr net/minecraft/unused/packageinfo/PackageInfocssrugqr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocwuokjtu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocwuokjtu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cwuokjtu net/minecraft/unused/packageinfo/PackageInfocwuokjtu
+CLASS net/minecraft/unmapped/C_cwuokjtu net/minecraft/unused/packageinfo/PackageInfocwuokjtu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocxdwharm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocxdwharm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cxdwharm net/minecraft/unused/packageinfo/PackageInfocxdwharm
+CLASS net/minecraft/unmapped/C_cxdwharm net/minecraft/unused/packageinfo/PackageInfocxdwharm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfocycfovow.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfocycfovow.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_cycfovow net/minecraft/unused/packageinfo/PackageInfocycfovow
+CLASS net/minecraft/unmapped/C_cycfovow net/minecraft/unused/packageinfo/PackageInfocycfovow

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodanfkylk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodanfkylk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_danfkylk net/minecraft/unused/packageinfo/PackageInfodanfkylk
+CLASS net/minecraft/unmapped/C_danfkylk net/minecraft/unused/packageinfo/PackageInfodanfkylk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodawjgmgb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodawjgmgb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dawjgmgb net/minecraft/unused/packageinfo/PackageInfodawjgmgb
+CLASS net/minecraft/unmapped/C_dawjgmgb net/minecraft/unused/packageinfo/PackageInfodawjgmgb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodcxnqqdc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodcxnqqdc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dcxnqqdc net/minecraft/unused/packageinfo/PackageInfodcxnqqdc
+CLASS net/minecraft/unmapped/C_dcxnqqdc net/minecraft/unused/packageinfo/PackageInfodcxnqqdc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodgydquzk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodgydquzk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dgydquzk net/minecraft/unused/packageinfo/PackageInfodgydquzk
+CLASS net/minecraft/unmapped/C_dgydquzk net/minecraft/unused/packageinfo/PackageInfodgydquzk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodjinqijc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodjinqijc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_djinqijc net/minecraft/unused/packageinfo/PackageInfodjinqijc
+CLASS net/minecraft/unmapped/C_djinqijc net/minecraft/unused/packageinfo/PackageInfodjinqijc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodmlnwige.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodmlnwige.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dmlnwige net/minecraft/unused/packageinfo/PackageInfodmlnwige
+CLASS net/minecraft/unmapped/C_dmlnwige net/minecraft/unused/packageinfo/PackageInfodmlnwige

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodnbsuczm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodnbsuczm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dnbsuczm net/minecraft/unused/packageinfo/PackageInfodnbsuczm
+CLASS net/minecraft/unmapped/C_dnbsuczm net/minecraft/unused/packageinfo/PackageInfodnbsuczm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodonvxeld.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodonvxeld.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_donvxeld net/minecraft/unused/packageinfo/PackageInfodonvxeld
+CLASS net/minecraft/unmapped/C_donvxeld net/minecraft/unused/packageinfo/PackageInfodonvxeld

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodoqtmbdl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodoqtmbdl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_doqtmbdl net/minecraft/unused/packageinfo/PackageInfodoqtmbdl
+CLASS net/minecraft/unmapped/C_doqtmbdl net/minecraft/unused/packageinfo/PackageInfodoqtmbdl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodrrextuw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodrrextuw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_drrextuw net/minecraft/unused/packageinfo/PackageInfodrrextuw
+CLASS net/minecraft/unmapped/C_drrextuw net/minecraft/unused/packageinfo/PackageInfodrrextuw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfodwzbavgv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfodwzbavgv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_dwzbavgv net/minecraft/unused/packageinfo/PackageInfodwzbavgv
+CLASS net/minecraft/unmapped/C_dwzbavgv net/minecraft/unused/packageinfo/PackageInfodwzbavgv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoedphqveu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoedphqveu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_edphqveu net/minecraft/unused/packageinfo/PackageInfoedphqveu
+CLASS net/minecraft/unmapped/C_edphqveu net/minecraft/unused/packageinfo/PackageInfoedphqveu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoegpvpgrk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoegpvpgrk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_egpvpgrk net/minecraft/unused/packageinfo/PackageInfoegpvpgrk
+CLASS net/minecraft/unmapped/C_egpvpgrk net/minecraft/unused/packageinfo/PackageInfoegpvpgrk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoehkzgtxh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoehkzgtxh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ehkzgtxh net/minecraft/unused/packageinfo/PackageInfoehkzgtxh
+CLASS net/minecraft/unmapped/C_ehkzgtxh net/minecraft/unused/packageinfo/PackageInfoehkzgtxh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoehmeacoe.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoehmeacoe.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ehmeacoe net/minecraft/unused/packageinfo/PackageInfoehmeacoe
+CLASS net/minecraft/unmapped/C_ehmeacoe net/minecraft/unused/packageinfo/PackageInfoehmeacoe

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoemdikpts.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoemdikpts.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_emdikpts net/minecraft/unused/packageinfo/PackageInfoemdikpts
+CLASS net/minecraft/unmapped/C_emdikpts net/minecraft/unused/packageinfo/PackageInfoemdikpts

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoemfcdtjt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoemfcdtjt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_emfcdtjt net/minecraft/unused/packageinfo/PackageInfoemfcdtjt
+CLASS net/minecraft/unmapped/C_emfcdtjt net/minecraft/unused/packageinfo/PackageInfoemfcdtjt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoemwkzkzq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoemwkzkzq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_emwkzkzq net/minecraft/unused/packageinfo/PackageInfoemwkzkzq
+CLASS net/minecraft/unmapped/C_emwkzkzq net/minecraft/unused/packageinfo/PackageInfoemwkzkzq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoethpjcjc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoethpjcjc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ethpjcjc net/minecraft/unused/packageinfo/PackageInfoethpjcjc
+CLASS net/minecraft/unmapped/C_ethpjcjc net/minecraft/unused/packageinfo/PackageInfoethpjcjc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoetybejqm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoetybejqm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_etybejqm net/minecraft/unused/packageinfo/PackageInfoetybejqm
+CLASS net/minecraft/unmapped/C_etybejqm net/minecraft/unused/packageinfo/PackageInfoetybejqm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoevfifjtk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoevfifjtk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_evfifjtk net/minecraft/unused/packageinfo/PackageInfoevfifjtk
+CLASS net/minecraft/unmapped/C_evfifjtk net/minecraft/unused/packageinfo/PackageInfoevfifjtk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoexvoosck.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoexvoosck.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_exvoosck net/minecraft/unused/packageinfo/PackageInfoexvoosck
+CLASS net/minecraft/unmapped/C_exvoosck net/minecraft/unused/packageinfo/PackageInfoexvoosck

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoexyhtjln.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoexyhtjln.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_exyhtjln net/minecraft/unused/packageinfo/PackageInfoexyhtjln
+CLASS net/minecraft/unmapped/C_exyhtjln net/minecraft/unused/packageinfo/PackageInfoexyhtjln

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoflhfmkzs.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoflhfmkzs.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_flhfmkzs net/minecraft/unused/packageinfo/PackageInfoflhfmkzs
+CLASS net/minecraft/unmapped/C_flhfmkzs net/minecraft/unused/packageinfo/PackageInfoflhfmkzs

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfofohowmkh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfofohowmkh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_fohowmkh net/minecraft/unused/packageinfo/PackageInfofohowmkh
+CLASS net/minecraft/unmapped/C_fohowmkh net/minecraft/unused/packageinfo/PackageInfofohowmkh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfofvdtabta.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfofvdtabta.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_fvdtabta net/minecraft/unused/packageinfo/PackageInfofvdtabta
+CLASS net/minecraft/unmapped/C_fvdtabta net/minecraft/unused/packageinfo/PackageInfofvdtabta

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogbbksdwv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogbbksdwv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_gbbksdwv net/minecraft/unused/packageinfo/PackageInfogbbksdwv
+CLASS net/minecraft/unmapped/C_gbbksdwv net/minecraft/unused/packageinfo/PackageInfogbbksdwv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogcornhgg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogcornhgg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_gcornhgg net/minecraft/unused/packageinfo/PackageInfogcornhgg
+CLASS net/minecraft/unmapped/C_gcornhgg net/minecraft/unused/packageinfo/PackageInfogcornhgg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoggdabgfp.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoggdabgfp.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ggdabgfp net/minecraft/unused/packageinfo/PackageInfoggdabgfp
+CLASS net/minecraft/unmapped/C_ggdabgfp net/minecraft/unused/packageinfo/PackageInfoggdabgfp

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoghtsmeyh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoghtsmeyh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ghtsmeyh net/minecraft/unused/packageinfo/PackageInfoghtsmeyh
+CLASS net/minecraft/unmapped/C_ghtsmeyh net/minecraft/unused/packageinfo/PackageInfoghtsmeyh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoghxcrmnr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoghxcrmnr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ghxcrmnr net/minecraft/unused/packageinfo/PackageInfoghxcrmnr
+CLASS net/minecraft/unmapped/C_ghxcrmnr net/minecraft/unused/packageinfo/PackageInfoghxcrmnr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogietefuj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogietefuj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_gietefuj net/minecraft/unused/packageinfo/PackageInfogietefuj
+CLASS net/minecraft/unmapped/C_gietefuj net/minecraft/unused/packageinfo/PackageInfogietefuj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogirgucoh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogirgucoh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_girgucoh net/minecraft/unused/packageinfo/PackageInfogirgucoh
+CLASS net/minecraft/unmapped/C_girgucoh net/minecraft/unused/packageinfo/PackageInfogirgucoh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogpkgmnaw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogpkgmnaw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_gpkgmnaw net/minecraft/unused/packageinfo/PackageInfogpkgmnaw
+CLASS net/minecraft/unmapped/C_gpkgmnaw net/minecraft/unused/packageinfo/PackageInfogpkgmnaw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfogubcdhwp.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfogubcdhwp.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_gubcdhwp net/minecraft/unused/packageinfo/PackageInfogubcdhwp
+CLASS net/minecraft/unmapped/C_gubcdhwp net/minecraft/unused/packageinfo/PackageInfogubcdhwp

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohcnpnfgn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohcnpnfgn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hcnpnfgn net/minecraft/unused/packageinfo/PackageInfohcnpnfgn
+CLASS net/minecraft/unmapped/C_hcnpnfgn net/minecraft/unused/packageinfo/PackageInfohcnpnfgn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohduidsxr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohduidsxr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hduidsxr net/minecraft/unused/packageinfo/PackageInfohduidsxr
+CLASS net/minecraft/unmapped/C_hduidsxr net/minecraft/unused/packageinfo/PackageInfohduidsxr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohgipndyj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohgipndyj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hgipndyj net/minecraft/unused/packageinfo/PackageInfohgipndyj
+CLASS net/minecraft/unmapped/C_hgipndyj net/minecraft/unused/packageinfo/PackageInfohgipndyj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohkrflmwo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohkrflmwo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hkrflmwo net/minecraft/unused/packageinfo/PackageInfohkrflmwo
+CLASS net/minecraft/unmapped/C_hkrflmwo net/minecraft/unused/packageinfo/PackageInfohkrflmwo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohpbxiqyb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohpbxiqyb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hpbxiqyb net/minecraft/unused/packageinfo/PackageInfohpbxiqyb
+CLASS net/minecraft/unmapped/C_hpbxiqyb net/minecraft/unused/packageinfo/PackageInfohpbxiqyb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohqwhbsqc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohqwhbsqc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_hqwhbsqc net/minecraft/unused/packageinfo/PackageInfohqwhbsqc
+CLASS net/minecraft/unmapped/C_hqwhbsqc net/minecraft/unused/packageinfo/PackageInfohqwhbsqc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfohtuuenyw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfohtuuenyw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_htuuenyw net/minecraft/unused/packageinfo/PackageInfohtuuenyw
+CLASS net/minecraft/unmapped/C_htuuenyw net/minecraft/unused/packageinfo/PackageInfohtuuenyw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoiacslglm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoiacslglm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_iacslglm net/minecraft/unused/packageinfo/PackageInfoiacslglm
+CLASS net/minecraft/unmapped/C_iacslglm net/minecraft/unused/packageinfo/PackageInfoiacslglm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoidmscmca.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoidmscmca.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_idmscmca net/minecraft/unused/packageinfo/PackageInfoidmscmca
+CLASS net/minecraft/unmapped/C_idmscmca net/minecraft/unused/packageinfo/PackageInfoidmscmca

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoifcjhzcg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoifcjhzcg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ifcjhzcg net/minecraft/unused/packageinfo/PackageInfoifcjhzcg
+CLASS net/minecraft/unmapped/C_ifcjhzcg net/minecraft/unused/packageinfo/PackageInfoifcjhzcg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoinnrksyx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoinnrksyx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_innrksyx net/minecraft/unused/packageinfo/PackageInfoinnrksyx
+CLASS net/minecraft/unmapped/C_innrksyx net/minecraft/unused/packageinfo/PackageInfoinnrksyx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoinzvnrig.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoinzvnrig.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_inzvnrig net/minecraft/unused/packageinfo/PackageInfoinzvnrig
+CLASS net/minecraft/unmapped/C_inzvnrig net/minecraft/unused/packageinfo/PackageInfoinzvnrig

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoipmhqtzb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoipmhqtzb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ipmhqtzb net/minecraft/unused/packageinfo/PackageInfoipmhqtzb
+CLASS net/minecraft/unmapped/C_ipmhqtzb net/minecraft/unused/packageinfo/PackageInfoipmhqtzb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoiprdmmlt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoiprdmmlt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_iprdmmlt net/minecraft/unused/packageinfo/PackageInfoiprdmmlt
+CLASS net/minecraft/unmapped/C_iprdmmlt net/minecraft/unused/packageinfo/PackageInfoiprdmmlt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoisschdam.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoisschdam.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_isschdam net/minecraft/unused/packageinfo/PackageInfoisschdam
+CLASS net/minecraft/unmapped/C_isschdam net/minecraft/unused/packageinfo/PackageInfoisschdam

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoitctiiqc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoitctiiqc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_itctiiqc net/minecraft/unused/packageinfo/PackageInfoitctiiqc
+CLASS net/minecraft/unmapped/C_itctiiqc net/minecraft/unused/packageinfo/PackageInfoitctiiqc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoixipundw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoixipundw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ixipundw net/minecraft/unused/packageinfo/PackageInfoixipundw
+CLASS net/minecraft/unmapped/C_ixipundw net/minecraft/unused/packageinfo/PackageInfoixipundw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoixxqjtbc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoixxqjtbc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ixxqjtbc net/minecraft/unused/packageinfo/PackageInfoixxqjtbc
+CLASS net/minecraft/unmapped/C_ixxqjtbc net/minecraft/unused/packageinfo/PackageInfoixxqjtbc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojacsngrx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojacsngrx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jacsngrx net/minecraft/unused/packageinfo/PackageInfojacsngrx
+CLASS net/minecraft/unmapped/C_jacsngrx net/minecraft/unused/packageinfo/PackageInfojacsngrx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojdbwrjub.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojdbwrjub.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jdbwrjub net/minecraft/unused/packageinfo/PackageInfojdbwrjub
+CLASS net/minecraft/unmapped/C_jdbwrjub net/minecraft/unused/packageinfo/PackageInfojdbwrjub

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojdsqetea.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojdsqetea.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jdsqetea net/minecraft/unused/packageinfo/PackageInfojdsqetea
+CLASS net/minecraft/unmapped/C_jdsqetea net/minecraft/unused/packageinfo/PackageInfojdsqetea

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojgabnaru.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojgabnaru.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jgabnaru net/minecraft/unused/packageinfo/PackageInfojgabnaru
+CLASS net/minecraft/unmapped/C_jgabnaru net/minecraft/unused/packageinfo/PackageInfojgabnaru

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojllfqijg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojllfqijg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jllfqijg net/minecraft/unused/packageinfo/PackageInfojllfqijg
+CLASS net/minecraft/unmapped/C_jllfqijg net/minecraft/unused/packageinfo/PackageInfojllfqijg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojptmklhf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojptmklhf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jptmklhf net/minecraft/unused/packageinfo/PackageInfojptmklhf
+CLASS net/minecraft/unmapped/C_jptmklhf net/minecraft/unused/packageinfo/PackageInfojptmklhf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojqeeitzn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojqeeitzn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jqeeitzn net/minecraft/unused/packageinfo/PackageInfojqeeitzn
+CLASS net/minecraft/unmapped/C_jqeeitzn net/minecraft/unused/packageinfo/PackageInfojqeeitzn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojsisyeow.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojsisyeow.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jsisyeow net/minecraft/unused/packageinfo/PackageInfojsisyeow
+CLASS net/minecraft/unmapped/C_jsisyeow net/minecraft/unused/packageinfo/PackageInfojsisyeow

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojuqnghuf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojuqnghuf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_juqnghuf net/minecraft/unused/packageinfo/PackageInfojuqnghuf
+CLASS net/minecraft/unmapped/C_juqnghuf net/minecraft/unused/packageinfo/PackageInfojuqnghuf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojxyvrhvx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojxyvrhvx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jxyvrhvx net/minecraft/unused/packageinfo/PackageInfojxyvrhvx
+CLASS net/minecraft/unmapped/C_jxyvrhvx net/minecraft/unused/packageinfo/PackageInfojxyvrhvx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfojyiojsue.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfojyiojsue.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_jyiojsue net/minecraft/unused/packageinfo/PackageInfojyiojsue
+CLASS net/minecraft/unmapped/C_jyiojsue net/minecraft/unused/packageinfo/PackageInfojyiojsue

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokbhxhxmg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokbhxhxmg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kbhxhxmg net/minecraft/unused/packageinfo/PackageInfokbhxhxmg
+CLASS net/minecraft/unmapped/C_kbhxhxmg net/minecraft/unused/packageinfo/PackageInfokbhxhxmg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokdlnzotn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokdlnzotn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kdlnzotn net/minecraft/unused/packageinfo/PackageInfokdlnzotn
+CLASS net/minecraft/unmapped/C_kdlnzotn net/minecraft/unused/packageinfo/PackageInfokdlnzotn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokgnsxkqw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokgnsxkqw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kgnsxkqw net/minecraft/unused/packageinfo/PackageInfokgnsxkqw
+CLASS net/minecraft/unmapped/C_kgnsxkqw net/minecraft/unused/packageinfo/PackageInfokgnsxkqw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoknhohgxz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoknhohgxz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_knhohgxz net/minecraft/unused/packageinfo/PackageInfoknhohgxz
+CLASS net/minecraft/unmapped/C_knhohgxz net/minecraft/unused/packageinfo/PackageInfoknhohgxz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokpxwjoku.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokpxwjoku.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kpxwjoku net/minecraft/unused/packageinfo/PackageInfokpxwjoku
+CLASS net/minecraft/unmapped/C_kpxwjoku net/minecraft/unused/packageinfo/PackageInfokpxwjoku

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoksszykcq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoksszykcq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ksszykcq net/minecraft/unused/packageinfo/PackageInfoksszykcq
+CLASS net/minecraft/unmapped/C_ksszykcq net/minecraft/unused/packageinfo/PackageInfoksszykcq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokthlcwnu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokthlcwnu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kthlcwnu net/minecraft/unused/packageinfo/PackageInfokthlcwnu
+CLASS net/minecraft/unmapped/C_kthlcwnu net/minecraft/unused/packageinfo/PackageInfokthlcwnu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokuoyjuwd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokuoyjuwd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kuoyjuwd net/minecraft/unused/packageinfo/PackageInfokuoyjuwd
+CLASS net/minecraft/unmapped/C_kuoyjuwd net/minecraft/unused/packageinfo/PackageInfokuoyjuwd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfokwugkiai.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfokwugkiai.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_kwugkiai net/minecraft/unused/packageinfo/PackageInfokwugkiai
+CLASS net/minecraft/unmapped/C_kwugkiai net/minecraft/unused/packageinfo/PackageInfokwugkiai

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolcsgarzq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolcsgarzq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lcsgarzq net/minecraft/unused/packageinfo/PackageInfolcsgarzq
+CLASS net/minecraft/unmapped/C_lcsgarzq net/minecraft/unused/packageinfo/PackageInfolcsgarzq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoleelveaa.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoleelveaa.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_leelveaa net/minecraft/unused/packageinfo/PackageInfoleelveaa
+CLASS net/minecraft/unmapped/C_leelveaa net/minecraft/unused/packageinfo/PackageInfoleelveaa

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolmnbtfat.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolmnbtfat.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lmnbtfat net/minecraft/unused/packageinfo/PackageInfolmnbtfat
+CLASS net/minecraft/unmapped/C_lmnbtfat net/minecraft/unused/packageinfo/PackageInfolmnbtfat

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolrmjudgm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolrmjudgm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lrmjudgm net/minecraft/unused/packageinfo/PackageInfolrmjudgm
+CLASS net/minecraft/unmapped/C_lrmjudgm net/minecraft/unused/packageinfo/PackageInfolrmjudgm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolubhhrlw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolubhhrlw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lubhhrlw net/minecraft/unused/packageinfo/PackageInfolubhhrlw
+CLASS net/minecraft/unmapped/C_lubhhrlw net/minecraft/unused/packageinfo/PackageInfolubhhrlw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolujkkxxw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolujkkxxw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lujkkxxw net/minecraft/unused/packageinfo/PackageInfolujkkxxw
+CLASS net/minecraft/unmapped/C_lujkkxxw net/minecraft/unused/packageinfo/PackageInfolujkkxxw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoluyzybls.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoluyzybls.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_luyzybls net/minecraft/unused/packageinfo/PackageInfoluyzybls
+CLASS net/minecraft/unmapped/C_luyzybls net/minecraft/unused/packageinfo/PackageInfoluyzybls

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfolwsegrxg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfolwsegrxg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_lwsegrxg net/minecraft/unused/packageinfo/PackageInfolwsegrxg
+CLASS net/minecraft/unmapped/C_lwsegrxg net/minecraft/unused/packageinfo/PackageInfolwsegrxg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfombbaogqv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfombbaogqv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mbbaogqv net/minecraft/unused/packageinfo/PackageInfombbaogqv
+CLASS net/minecraft/unmapped/C_mbbaogqv net/minecraft/unused/packageinfo/PackageInfombbaogqv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomdvmiuaa.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomdvmiuaa.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mdvmiuaa net/minecraft/unused/packageinfo/PackageInfomdvmiuaa
+CLASS net/minecraft/unmapped/C_mdvmiuaa net/minecraft/unused/packageinfo/PackageInfomdvmiuaa

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomielxusc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomielxusc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mielxusc net/minecraft/unused/packageinfo/PackageInfomielxusc
+CLASS net/minecraft/unmapped/C_mielxusc net/minecraft/unused/packageinfo/PackageInfomielxusc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomkpaecdp.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomkpaecdp.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mkpaecdp net/minecraft/unused/packageinfo/PackageInfomkpaecdp
+CLASS net/minecraft/unmapped/C_mkpaecdp net/minecraft/unused/packageinfo/PackageInfomkpaecdp

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfommppakdn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfommppakdn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mmppakdn net/minecraft/unused/packageinfo/PackageInfommppakdn
+CLASS net/minecraft/unmapped/C_mmppakdn net/minecraft/unused/packageinfo/PackageInfommppakdn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomnjetibu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomnjetibu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mnjetibu net/minecraft/unused/packageinfo/PackageInfomnjetibu
+CLASS net/minecraft/unmapped/C_mnjetibu net/minecraft/unused/packageinfo/PackageInfomnjetibu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfompqjqopq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfompqjqopq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mpqjqopq net/minecraft/unused/packageinfo/PackageInfompqjqopq
+CLASS net/minecraft/unmapped/C_mpqjqopq net/minecraft/unused/packageinfo/PackageInfompqjqopq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomutancvk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomutancvk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mutancvk net/minecraft/unused/packageinfo/PackageInfomutancvk
+CLASS net/minecraft/unmapped/C_mutancvk net/minecraft/unused/packageinfo/PackageInfomutancvk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomxwyhpcg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomxwyhpcg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mxwyhpcg net/minecraft/unused/packageinfo/PackageInfomxwyhpcg
+CLASS net/minecraft/unmapped/C_mxwyhpcg net/minecraft/unused/packageinfo/PackageInfomxwyhpcg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomzmmwfun.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomzmmwfun.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mzmmwfun net/minecraft/unused/packageinfo/PackageInfomzmmwfun
+CLASS net/minecraft/unmapped/C_mzmmwfun net/minecraft/unused/packageinfo/PackageInfomzmmwfun

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfomzssctij.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfomzssctij.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_mzssctij net/minecraft/unused/packageinfo/PackageInfomzssctij
+CLASS net/minecraft/unmapped/C_mzssctij net/minecraft/unused/packageinfo/PackageInfomzssctij

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonagjmgur.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonagjmgur.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nagjmgur net/minecraft/unused/packageinfo/PackageInfonagjmgur
+CLASS net/minecraft/unmapped/C_nagjmgur net/minecraft/unused/packageinfo/PackageInfonagjmgur

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonfamixzb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonfamixzb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nfamixzb net/minecraft/unused/packageinfo/PackageInfonfamixzb
+CLASS net/minecraft/unmapped/C_nfamixzb net/minecraft/unused/packageinfo/PackageInfonfamixzb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonqfyvvxb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonqfyvvxb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nqfyvvxb net/minecraft/unused/packageinfo/PackageInfonqfyvvxb
+CLASS net/minecraft/unmapped/C_nqfyvvxb net/minecraft/unused/packageinfo/PackageInfonqfyvvxb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonqyuevwf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonqyuevwf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nqyuevwf net/minecraft/unused/packageinfo/PackageInfonqyuevwf
+CLASS net/minecraft/unmapped/C_nqyuevwf net/minecraft/unused/packageinfo/PackageInfonqyuevwf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonrllozok.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonrllozok.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nrllozok net/minecraft/unused/packageinfo/PackageInfonrllozok
+CLASS net/minecraft/unmapped/C_nrllozok net/minecraft/unused/packageinfo/PackageInfonrllozok

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonrornqyb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonrornqyb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nrornqyb net/minecraft/unused/packageinfo/PackageInfonrornqyb
+CLASS net/minecraft/unmapped/C_nrornqyb net/minecraft/unused/packageinfo/PackageInfonrornqyb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonrqcqxkj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonrqcqxkj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nrqcqxkj net/minecraft/unused/packageinfo/PackageInfonrqcqxkj
+CLASS net/minecraft/unmapped/C_nrqcqxkj net/minecraft/unused/packageinfo/PackageInfonrqcqxkj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonscmvkul.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonscmvkul.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nscmvkul net/minecraft/unused/packageinfo/PackageInfonscmvkul
+CLASS net/minecraft/unmapped/C_nscmvkul net/minecraft/unused/packageinfo/PackageInfonscmvkul

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonsrhalyd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonsrhalyd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nsrhalyd net/minecraft/unused/packageinfo/PackageInfonsrhalyd
+CLASS net/minecraft/unmapped/C_nsrhalyd net/minecraft/unused/packageinfo/PackageInfonsrhalyd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfontonodus.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfontonodus.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ntonodus net/minecraft/unused/packageinfo/PackageInfontonodus
+CLASS net/minecraft/unmapped/C_ntonodus net/minecraft/unused/packageinfo/PackageInfontonodus

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonxxdhyla.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonxxdhyla.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nxxdhyla net/minecraft/unused/packageinfo/PackageInfonxxdhyla
+CLASS net/minecraft/unmapped/C_nxxdhyla net/minecraft/unused/packageinfo/PackageInfonxxdhyla

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonybstdfe.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonybstdfe.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nybstdfe net/minecraft/unused/packageinfo/PackageInfonybstdfe
+CLASS net/minecraft/unmapped/C_nybstdfe net/minecraft/unused/packageinfo/PackageInfonybstdfe

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfonzlycxrs.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfonzlycxrs.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_nzlycxrs net/minecraft/unused/packageinfo/PackageInfonzlycxrs
+CLASS net/minecraft/unmapped/C_nzlycxrs net/minecraft/unused/packageinfo/PackageInfonzlycxrs

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfooaakyouy.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfooaakyouy.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_oaakyouy net/minecraft/unused/packageinfo/PackageInfooaakyouy
+CLASS net/minecraft/unmapped/C_oaakyouy net/minecraft/unused/packageinfo/PackageInfooaakyouy

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoofcuboxh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoofcuboxh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ofcuboxh net/minecraft/unused/packageinfo/PackageInfoofcuboxh
+CLASS net/minecraft/unmapped/C_ofcuboxh net/minecraft/unused/packageinfo/PackageInfoofcuboxh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoojyqppjw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoojyqppjw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ojyqppjw net/minecraft/unused/packageinfo/PackageInfoojyqppjw
+CLASS net/minecraft/unmapped/C_ojyqppjw net/minecraft/unused/packageinfo/PackageInfoojyqppjw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoonxlqoks.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoonxlqoks.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_onxlqoks net/minecraft/unused/packageinfo/PackageInfoonxlqoks
+CLASS net/minecraft/unmapped/C_onxlqoks net/minecraft/unused/packageinfo/PackageInfoonxlqoks

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoopzalegh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoopzalegh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_opzalegh net/minecraft/unused/packageinfo/PackageInfoopzalegh
+CLASS net/minecraft/unmapped/C_opzalegh net/minecraft/unused/packageinfo/PackageInfoopzalegh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoowmgjpkz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoowmgjpkz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_owmgjpkz net/minecraft/unused/packageinfo/PackageInfoowmgjpkz
+CLASS net/minecraft/unmapped/C_owmgjpkz net/minecraft/unused/packageinfo/PackageInfoowmgjpkz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoozhegduy.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoozhegduy.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ozhegduy net/minecraft/unused/packageinfo/PackageInfoozhegduy
+CLASS net/minecraft/unmapped/C_ozhegduy net/minecraft/unused/packageinfo/PackageInfoozhegduy

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopbdzyvrv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopbdzyvrv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pbdzyvrv net/minecraft/unused/packageinfo/PackageInfopbdzyvrv
+CLASS net/minecraft/unmapped/C_pbdzyvrv net/minecraft/unused/packageinfo/PackageInfopbdzyvrv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopcbgjhpo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopcbgjhpo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pcbgjhpo net/minecraft/unused/packageinfo/PackageInfopcbgjhpo
+CLASS net/minecraft/unmapped/C_pcbgjhpo net/minecraft/unused/packageinfo/PackageInfopcbgjhpo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopemrjels.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopemrjels.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pemrjels net/minecraft/unused/packageinfo/PackageInfopemrjels
+CLASS net/minecraft/unmapped/C_pemrjels net/minecraft/unused/packageinfo/PackageInfopemrjels

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopfhyzryz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopfhyzryz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pfhyzryz net/minecraft/unused/packageinfo/PackageInfopfhyzryz
+CLASS net/minecraft/unmapped/C_pfhyzryz net/minecraft/unused/packageinfo/PackageInfopfhyzryz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopfunjnvf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopfunjnvf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pfunjnvf net/minecraft/unused/packageinfo/PackageInfopfunjnvf
+CLASS net/minecraft/unmapped/C_pfunjnvf net/minecraft/unused/packageinfo/PackageInfopfunjnvf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopleoekpb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopleoekpb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pleoekpb net/minecraft/unused/packageinfo/PackageInfopleoekpb
+CLASS net/minecraft/unmapped/C_pleoekpb net/minecraft/unused/packageinfo/PackageInfopleoekpb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopltjtrhq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopltjtrhq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pltjtrhq net/minecraft/unused/packageinfo/PackageInfopltjtrhq
+CLASS net/minecraft/unmapped/C_pltjtrhq net/minecraft/unused/packageinfo/PackageInfopltjtrhq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopmzamcjs.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopmzamcjs.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_pmzamcjs net/minecraft/unused/packageinfo/PackageInfopmzamcjs
+CLASS net/minecraft/unmapped/C_pmzamcjs net/minecraft/unused/packageinfo/PackageInfopmzamcjs

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoppmcxorf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoppmcxorf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ppmcxorf net/minecraft/unused/packageinfo/PackageInfoppmcxorf
+CLASS net/minecraft/unmapped/C_ppmcxorf net/minecraft/unused/packageinfo/PackageInfoppmcxorf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopsolwgim.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopsolwgim.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_psolwgim net/minecraft/unused/packageinfo/PackageInfopsolwgim
+CLASS net/minecraft/unmapped/C_psolwgim net/minecraft/unused/packageinfo/PackageInfopsolwgim

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfopsyznqgg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfopsyznqgg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_psyznqgg net/minecraft/unused/packageinfo/PackageInfopsyznqgg
+CLASS net/minecraft/unmapped/C_psyznqgg net/minecraft/unused/packageinfo/PackageInfopsyznqgg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqedldjnq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqedldjnq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qedldjnq net/minecraft/unused/packageinfo/PackageInfoqedldjnq
+CLASS net/minecraft/unmapped/C_qedldjnq net/minecraft/unused/packageinfo/PackageInfoqedldjnq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqgfywxkq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqgfywxkq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qgfywxkq net/minecraft/unused/packageinfo/PackageInfoqgfywxkq
+CLASS net/minecraft/unmapped/C_qgfywxkq net/minecraft/unused/packageinfo/PackageInfoqgfywxkq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqgydkdgg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqgydkdgg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qgydkdgg net/minecraft/unused/packageinfo/PackageInfoqgydkdgg
+CLASS net/minecraft/unmapped/C_qgydkdgg net/minecraft/unused/packageinfo/PackageInfoqgydkdgg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqjfphgmt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqjfphgmt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qjfphgmt net/minecraft/unused/packageinfo/PackageInfoqjfphgmt
+CLASS net/minecraft/unmapped/C_qjfphgmt net/minecraft/unused/packageinfo/PackageInfoqjfphgmt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqjkryhfo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqjkryhfo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qjkryhfo net/minecraft/unused/packageinfo/PackageInfoqjkryhfo
+CLASS net/minecraft/unmapped/C_qjkryhfo net/minecraft/unused/packageinfo/PackageInfoqjkryhfo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqkmzbgvj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqkmzbgvj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qkmzbgvj net/minecraft/unused/packageinfo/PackageInfoqkmzbgvj
+CLASS net/minecraft/unmapped/C_qkmzbgvj net/minecraft/unused/packageinfo/PackageInfoqkmzbgvj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqmsmlunk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqmsmlunk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qmsmlunk net/minecraft/unused/packageinfo/PackageInfoqmsmlunk
+CLASS net/minecraft/unmapped/C_qmsmlunk net/minecraft/unused/packageinfo/PackageInfoqmsmlunk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqnmgklam.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqnmgklam.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qnmgklam net/minecraft/unused/packageinfo/PackageInfoqnmgklam
+CLASS net/minecraft/unmapped/C_qnmgklam net/minecraft/unused/packageinfo/PackageInfoqnmgklam

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqnnyjyvm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqnnyjyvm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qnnyjyvm net/minecraft/unused/packageinfo/PackageInfoqnnyjyvm
+CLASS net/minecraft/unmapped/C_qnnyjyvm net/minecraft/unused/packageinfo/PackageInfoqnnyjyvm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqwomkzyy.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqwomkzyy.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qwomkzyy net/minecraft/unused/packageinfo/PackageInfoqwomkzyy
+CLASS net/minecraft/unmapped/C_qwomkzyy net/minecraft/unused/packageinfo/PackageInfoqwomkzyy

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoqytycufr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoqytycufr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_qytycufr net/minecraft/unused/packageinfo/PackageInfoqytycufr
+CLASS net/minecraft/unmapped/C_qytycufr net/minecraft/unused/packageinfo/PackageInfoqytycufr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforezlmiqt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforezlmiqt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rezlmiqt net/minecraft/unused/packageinfo/PackageInforezlmiqt
+CLASS net/minecraft/unmapped/C_rezlmiqt net/minecraft/unused/packageinfo/PackageInforezlmiqt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforjkwigln.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforjkwigln.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rjkwigln net/minecraft/unused/packageinfo/PackageInforjkwigln
+CLASS net/minecraft/unmapped/C_rjkwigln net/minecraft/unused/packageinfo/PackageInforjkwigln

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforjwcryqm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforjwcryqm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rjwcryqm net/minecraft/unused/packageinfo/PackageInforjwcryqm
+CLASS net/minecraft/unmapped/C_rjwcryqm net/minecraft/unused/packageinfo/PackageInforjwcryqm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforqlnckvv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforqlnckvv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rqlnckvv net/minecraft/unused/packageinfo/PackageInforqlnckvv
+CLASS net/minecraft/unmapped/C_rqlnckvv net/minecraft/unused/packageinfo/PackageInforqlnckvv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforwrihoow.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforwrihoow.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rwrihoow net/minecraft/unused/packageinfo/PackageInforwrihoow
+CLASS net/minecraft/unmapped/C_rwrihoow net/minecraft/unused/packageinfo/PackageInforwrihoow

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforwrzrixz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforwrzrixz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rwrzrixz net/minecraft/unused/packageinfo/PackageInforwrzrixz
+CLASS net/minecraft/unmapped/C_rwrzrixz net/minecraft/unused/packageinfo/PackageInforwrzrixz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInforxzejxbf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInforxzejxbf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_rxzejxbf net/minecraft/unused/packageinfo/PackageInforxzejxbf
+CLASS net/minecraft/unmapped/C_rxzejxbf net/minecraft/unused/packageinfo/PackageInforxzejxbf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosbzbovoz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosbzbovoz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_sbzbovoz net/minecraft/unused/packageinfo/PackageInfosbzbovoz
+CLASS net/minecraft/unmapped/C_sbzbovoz net/minecraft/unused/packageinfo/PackageInfosbzbovoz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosdxirivr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosdxirivr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_sdxirivr net/minecraft/unused/packageinfo/PackageInfosdxirivr
+CLASS net/minecraft/unmapped/C_sdxirivr net/minecraft/unused/packageinfo/PackageInfosdxirivr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosgzlvqzi.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosgzlvqzi.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_sgzlvqzi net/minecraft/unused/packageinfo/PackageInfosgzlvqzi
+CLASS net/minecraft/unmapped/C_sgzlvqzi net/minecraft/unused/packageinfo/PackageInfosgzlvqzi

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoshbdhxmv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoshbdhxmv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_shbdhxmv net/minecraft/unused/packageinfo/PackageInfoshbdhxmv
+CLASS net/minecraft/unmapped/C_shbdhxmv net/minecraft/unused/packageinfo/PackageInfoshbdhxmv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosiibxzfw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosiibxzfw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_siibxzfw net/minecraft/unused/packageinfo/PackageInfosiibxzfw
+CLASS net/minecraft/unmapped/C_siibxzfw net/minecraft/unused/packageinfo/PackageInfosiibxzfw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosmzvytuv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosmzvytuv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_smzvytuv net/minecraft/unused/packageinfo/PackageInfosmzvytuv
+CLASS net/minecraft/unmapped/C_smzvytuv net/minecraft/unused/packageinfo/PackageInfosmzvytuv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosnemhbci.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosnemhbci.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_snemhbci net/minecraft/unused/packageinfo/PackageInfosnemhbci
+CLASS net/minecraft/unmapped/C_snemhbci net/minecraft/unused/packageinfo/PackageInfosnemhbci

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosoerzsbg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosoerzsbg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_soerzsbg net/minecraft/unused/packageinfo/PackageInfosoerzsbg
+CLASS net/minecraft/unmapped/C_soerzsbg net/minecraft/unused/packageinfo/PackageInfosoerzsbg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosopvsnue.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosopvsnue.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_sopvsnue net/minecraft/unused/packageinfo/PackageInfosopvsnue
+CLASS net/minecraft/unmapped/C_sopvsnue net/minecraft/unused/packageinfo/PackageInfosopvsnue

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfosrtevqgn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfosrtevqgn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_srtevqgn net/minecraft/unused/packageinfo/PackageInfosrtevqgn
+CLASS net/minecraft/unmapped/C_srtevqgn net/minecraft/unused/packageinfo/PackageInfosrtevqgn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfostnyttmh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfostnyttmh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_stnyttmh net/minecraft/unused/packageinfo/PackageInfostnyttmh
+CLASS net/minecraft/unmapped/C_stnyttmh net/minecraft/unused/packageinfo/PackageInfostnyttmh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoszowhttx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoszowhttx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_szowhttx net/minecraft/unused/packageinfo/PackageInfoszowhttx
+CLASS net/minecraft/unmapped/C_szowhttx net/minecraft/unused/packageinfo/PackageInfoszowhttx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotewidjcl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotewidjcl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tewidjcl net/minecraft/unused/packageinfo/PackageInfotewidjcl
+CLASS net/minecraft/unmapped/C_tewidjcl net/minecraft/unused/packageinfo/PackageInfotewidjcl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotfaqhbsv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotfaqhbsv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tfaqhbsv net/minecraft/unused/packageinfo/PackageInfotfaqhbsv
+CLASS net/minecraft/unmapped/C_tfaqhbsv net/minecraft/unused/packageinfo/PackageInfotfaqhbsv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotgytavsc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotgytavsc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tgytavsc net/minecraft/unused/packageinfo/PackageInfotgytavsc
+CLASS net/minecraft/unmapped/C_tgytavsc net/minecraft/unused/packageinfo/PackageInfotgytavsc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfothyfwnih.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfothyfwnih.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_thyfwnih net/minecraft/unused/packageinfo/PackageInfothyfwnih
+CLASS net/minecraft/unmapped/C_thyfwnih net/minecraft/unused/packageinfo/PackageInfothyfwnih

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotisxxxgt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotisxxxgt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tisxxxgt net/minecraft/unused/packageinfo/PackageInfotisxxxgt
+CLASS net/minecraft/unmapped/C_tisxxxgt net/minecraft/unused/packageinfo/PackageInfotisxxxgt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotokzrkqm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotokzrkqm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tokzrkqm net/minecraft/unused/packageinfo/PackageInfotokzrkqm
+CLASS net/minecraft/unmapped/C_tokzrkqm net/minecraft/unused/packageinfo/PackageInfotokzrkqm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotpxjeudd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotpxjeudd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tpxjeudd net/minecraft/unused/packageinfo/PackageInfotpxjeudd
+CLASS net/minecraft/unmapped/C_tpxjeudd net/minecraft/unused/packageinfo/PackageInfotpxjeudd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotrwqlugf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotrwqlugf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_trwqlugf net/minecraft/unused/packageinfo/PackageInfotrwqlugf
+CLASS net/minecraft/unmapped/C_trwqlugf net/minecraft/unused/packageinfo/PackageInfotrwqlugf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotrxbabwd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotrxbabwd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_trxbabwd net/minecraft/unused/packageinfo/PackageInfotrxbabwd
+CLASS net/minecraft/unmapped/C_trxbabwd net/minecraft/unused/packageinfo/PackageInfotrxbabwd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotutnblzj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotutnblzj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tutnblzj net/minecraft/unused/packageinfo/PackageInfotutnblzj
+CLASS net/minecraft/unmapped/C_tutnblzj net/minecraft/unused/packageinfo/PackageInfotutnblzj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotvqcxdhw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotvqcxdhw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tvqcxdhw net/minecraft/unused/packageinfo/PackageInfotvqcxdhw
+CLASS net/minecraft/unmapped/C_tvqcxdhw net/minecraft/unused/packageinfo/PackageInfotvqcxdhw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfotzwzdmbu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfotzwzdmbu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_tzwzdmbu net/minecraft/unused/packageinfo/PackageInfotzwzdmbu
+CLASS net/minecraft/unmapped/C_tzwzdmbu net/minecraft/unused/packageinfo/PackageInfotzwzdmbu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouadqooqx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouadqooqx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uadqooqx net/minecraft/unused/packageinfo/PackageInfouadqooqx
+CLASS net/minecraft/unmapped/C_uadqooqx net/minecraft/unused/packageinfo/PackageInfouadqooqx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouewevfzn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouewevfzn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uewevfzn net/minecraft/unused/packageinfo/PackageInfouewevfzn
+CLASS net/minecraft/unmapped/C_uewevfzn net/minecraft/unused/packageinfo/PackageInfouewevfzn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouftkykgj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouftkykgj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uftkykgj net/minecraft/unused/packageinfo/PackageInfouftkykgj
+CLASS net/minecraft/unmapped/C_uftkykgj net/minecraft/unused/packageinfo/PackageInfouftkykgj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfougbxwwxi.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfougbxwwxi.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ugbxwwxi net/minecraft/unused/packageinfo/PackageInfougbxwwxi
+CLASS net/minecraft/unmapped/C_ugbxwwxi net/minecraft/unused/packageinfo/PackageInfougbxwwxi

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfougkxxxmx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfougkxxxmx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ugkxxxmx net/minecraft/unused/packageinfo/PackageInfougkxxxmx
+CLASS net/minecraft/unmapped/C_ugkxxxmx net/minecraft/unused/packageinfo/PackageInfougkxxxmx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfougyfdphn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfougyfdphn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ugyfdphn net/minecraft/unused/packageinfo/PackageInfougyfdphn
+CLASS net/minecraft/unmapped/C_ugyfdphn net/minecraft/unused/packageinfo/PackageInfougyfdphn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouklvsovn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouklvsovn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uklvsovn net/minecraft/unused/packageinfo/PackageInfouklvsovn
+CLASS net/minecraft/unmapped/C_uklvsovn net/minecraft/unused/packageinfo/PackageInfouklvsovn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoulgiqdfl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoulgiqdfl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ulgiqdfl net/minecraft/unused/packageinfo/PackageInfoulgiqdfl
+CLASS net/minecraft/unmapped/C_ulgiqdfl net/minecraft/unused/packageinfo/PackageInfoulgiqdfl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouohbegpb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouohbegpb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uohbegpb net/minecraft/unused/packageinfo/PackageInfouohbegpb
+CLASS net/minecraft/unmapped/C_uohbegpb net/minecraft/unused/packageinfo/PackageInfouohbegpb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouopioinc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouopioinc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uopioinc net/minecraft/unused/packageinfo/PackageInfouopioinc
+CLASS net/minecraft/unmapped/C_uopioinc net/minecraft/unused/packageinfo/PackageInfouopioinc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouvoccecb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouvoccecb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uvoccecb net/minecraft/unused/packageinfo/PackageInfouvoccecb
+CLASS net/minecraft/unmapped/C_uvoccecb net/minecraft/unused/packageinfo/PackageInfouvoccecb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouwgcjniw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouwgcjniw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uwgcjniw net/minecraft/unused/packageinfo/PackageInfouwgcjniw
+CLASS net/minecraft/unmapped/C_uwgcjniw net/minecraft/unused/packageinfo/PackageInfouwgcjniw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouywperek.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouywperek.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uywperek net/minecraft/unused/packageinfo/PackageInfouywperek
+CLASS net/minecraft/unmapped/C_uywperek net/minecraft/unused/packageinfo/PackageInfouywperek

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfouzmyxgnx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfouzmyxgnx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_uzmyxgnx net/minecraft/unused/packageinfo/PackageInfouzmyxgnx
+CLASS net/minecraft/unmapped/C_uzmyxgnx net/minecraft/unused/packageinfo/PackageInfouzmyxgnx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovbsftzvv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovbsftzvv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vbsftzvv net/minecraft/unused/packageinfo/PackageInfovbsftzvv
+CLASS net/minecraft/unmapped/C_vbsftzvv net/minecraft/unused/packageinfo/PackageInfovbsftzvv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovevjivlf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovevjivlf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vevjivlf net/minecraft/unused/packageinfo/PackageInfovevjivlf
+CLASS net/minecraft/unmapped/C_vevjivlf net/minecraft/unused/packageinfo/PackageInfovevjivlf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovgxkkbnw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovgxkkbnw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vgxkkbnw net/minecraft/unused/packageinfo/PackageInfovgxkkbnw
+CLASS net/minecraft/unmapped/C_vgxkkbnw net/minecraft/unused/packageinfo/PackageInfovgxkkbnw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovjlbrrdj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovjlbrrdj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vjlbrrdj net/minecraft/unused/packageinfo/PackageInfovjlbrrdj
+CLASS net/minecraft/unmapped/C_vjlbrrdj net/minecraft/unused/packageinfo/PackageInfovjlbrrdj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovklvjogf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovklvjogf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vklvjogf net/minecraft/unused/packageinfo/PackageInfovklvjogf
+CLASS net/minecraft/unmapped/C_vklvjogf net/minecraft/unused/packageinfo/PackageInfovklvjogf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovrvjrdrk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovrvjrdrk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vrvjrdrk net/minecraft/unused/packageinfo/PackageInfovrvjrdrk
+CLASS net/minecraft/unmapped/C_vrvjrdrk net/minecraft/unused/packageinfo/PackageInfovrvjrdrk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovtguyurn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovtguyurn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vtguyurn net/minecraft/unused/packageinfo/PackageInfovtguyurn
+CLASS net/minecraft/unmapped/C_vtguyurn net/minecraft/unused/packageinfo/PackageInfovtguyurn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovtzjmwcn.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovtzjmwcn.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vtzjmwcn net/minecraft/unused/packageinfo/PackageInfovtzjmwcn
+CLASS net/minecraft/unmapped/C_vtzjmwcn net/minecraft/unused/packageinfo/PackageInfovtzjmwcn

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovvngyryw.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovvngyryw.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vvngyryw net/minecraft/unused/packageinfo/PackageInfovvngyryw
+CLASS net/minecraft/unmapped/C_vvngyryw net/minecraft/unused/packageinfo/PackageInfovvngyryw

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovxftxkrs.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovxftxkrs.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vxftxkrs net/minecraft/unused/packageinfo/PackageInfovxftxkrs
+CLASS net/minecraft/unmapped/C_vxftxkrs net/minecraft/unused/packageinfo/PackageInfovxftxkrs

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfovxqzfdtu.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfovxqzfdtu.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_vxqzfdtu net/minecraft/unused/packageinfo/PackageInfovxqzfdtu
+CLASS net/minecraft/unmapped/C_vxqzfdtu net/minecraft/unused/packageinfo/PackageInfovxqzfdtu

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowddcftxf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowddcftxf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wddcftxf net/minecraft/unused/packageinfo/PackageInfowddcftxf
+CLASS net/minecraft/unmapped/C_wddcftxf net/minecraft/unused/packageinfo/PackageInfowddcftxf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoweijoazg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoweijoazg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_weijoazg net/minecraft/unused/packageinfo/PackageInfoweijoazg
+CLASS net/minecraft/unmapped/C_weijoazg net/minecraft/unused/packageinfo/PackageInfoweijoazg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowfyhekeb.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowfyhekeb.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wfyhekeb net/minecraft/unused/packageinfo/PackageInfowfyhekeb
+CLASS net/minecraft/unmapped/C_wfyhekeb net/minecraft/unused/packageinfo/PackageInfowfyhekeb

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowgdgjyui.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowgdgjyui.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wgdgjyui net/minecraft/unused/packageinfo/PackageInfowgdgjyui
+CLASS net/minecraft/unmapped/C_wgdgjyui net/minecraft/unused/packageinfo/PackageInfowgdgjyui

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowhbbvjwl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowhbbvjwl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_whbbvjwl net/minecraft/unused/packageinfo/PackageInfowhbbvjwl
+CLASS net/minecraft/unmapped/C_whbbvjwl net/minecraft/unused/packageinfo/PackageInfowhbbvjwl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowhcsebfm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowhcsebfm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_whcsebfm net/minecraft/unused/packageinfo/PackageInfowhcsebfm
+CLASS net/minecraft/unmapped/C_whcsebfm net/minecraft/unused/packageinfo/PackageInfowhcsebfm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowhjcjlib.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowhjcjlib.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_whjcjlib net/minecraft/unused/packageinfo/PackageInfowhjcjlib
+CLASS net/minecraft/unmapped/C_whjcjlib net/minecraft/unused/packageinfo/PackageInfowhjcjlib

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowkqjhhpl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowkqjhhpl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wkqjhhpl net/minecraft/unused/packageinfo/PackageInfowkqjhhpl
+CLASS net/minecraft/unmapped/C_wkqjhhpl net/minecraft/unused/packageinfo/PackageInfowkqjhhpl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowldsbddx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowldsbddx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wldsbddx net/minecraft/unused/packageinfo/PackageInfowldsbddx
+CLASS net/minecraft/unmapped/C_wldsbddx net/minecraft/unused/packageinfo/PackageInfowldsbddx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowoquabmx.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowoquabmx.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_woquabmx net/minecraft/unused/packageinfo/PackageInfowoquabmx
+CLASS net/minecraft/unmapped/C_woquabmx net/minecraft/unused/packageinfo/PackageInfowoquabmx

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowphwsiun.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowphwsiun.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wphwsiun net/minecraft/unused/packageinfo/PackageInfowphwsiun
+CLASS net/minecraft/unmapped/C_wphwsiun net/minecraft/unused/packageinfo/PackageInfowphwsiun

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowrynccro.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowrynccro.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wrynccro net/minecraft/unused/packageinfo/PackageInfowrynccro
+CLASS net/minecraft/unmapped/C_wrynccro net/minecraft/unused/packageinfo/PackageInfowrynccro

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfowwixurpj.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfowwixurpj.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_wwixurpj net/minecraft/unused/packageinfo/PackageInfowwixurpj
+CLASS net/minecraft/unmapped/C_wwixurpj net/minecraft/unused/packageinfo/PackageInfowwixurpj

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxasjaonh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxasjaonh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xasjaonh net/minecraft/unused/packageinfo/PackageInfoxasjaonh
+CLASS net/minecraft/unmapped/C_xasjaonh net/minecraft/unused/packageinfo/PackageInfoxasjaonh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxcejbmaq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxcejbmaq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xcejbmaq net/minecraft/unused/packageinfo/PackageInfoxcejbmaq
+CLASS net/minecraft/unmapped/C_xcejbmaq net/minecraft/unused/packageinfo/PackageInfoxcejbmaq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxcskjiwv.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxcskjiwv.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xcskjiwv net/minecraft/unused/packageinfo/PackageInfoxcskjiwv
+CLASS net/minecraft/unmapped/C_xcskjiwv net/minecraft/unused/packageinfo/PackageInfoxcskjiwv

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxetuxqgl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxetuxqgl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xetuxqgl net/minecraft/unused/packageinfo/PackageInfoxetuxqgl
+CLASS net/minecraft/unmapped/C_xetuxqgl net/minecraft/unused/packageinfo/PackageInfoxetuxqgl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxevwkpek.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxevwkpek.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xevwkpek net/minecraft/unused/packageinfo/PackageInfoxevwkpek
+CLASS net/minecraft/unmapped/C_xevwkpek net/minecraft/unused/packageinfo/PackageInfoxevwkpek

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxewadtko.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxewadtko.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xewadtko net/minecraft/unused/packageinfo/PackageInfoxewadtko
+CLASS net/minecraft/unmapped/C_xewadtko net/minecraft/unused/packageinfo/PackageInfoxewadtko

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxhcpreqo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxhcpreqo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xhcpreqo net/minecraft/unused/packageinfo/PackageInfoxhcpreqo
+CLASS net/minecraft/unmapped/C_xhcpreqo net/minecraft/unused/packageinfo/PackageInfoxhcpreqo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxijosrpe.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxijosrpe.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xijosrpe net/minecraft/unused/packageinfo/PackageInfoxijosrpe
+CLASS net/minecraft/unmapped/C_xijosrpe net/minecraft/unused/packageinfo/PackageInfoxijosrpe

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxjyxqzsf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxjyxqzsf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xjyxqzsf net/minecraft/unused/packageinfo/PackageInfoxjyxqzsf
+CLASS net/minecraft/unmapped/C_xjyxqzsf net/minecraft/unused/packageinfo/PackageInfoxjyxqzsf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxlroyrxk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxlroyrxk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xlroyrxk net/minecraft/unused/packageinfo/PackageInfoxlroyrxk
+CLASS net/minecraft/unmapped/C_xlroyrxk net/minecraft/unused/packageinfo/PackageInfoxlroyrxk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxmuwqpzt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxmuwqpzt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xmuwqpzt net/minecraft/unused/packageinfo/PackageInfoxmuwqpzt
+CLASS net/minecraft/unmapped/C_xmuwqpzt net/minecraft/unused/packageinfo/PackageInfoxmuwqpzt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxneakpuq.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxneakpuq.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xneakpuq net/minecraft/unused/packageinfo/PackageInfoxneakpuq
+CLASS net/minecraft/unmapped/C_xneakpuq net/minecraft/unused/packageinfo/PackageInfoxneakpuq

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxnsbyhis.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxnsbyhis.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xnsbyhis net/minecraft/unused/packageinfo/PackageInfoxnsbyhis
+CLASS net/minecraft/unmapped/C_xnsbyhis net/minecraft/unused/packageinfo/PackageInfoxnsbyhis

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxnttkkgr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxnttkkgr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xnttkkgr net/minecraft/unused/packageinfo/PackageInfoxnttkkgr
+CLASS net/minecraft/unmapped/C_xnttkkgr net/minecraft/unused/packageinfo/PackageInfoxnttkkgr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxriwepng.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxriwepng.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xriwepng net/minecraft/unused/packageinfo/PackageInfoxriwepng
+CLASS net/minecraft/unmapped/C_xriwepng net/minecraft/unused/packageinfo/PackageInfoxriwepng

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxyqauadh.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxyqauadh.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xyqauadh net/minecraft/unused/packageinfo/PackageInfoxyqauadh
+CLASS net/minecraft/unmapped/C_xyqauadh net/minecraft/unused/packageinfo/PackageInfoxyqauadh

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoxzkgbagd.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoxzkgbagd.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_xzkgbagd net/minecraft/unused/packageinfo/PackageInfoxzkgbagd
+CLASS net/minecraft/unmapped/C_xzkgbagd net/minecraft/unused/packageinfo/PackageInfoxzkgbagd

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyfewkyae.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyfewkyae.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yfewkyae net/minecraft/unused/packageinfo/PackageInfoyfewkyae
+CLASS net/minecraft/unmapped/C_yfewkyae net/minecraft/unused/packageinfo/PackageInfoyfewkyae

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyheymuku.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyheymuku.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yheymuku net/minecraft/unused/packageinfo/PackageInfoyheymuku
+CLASS net/minecraft/unmapped/C_yheymuku net/minecraft/unused/packageinfo/PackageInfoyheymuku

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoykkfjsgp.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoykkfjsgp.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ykkfjsgp net/minecraft/unused/packageinfo/PackageInfoykkfjsgp
+CLASS net/minecraft/unmapped/C_ykkfjsgp net/minecraft/unused/packageinfo/PackageInfoykkfjsgp

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyrvrbfns.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyrvrbfns.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yrvrbfns net/minecraft/unused/packageinfo/PackageInfoyrvrbfns
+CLASS net/minecraft/unmapped/C_yrvrbfns net/minecraft/unused/packageinfo/PackageInfoyrvrbfns

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyrwwntjo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyrwwntjo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yrwwntjo net/minecraft/unused/packageinfo/PackageInfoyrwwntjo
+CLASS net/minecraft/unmapped/C_yrwwntjo net/minecraft/unused/packageinfo/PackageInfoyrwwntjo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoysebavlk.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoysebavlk.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ysebavlk net/minecraft/unused/packageinfo/PackageInfoysebavlk
+CLASS net/minecraft/unmapped/C_ysebavlk net/minecraft/unused/packageinfo/PackageInfoysebavlk

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoytkwkqub.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoytkwkqub.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ytkwkqub net/minecraft/unused/packageinfo/PackageInfoytkwkqub
+CLASS net/minecraft/unmapped/C_ytkwkqub net/minecraft/unused/packageinfo/PackageInfoytkwkqub

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyyiriqgo.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyyiriqgo.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yyiriqgo net/minecraft/unused/packageinfo/PackageInfoyyiriqgo
+CLASS net/minecraft/unmapped/C_yyiriqgo net/minecraft/unused/packageinfo/PackageInfoyyiriqgo

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoyyjxtpxz.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoyyjxtpxz.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_yyjxtpxz net/minecraft/unused/packageinfo/PackageInfoyyjxtpxz
+CLASS net/minecraft/unmapped/C_yyjxtpxz net/minecraft/unused/packageinfo/PackageInfoyyjxtpxz

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozbgubnpr.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozbgubnpr.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zbgubnpr net/minecraft/unused/packageinfo/PackageInfozbgubnpr
+CLASS net/minecraft/unmapped/C_zbgubnpr net/minecraft/unused/packageinfo/PackageInfozbgubnpr

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozdculxrg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozdculxrg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zdculxrg net/minecraft/unused/packageinfo/PackageInfozdculxrg
+CLASS net/minecraft/unmapped/C_zdculxrg net/minecraft/unused/packageinfo/PackageInfozdculxrg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozfawkrhf.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozfawkrhf.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zfawkrhf net/minecraft/unused/packageinfo/PackageInfozfawkrhf
+CLASS net/minecraft/unmapped/C_zfawkrhf net/minecraft/unused/packageinfo/PackageInfozfawkrhf

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozjkxwsxl.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozjkxwsxl.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zjkxwsxl net/minecraft/unused/packageinfo/PackageInfozjkxwsxl
+CLASS net/minecraft/unmapped/C_zjkxwsxl net/minecraft/unused/packageinfo/PackageInfozjkxwsxl

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozmfxkxvt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozmfxkxvt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zmfxkxvt net/minecraft/unused/packageinfo/PackageInfozmfxkxvt
+CLASS net/minecraft/unmapped/C_zmfxkxvt net/minecraft/unused/packageinfo/PackageInfozmfxkxvt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozoopzuxt.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozoopzuxt.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zoopzuxt net/minecraft/unused/packageinfo/PackageInfozoopzuxt
+CLASS net/minecraft/unmapped/C_zoopzuxt net/minecraft/unused/packageinfo/PackageInfozoopzuxt

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozqqganun.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozqqganun.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zqqganun net/minecraft/unused/packageinfo/PackageInfozqqganun
+CLASS net/minecraft/unmapped/C_zqqganun net/minecraft/unused/packageinfo/PackageInfozqqganun

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozsadynee.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozsadynee.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zsadynee net/minecraft/unused/packageinfo/PackageInfozsadynee
+CLASS net/minecraft/unmapped/C_zsadynee net/minecraft/unused/packageinfo/PackageInfozsadynee

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozsmhljvc.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozsmhljvc.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zsmhljvc net/minecraft/unused/packageinfo/PackageInfozsmhljvc
+CLASS net/minecraft/unmapped/C_zsmhljvc net/minecraft/unused/packageinfo/PackageInfozsmhljvc

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfoztmtenmm.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfoztmtenmm.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_ztmtenmm net/minecraft/unused/packageinfo/PackageInfoztmtenmm
+CLASS net/minecraft/unmapped/C_ztmtenmm net/minecraft/unused/packageinfo/PackageInfoztmtenmm

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozuenahho.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozuenahho.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zuenahho net/minecraft/unused/packageinfo/PackageInfozuenahho
+CLASS net/minecraft/unmapped/C_zuenahho net/minecraft/unused/packageinfo/PackageInfozuenahho

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozwasfkgg.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozwasfkgg.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zwasfkgg net/minecraft/unused/packageinfo/PackageInfozwasfkgg
+CLASS net/minecraft/unmapped/C_zwasfkgg net/minecraft/unused/packageinfo/PackageInfozwasfkgg

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfozwyqnwml.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfozwyqnwml.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/C_zwyqnwml net/minecraft/unused/packageinfo/PackageInfozwyqnwml
+CLASS net/minecraft/unmapped/C_zwyqnwml net/minecraft/unused/packageinfo/PackageInfozwyqnwml


### PR DESCRIPTION
Filament produces invalid hashed names because of a hardcoded string when running `generatePackageInfoMappings`