### PR TITLE
Add dropInvalidMappings task

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,7 +17,6 @@ repositories {
 		name "Mojang"
 		url 'https://libraries.minecraft.net/'
 	}
-	mavenLocal()
 }
 
 dependencies {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,6 +17,7 @@ repositories {
 		name "Mojang"
 		url 'https://libraries.minecraft.net/'
 	}
+	mavenLocal()
 }
 
 dependencies {

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.0.4
+enigma_version=1.0.5
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9

--- a/buildSrc/src/main/java/quilt/internal/MappingsPlugin.java
+++ b/buildSrc/src/main/java/quilt/internal/MappingsPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.TaskContainer;
 import quilt.internal.tasks.build.BuildMappingsTinyTask;
 import quilt.internal.tasks.build.CheckMappingsTask;
 import quilt.internal.tasks.build.CompressTinyTask;
+import quilt.internal.tasks.build.DropInvalidMappingsTask;
 import quilt.internal.tasks.build.GeneratePackageInfoMappingsTask;
 import quilt.internal.tasks.build.InvertPerVersionMappingsTask;
 import quilt.internal.tasks.build.MergeTinyTask;
@@ -45,6 +46,7 @@ public class MappingsPlugin implements Plugin<Project> {
         tasks.create(MergeTinyV2Task.TASK_NAME, MergeTinyV2Task.class);
         tasks.create(TinyJarTask.TASK_NAME, TinyJarTask.class);
         tasks.create(CompressTinyTask.TASK_NAME, CompressTinyTask.class);
+        tasks.create(DropInvalidMappingsTask.TASK_NAME, DropInvalidMappingsTask.class);
 
         tasks.create(MapPerVersionMappingsJarTask.TASK_NAME, MapPerVersionMappingsJarTask.class);
         tasks.create(MapNamedJarTask.TASK_NAME, MapNamedJarTask.class);

--- a/buildSrc/src/main/java/quilt/internal/tasks/build/DropInvalidMappingsTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/DropInvalidMappingsTask.java
@@ -1,0 +1,36 @@
+package quilt.internal.tasks.build;
+
+import cuchaz.enigma.command.DropInvalidMappingsCommand;
+import org.gradle.api.tasks.TaskAction;
+import quilt.internal.Constants;
+import quilt.internal.tasks.DefaultMappingsTask;
+import quilt.internal.tasks.jarmapping.MapPerVersionMappingsJarTask;
+
+import java.io.File;
+
+public class DropInvalidMappingsTask extends DefaultMappingsTask {
+    public static final String TASK_NAME = "dropInvalidMappings";
+    private final File mappings = getProject().file("mappings");
+
+    public DropInvalidMappingsTask() {
+        super(Constants.Groups.BUILD_MAPPINGS_GROUP);
+        getInputs().dir(mappings);
+        this.dependsOn(MapPerVersionMappingsJarTask.TASK_NAME);
+    }
+
+    @TaskAction
+    public void dropInvalidMappings() {
+        getLogger().info(":dropping invalid mappings");
+
+        String[] args = new String[]{
+                fileConstants.perVersionMappingsJar.getAbsolutePath(),
+                mappings.getAbsolutePath()
+        };
+
+        try {
+            new DropInvalidMappingsCommand().run(args);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.0.4
+enigma_version=1.0.5
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9

--- a/mappings/net/minecraft/enchantment/Enchantment.mapping
+++ b/mappings/net/minecraft/enchantment/Enchantment.mapping
@@ -32,7 +32,7 @@ CLASS net/minecraft/unmapped/C_jxtrubuh net/minecraft/enchantment/Enchantment
 		ARG 2 group
 	METHOD m_lkqpuckl isTreasure ()Z
 		COMMENT {@return whether this enchantment will appear in the enchantment table and loot chests or loot chests only. E.G Mending}
-		COMMENT Villagers will sell treasure enchantments for double the price of a regular one. 
+		COMMENT Villagers will sell treasure enchantments for double the price of a regular one.
 	METHOD m_phdcatdd onTargetDamaged (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_astfners;I)V
 		COMMENT This method is called when an Entity ({@code target}) is hit by the Player ({@code user}) with an Item that has this enchantment on it.
 		ARG 1 user
@@ -47,7 +47,7 @@ CLASS net/minecraft/unmapped/C_jxtrubuh net/minecraft/enchantment/Enchantment
 		COMMENT offers of librarian villagers}
 	METHOD m_sufqbdfo isCursed ()Z
 		COMMENT {@return whether the enchantment is a curse. E.G: Curse of Binding}
-		COMMENT Enchantments that are cursed cannot be removed from the item, even in a Grindstone. 
+		COMMENT Enchantments that are cursed cannot be removed from the item, even in a Grindstone.
 	METHOD m_sxyjtpkf onUserDamaged (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_astfners;I)V
 		COMMENT This method is called when the Player ({@code user} is attacked by another Entity ({@code attacker}) and is wearing something that contains the enchantment}.
 		ARG 1 user

--- a/mappings/net/minecraft/util/dynamic/RegistryOps.mapping
+++ b/mappings/net/minecraft/util/dynamic/RegistryOps.mapping
@@ -15,8 +15,6 @@ CLASS net/minecraft/unmapped/C_udwrczdh net/minecraft/util/dynamic/RegistryOps
 		ARG 4 allowInlineDefinitions
 	METHOD m_ezvmzsgh ofLoaded (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/unmapped/C_tmnrpasf;Lnet/minecraft/unmapped/C_wqxmvzdq;)Lnet/minecraft/unmapped/C_udwrczdh;
 		ARG 2 registryManager
-	METHOD m_lpqvvscg getValueHolder (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_udwrczdh$C_wlzreysy;
-		ARG 1 registryRef
 	METHOD m_iuwpoebf readSupplier (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_eexxncvi;Lcom/mojang/serialization/Codec;Lnet/minecraft/unmapped/C_xhhleach;)Lcom/mojang/serialization/DataResult;
 		COMMENT Reads a supplier for a registry element.
 		COMMENT
@@ -24,6 +22,8 @@ CLASS net/minecraft/unmapped/C_udwrczdh net/minecraft/util/dynamic/RegistryOps
 		ARG 1 key
 		ARG 2 registry
 		ARG 3 codec
+	METHOD m_lpqvvscg getValueHolder (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_udwrczdh$C_wlzreysy;
+		ARG 1 registryRef
 	METHOD m_oahfbjzp loadToRegistry (Lnet/minecraft/unmapped/C_secmvxxe;Lnet/minecraft/unmapped/C_xhhleach;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/DataResult;
 		COMMENT Loads elements into a registry just loaded from a decoder.
 		ARG 1 registry

--- a/mappings/net/minecraft/world/chunk/Chunk.mapping
+++ b/mappings/net/minecraft/world/chunk/Chunk.mapping
@@ -68,10 +68,10 @@ CLASS net/minecraft/unmapped/C_lwzmmmqr net/minecraft/world/chunk/Chunk
 		ARG 2 state
 		ARG 3 moved
 	METHOD m_qkpdcbbf getStatus ()Lnet/minecraft/unmapped/C_kogtzhzt;
-	METHOD m_rirvxrfe setStructureStarts (Ljava/util/Map;)V
-		ARG 1 structureStarts
 	METHOD m_rgzeprey setBiomesFromNoise (Lnet/minecraft/unmapped/C_nhlknxak;Lnet/minecraft/unmapped/C_ohqwadgy$C_pigoipju;)V
 		ARG 2 sampler
+	METHOD m_rirvxrfe setStructureStarts (Ljava/util/Map;)V
+		ARG 1 structureStarts
 	METHOD m_rqpedvcc getSection (I)Lnet/minecraft/unmapped/C_aurosfgf;
 		ARG 1 section
 	METHOD m_rxqzlewx markBlockForPostProcessing (Lnet/minecraft/unmapped/C_hynzadkk;)V

--- a/mappings/net/minecraft/world/tick/OrderedTick.mapping
+++ b/mappings/net/minecraft/world/tick/OrderedTick.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/unmapped/C_bokjrzyn net/minecraft/world/tick/OrderedTick
 	FIELD f_lvcoyuct type Ljava/lang/Object;
-	FIELD f_ofympicf pos Lnet/minecraft/unmapped/C_hynzadkk;
 	FIELD f_mcjmrfuw priority Lnet/minecraft/unmapped/C_gkdmrpwk;
-	FIELD f_qvqproky triggerTick J
+	FIELD f_ofympicf pos Lnet/minecraft/unmapped/C_hynzadkk;
 	FIELD f_okcmnlrw subTickOrder J
+	FIELD f_qvqproky triggerTick J
 	METHOD <init> (Ljava/lang/Object;Lnet/minecraft/unmapped/C_hynzadkk;JJ)V
 		ARG 1 type
 		ARG 2 pos

--- a/mappings/net/minecraft/world/tick/Tick.mapping
+++ b/mappings/net/minecraft/world/tick/Tick.mapping
@@ -3,12 +3,12 @@ CLASS net/minecraft/unmapped/C_hojywanl net/minecraft/world/tick/Tick
 	FIELD f_cnmngxch Z_KEY Ljava/lang/String;
 	FIELD f_dxqrsdpr DELAY_KEY Ljava/lang/String;
 	FIELD f_eqcuxhzl Y_KEY Ljava/lang/String;
+	FIELD f_hdqigtch priority Lnet/minecraft/unmapped/C_gkdmrpwk;
 	FIELD f_hfaclqlj PRIORITY_KEY Ljava/lang/String;
-	FIELD f_qezkpymu X_KEY Ljava/lang/String;
 	FIELD f_kokmfvge type Ljava/lang/Object;
 	FIELD f_lbpayevv pos Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_qezkpymu X_KEY Ljava/lang/String;
 	FIELD f_wmtupvmq delay I
-	FIELD f_hdqigtch priority Lnet/minecraft/unmapped/C_gkdmrpwk;
 	METHOD <init> (Ljava/lang/Object;Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_gkdmrpwk;)V
 		ARG 1 type
 		ARG 2 pos


### PR DESCRIPTION
Uses the DropInvalidMappingsCommand I added to Enigma 1.0.5 (QuiltMC/enigma@64e33397429eca91112ee81f6d8c8a73efd37bc5). Would be a part of a solution for #48