### PR TITLE
Add new JavaDoc generation

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -138,7 +138,7 @@ Since enigma format does not support `package-info.java` file creation, Quilt Ma
 
 ### Tooling
 
-Quilt-hosted Javadocs are generated using [JDK 16 Standard Doclet](https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html) and can use any feature it supports. For example, it has a [list of supported tags](https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#where-tags-can-be-used). You can personally build the documentation with a newer Java version. See [the 'Checking Javadoc' section](#checking-javadoc) for how to build the documentation locally.
+Quilt-hosted Javadocs are generated using [JDK 17 Standard Doclet](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html) and can use any feature it supports. For example, it has a [list of supported tags](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#where-tags-can-be-used). You can personally build the documentation with a newer Java version. See [the 'Checking Javadoc' section](#checking-javadoc) for how to build the documentation locally.
 
 ### Custom tags
 
@@ -160,9 +160,9 @@ A class is assumed to be imported in the following scenarios:
 
 - If it is from the `java.lang` package
 - If it is from the same package as the currently documented class
-- If it is used as part of its API, such as in the signature of the class or its members (methods and fields). See Javadoc's definition of "use" in its [`-use` command line option specification](https://docs.oracle.com/en/java/javase/16/docs/specs/man/javadoc.html#options-for-javadoc).
+- If it is used as part of its API, such as in the signature of the class or its members (methods and fields). See Javadoc's definition of "use" in its [`-use` command line option specification](https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#options-for-javadoc).
 
-If it does not fulfill one of these scenarios, use the [full binary name](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/ClassLoader.html#binary-name), such as `com.google.common.collect.Lists` rather than simply `Lists`. Unlike class naming in enigma, do not use `/` to separate packages; use `.` instead.
+If it does not fulfill one of these scenarios, use the [full binary name](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ClassLoader.html#binary-name), such as `com.google.common.collect.Lists` rather than simply `Lists`. Unlike class naming in enigma, do not use `/` to separate packages; use `.` instead.
 
 Use Quilt Mappings when referencing Minecraft members, such as `net.minecraft.server.world.ThreadedAnvilChunkStorage` rather than `net.minecraft.unmapped.C_ccazprxg`. The Javadoc task will warn if some links no longer work after a rename.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use Quilt Mappings-deobfuscated Minecraft for Minecraft modding or as a depen
 
 To obtain a deobfuscated Minecraft jar, [`./gradlew mapNamedJar`](#mapNamedJar) will generate a jar named like `<minecraft version>-named.jar`, which can be sent to a decompiler for deobfuscated code.
 
-Please note to run the Quilt Mappings build script **Java 16** or higher is required!
+Please note to run the Quilt Mappings build script **Java 17** or higher is required!
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -224,8 +224,7 @@ task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, zipErasedByteco
 
 	doFirst {
 		fakeSourceDir.deleteDir()
-	}
-	doLast {
+
 		def jdProvider = new MappingsJavadocProvider(mergeTinyV2.outputMappings, "named")
 		classJavadocProvider(jdProvider)
 		fieldJavadocProvider(jdProvider)
@@ -259,6 +258,7 @@ task decompileQuiltflower(type: DecompileTask, dependsOn: [mapNamedJar]) {
 javadoc {
 	dependsOn genFakeSource
 	dependsOn downloadMinecraftLibraries
+	dependsOn docletClasses // Needed for javadoc to find the doclet classes.
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
@@ -280,7 +280,7 @@ javadoc {
 				'implSpec:a:Implementation Requirements:',
 				'implNote:a:Implementation Note:'
 		)
-		// taglets "quilt.internal.taglet.MappingTaglet" // TODO: Do we need a namespace table?
+		taglets "quilt.internal.taglet.MappingTaglet"
 		// taglet path, header, extra stylesheet settings deferred
 		it.use()
 
@@ -322,7 +322,7 @@ javadoc {
 	doFirst {
 		// lazy setting
 		options {
-			// tagletPath sourceSets.doclet.output.classesDirs.files.toList()
+			tagletPath sourceSets.doclet.output.classesDirs.files.toList()
 			header docletResources.filter { it.name == 'javadoc_header.txt' }.singleFile.text.trim()
 			addFileOption "-add-stylesheet", docletResources.filter { it.name == 'style.css' }.singleFile
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -65,13 +65,6 @@ configurations {
 	enigmaRuntime
 	javadocClasspath
 	decompileClasspath
-	mappingPoetJar {
-		transitive = false
-	}
-	mappingPoet {
-		extendsFrom mappingPoetJar
-		transitive = true
-	}
 	unpick
 	hashed
 }
@@ -83,7 +76,6 @@ dependencies {
 	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2" // for some other jsr annotations
 	decompileClasspath "net.fabricmc:cfr:${project.cfr_version}"
-	mappingPoetJar "org.quiltmc:mapping-poet:${project.mapping_poet_version}"
 	unpick "net.fabricmc.unpick:unpick-cli:${project.unpick_version}"
 	hashed "org.quiltmc:hashed:${minecraft_version}${USE_SNAPSHOT_HASHES ? "-SNAPSHOT" : ""}"
 }
@@ -139,6 +131,7 @@ tasks.withType(JavaCompile).configureEach {
 sourceSets {
 	constants
 	packageDocs // package info files
+	doclet
 }
 
 license {
@@ -269,7 +262,7 @@ javadoc {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
-	def mappingPoetJar = project.provider { zipTree configurations.mappingPoetJar.singleFile }
+	def docletResources = sourceSets.doclet.resources.asFileTree
 
 	failOnError = false
 	maxMemory = '2G'
@@ -287,7 +280,7 @@ javadoc {
 				'implSpec:a:Implementation Requirements:',
 				'implNote:a:Implementation Note:'
 		)
-		taglets "org.quiltmc.mappingpoet.jd.MappingTaglet"
+		// taglets "quilt.internal.taglet.MappingTaglet" // TODO: Do we need a namespace table?
 		// taglet path, header, extra stylesheet settings deferred
 		it.use()
 
@@ -320,7 +313,7 @@ javadoc {
 
 	doLast {
 		project.copy {
-			from mappingPoetJar
+			from docletResources
 			include "copy_on_click.js"
 			into javadoc.outputDirectory
 		}
@@ -329,10 +322,9 @@ javadoc {
 	doFirst {
 		// lazy setting
 		options {
-			tagletPath configurations.mappingPoet.files.toList()
-			header mappingPoetJar.get().filter { it.name == 'javadoc_header.txt' }.singleFile.text.trim()
-			// cannot include line breaks
-			addFileOption "-add-stylesheet", mappingPoetJar.get().filter { it.name == 'forms.css' }.singleFile
+			// tagletPath sourceSets.doclet.output.classesDirs.files.toList()
+			header docletResources.filter { it.name == 'javadoc_header.txt' }.singleFile.text.trim()
+			addFileOption "-add-stylesheet", docletResources.filter { it.name == 'style.css' }.singleFile
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,8 @@ task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, zipErasedByteco
 		classJavadocProvider(jdProvider)
 		fieldJavadocProvider(jdProvider)
 		methodJavadocProvider(jdProvider)
+	}
+	doLast {
 		logger.lifecycle ":Fake source generated"
 	}
 }
@@ -310,7 +312,7 @@ javadoc {
 		addBooleanOption 'Xdoclint:accessibility', true
 	}
 	source fileTree(fakeSourceDir) + sourceSets.constants.allJava + sourceSets.packageDocs.allJava
-	classpath = configurations.javadocClasspath.plus downloadMinecraftLibraries.outputs.files.asFileTree
+	classpath = configurations.javadocClasspath + downloadMinecraftLibraries.outputs.files.asFileTree + mapNamedJar.outputs.files.asFileTree
 
 	doLast {
 		project.copy {

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ task eraseBytecode(type: TransformJarClassesTask, dependsOn: mapNamedJar) {
 	output = file(".gradle/temp/erased-classes/")
 	visitor(DraftsmanClassVisitor::new)
 	// Set protected/package-private classes to public so that we don't have any access compile errors.
+	// TODO: Fix this by putting the classes in the same package. Javadoc shows the modifier
 	visitor { new ClassVisitor(Opcodes.ASM9, it) {
 		private int toPublicAccess(int access) {
 			if ((access & Opcodes.ACC_PROTECTED) != 0 || ((access & Opcodes.ACC_PRIVATE) == 0 && (access & Opcodes.ACC_PUBLIC) == 0)) {

--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,14 @@ dependencies {
 	hashed "org.quiltmc:hashed:${minecraft_version}${USE_SNAPSHOT_HASHES ? "-SNAPSHOT" : ""}"
 }
 
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Opcodes
+import org.quiltmc.draftsman.asm.visitor.DraftsmanClassVisitor
 import quilt.internal.Constants
 import quilt.internal.tasks.build.AddProposedFieldMappingsTask
-import quilt.internal.tasks.build.EraseBytecodeTask
 import quilt.internal.tasks.build.MappingsV2JarTask
 import quilt.internal.decompile.Decompilers
+import quilt.internal.tasks.build.TransformJarClassesTask
 import quilt.internal.tasks.mappings.EnigmaMappingsTask
 import quilt.internal.tasks.unpick.UnpickJarTask
 import quilt.internal.tasks.decompile.DecompileTask
@@ -182,9 +185,30 @@ task v2MergedMappingsJar(dependsOn: ["mergeTinyV2"], type: MappingsV2JarTask) {
 	mappings = mergeTinyV2.outputMappings
 }
 
-task eraseBytecode(type: EraseBytecodeTask, dependsOn: mapNamedJar) {
+task eraseBytecode(type: TransformJarClassesTask, dependsOn: mapNamedJar) {
 	jarFile = mappings.fileConstants.namedJar
 	output = file(".gradle/temp/erased-classes/")
+	visitor(DraftsmanClassVisitor::new)
+	// Set protected/package-private classes to public so that we don't have any access compile errors.
+	visitor { new ClassVisitor(Opcodes.ASM9, it) {
+		private int toPublicAccess(int access) {
+			if ((access & Opcodes.ACC_PROTECTED) != 0 || ((access & Opcodes.ACC_PRIVATE) == 0 && (access & Opcodes.ACC_PUBLIC) == 0)) {
+				access = access & ~Opcodes.ACC_PROTECTED
+				access = access | Opcodes.ACC_PUBLIC
+			}
+			return access
+		}
+
+		@Override
+		void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+			super.visit(version, toPublicAccess(access), name, signature, superName, interfaces)
+		}
+
+		@Override
+		void visitInnerClass(String name, String outerName, String innerName, int access) {
+			super.visitInnerClass(name, outerName, innerName, toPublicAccess(access))
+		}
+	} }
 }
 
 task zipErasedBytecode(type: Zip, dependsOn: eraseBytecode) {
@@ -201,18 +225,18 @@ task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, zipErasedByteco
 	libraries = files(mappings.fileConstants.libraries)
 	decompilerOptions = [
 			"rsy": "1", // remove synthetics
+			"dgs": "1", // decompile generic signatures
 			"pll": "99999" // pll (Preferred Line Length) is length for line wrapping
 	]
-
-	def jdProvider = new MappingsJavadocProvider(mergeTinyV2.outputMappings, "named")
-	classJavadocProvider(jdProvider)
-	fieldJavadocProvider(jdProvider)
-	methodJavadocProvider(jdProvider)
 
 	doFirst {
 		fakeSourceDir.deleteDir()
 	}
 	doLast {
+		def jdProvider = new MappingsJavadocProvider(mergeTinyV2.outputMappings, "named")
+		classJavadocProvider(jdProvider)
+		fieldJavadocProvider(jdProvider)
+		methodJavadocProvider(jdProvider)
 		logger.lifecycle ":Fake source generated"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,13 @@ dependencies {
 
 import quilt.internal.Constants
 import quilt.internal.tasks.build.AddProposedFieldMappingsTask
+import quilt.internal.tasks.build.EraseBytecodeTask
 import quilt.internal.tasks.build.MappingsV2JarTask
 import quilt.internal.decompile.Decompilers
 import quilt.internal.tasks.mappings.EnigmaMappingsTask
 import quilt.internal.tasks.unpick.UnpickJarTask
 import quilt.internal.tasks.decompile.DecompileTask
+import quilt.internal.util.MappingsJavadocProvider
 
 clean.doFirst {
 	delete mappings.fileConstants.tempDir, mappings.fileConstants.cacheFilesMinecraft
@@ -123,12 +125,12 @@ remapUnpickDefinitions {
 	mappings = buildTinyWithEnum.outputMappings
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	it.options.release = 16
+	it.options.release = 17
 }
 
 sourceSets {
@@ -180,16 +182,36 @@ task v2MergedMappingsJar(dependsOn: ["mergeTinyV2"], type: MappingsV2JarTask) {
 	mappings = mergeTinyV2.outputMappings
 }
 
+task eraseBytecode(type: EraseBytecodeTask, dependsOn: mapNamedJar) {
+	jarFile = mappings.fileConstants.namedJar
+	output = file(".gradle/temp/erased-classes/")
+}
+
+task zipErasedBytecode(type: Zip, dependsOn: eraseBytecode) {
+	from eraseBytecode.output
+	archiveName = "erased-classes.jar"
+	destinationDirectory = mappings.fileConstants.tempDir
+}
+
 def fakeSourceDir = file(".gradle/temp/fakeSource")
-task genFakeSource(type: JavaExec, dependsOn: ["mergeTinyV2", "mapNamedJar"]) {
-	group = "javadoc generation"
-	outputs.upToDateWhen { false }
+task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, zipErasedBytecode]) {
+	input = zipErasedBytecode.outputs.getFiles().getSingleFile()
+	output = fakeSourceDir
+	decompiler = Decompilers.QUILTFLOWER
+	libraries = files(mappings.fileConstants.libraries)
+	decompilerOptions = [
+			"rsy": "1", // remove synthetics
+			"pll": "99999" // pll (Preferred Line Length) is length for line wrapping
+	]
 
-	mainClass = "org.quiltmc.mappingpoet.Main"
-	classpath configurations.mappingPoet
-	// use merged v2 so we have all namespaces in jd
-	args mergeTinyV2.outputMappings.getAbsolutePath(), mappings.fileConstants.namedJar.getAbsolutePath(), fakeSourceDir.getAbsolutePath(), mappings.fileConstants.libraries.getAbsolutePath()
+	def jdProvider = new MappingsJavadocProvider(mergeTinyV2.outputMappings, "named")
+	classJavadocProvider(jdProvider)
+	fieldJavadocProvider(jdProvider)
+	methodJavadocProvider(jdProvider)
 
+	doFirst {
+		fakeSourceDir.deleteDir()
+	}
 	doLast {
 		logger.lifecycle ":Fake source generated"
 	}
@@ -218,17 +240,10 @@ task decompileQuiltflower(type: DecompileTask, dependsOn: [mapNamedJar]) {
 }
 
 javadoc {
-//	dependsOn genFakeSource
+	dependsOn genFakeSource
 	dependsOn downloadMinecraftLibraries
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
-
-	if (ENV.CI) {
-		// Java 17 is provided on CI to build the javadocs with, see https://github.com/FabricMC/yarn/issues/2429
-		javadocTool = javaToolchains.javadocToolFor {
-			languageVersion = JavaLanguageVersion.of(17)
-		}
-	}
 
 	def mappingPoetJar = project.provider { zipTree configurations.mappingPoetJar.singleFile }
 
@@ -238,7 +253,7 @@ javadoc {
 	// verbose = true // enable to debug
 	options {
 		// verbose() // enable to debug
-		source = "16"
+		source = "17"
 		encoding = 'UTF-8'
 		charSet = 'UTF-8'
 		memberLevel = JavadocMemberLevel.PRIVATE
@@ -268,15 +283,15 @@ javadoc {
 				'https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs',
 				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
 				"https://maven.fabricmc.net/docs/fabric-loader-${project.fabric_loader_version}/",
-				"https://docs.oracle.com/en/java/javase/16/docs/api/"
+				"https://docs.oracle.com/en/java/javase/17/docs/api/"
 		)
-		// https://docs.oracle.com/en/java/javase/16/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
+		// https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
 		addBooleanOption 'Xdoclint:html', true
 		addBooleanOption 'Xdoclint:syntax', true
 		addBooleanOption 'Xdoclint:reference', true
 		addBooleanOption 'Xdoclint:accessibility', true
 	}
-	source /*fileTree(fakeSourceDir) +*/ sourceSets.constants.allJava + sourceSets.packageDocs.allJava
+	source fileTree(fakeSourceDir) + sourceSets.constants.allJava + sourceSets.packageDocs.allJava
 	classpath = configurations.javadocClasspath.plus downloadMinecraftLibraries.outputs.files.asFileTree
 
 	doLast {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,6 +10,10 @@ repositories {
 		url "https://maven.quiltmc.org/repository/release"
 	}
 	maven {
+		name "Quilt Snapshots"
+		url "https://maven.quiltmc.org/repository/snapshot"
+	}
+	maven {
 		name "Fabric Repository"
 		url 'https://maven.fabricmc.net'
 	}
@@ -32,6 +36,7 @@ dependencies {
 	implementation("net.fabricmc.unpick:unpick-format-utils:${project.unpick_version}")
 	implementation("net.fabricmc.unpick:unpick-cli:${project.unpick_version}")
 	implementation("net.fabricmc:mapping-io:0.3.0")
+	implementation("org.quiltmc:javadoc-draftsman:1.0.0")
 
 	// Decompilers
 	implementation("net.fabricmc:cfr:${project.cfr_version}")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation("net.fabricmc.unpick:unpick-format-utils:${project.unpick_version}")
 	implementation("net.fabricmc.unpick:unpick-cli:${project.unpick_version}")
 	implementation("net.fabricmc:mapping-io:0.3.0")
-	implementation("org.quiltmc:javadoc-draftsman:1.0.0")
+	implementation("org.quiltmc:javadoc-draftsman:1.0.1")
 
 	// Decompilers
 	implementation("net.fabricmc:cfr:${project.cfr_version}")

--- a/buildSrc/src/main/java/quilt/internal/decompile/cfr/CfrObfuscationMapping.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/cfr/CfrObfuscationMapping.java
@@ -35,7 +35,7 @@ public class CfrObfuscationMapping extends NullMapping {
 
         @Override
         public Dumper dumpClassDoc(JavaTypeInstance owner) {
-            String javadoc = classJavadocProvider.provide(owner.getRawName(), isRecord(owner));
+            String javadoc = classJavadocProvider.provideClassJavadoc(owner.getRawName(), isRecord(owner));
             if (javadoc != null) {
                 dumpJavadoc(javadoc);
             }
@@ -45,7 +45,7 @@ public class CfrObfuscationMapping extends NullMapping {
 
         @Override
         public Dumper dumpMethodDoc(MethodPrototype method) {
-            String javadoc = methodJavadocProvider.provide(method.getName(), method.getOriginalDescriptor(), method.getOwner().getRawName());
+            String javadoc = methodJavadocProvider.provideMethodJavadoc(method.getName(), method.getOriginalDescriptor(), method.getOwner().getRawName());
             if (javadoc != null) {
                 dumpJavadoc(javadoc);
             }
@@ -55,7 +55,7 @@ public class CfrObfuscationMapping extends NullMapping {
 
         @Override
         public Dumper dumpFieldDoc(Field field, JavaTypeInstance owner) {
-            String javadoc = fieldJavadocProvider.provide(field.getFieldName(), field.getDescriptor(), owner.getRawName());
+            String javadoc = fieldJavadocProvider.provideFieldJavadoc(field.getFieldName(), field.getDescriptor(), owner.getRawName());
             if (javadoc != null) {
                 dumpJavadoc(javadoc);
             }

--- a/buildSrc/src/main/java/quilt/internal/decompile/javadoc/ClassJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/javadoc/ClassJavadocProvider.java
@@ -3,5 +3,5 @@ package quilt.internal.decompile.javadoc;
 public interface ClassJavadocProvider {
     ClassJavadocProvider EMPTY = (className, isRecord) -> null;
 
-    String provide(String className, boolean isRecord);
+    String provideClassJavadoc(String className, boolean isRecord);
 }

--- a/buildSrc/src/main/java/quilt/internal/decompile/javadoc/FieldJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/javadoc/FieldJavadocProvider.java
@@ -3,5 +3,5 @@ package quilt.internal.decompile.javadoc;
 public interface FieldJavadocProvider {
     FieldJavadocProvider EMPTY = (fieldName, descriptor, owner) -> null;
 
-    String provide(String fieldName, String descriptor, String owner);
+    String provideFieldJavadoc(String fieldName, String descriptor, String owner);
 }

--- a/buildSrc/src/main/java/quilt/internal/decompile/javadoc/MethodJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/javadoc/MethodJavadocProvider.java
@@ -3,5 +3,5 @@ package quilt.internal.decompile.javadoc;
 public interface MethodJavadocProvider {
     MethodJavadocProvider EMPTY = (methodName, descriptor, owner) -> null;
 
-    String provide(String methodName, String descriptor, String owner);
+    String provideMethodJavadoc(String methodName, String descriptor, String owner);
 }

--- a/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerJavadocProvider.java
@@ -22,16 +22,16 @@ public class QuiltflowerJavadocProvider implements IFabricJavadocProvider {
     @Override
     public String getClassDoc(StructClass structClass) {
         boolean isRecord = (structClass.getAccessFlags() & 0x10000) != 0; // ACC_RECORD
-        return classJavadocProvider.provide(structClass.qualifiedName, isRecord);
+        return classJavadocProvider.provideClassJavadoc(structClass.qualifiedName, isRecord);
     }
 
     @Override
     public String getFieldDoc(StructClass structClass, StructField structField) {
-        return fieldJavadocProvider.provide(structField.getName(), structField.getDescriptor(), structClass.qualifiedName);
+        return fieldJavadocProvider.provideFieldJavadoc(structField.getName(), structField.getDescriptor(), structClass.qualifiedName);
     }
 
     @Override
     public String getMethodDoc(StructClass structClass, StructMethod structMethod) {
-        return methodJavadocProvider.provide(structMethod.getName(), structMethod.getDescriptor(), structClass.qualifiedName);
+        return methodJavadocProvider.provideMethodJavadoc(structMethod.getName(), structMethod.getDescriptor(), structClass.qualifiedName);
     }
 }

--- a/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerResultSaver.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerResultSaver.java
@@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.jar.Manifest;
 
 public class QuiltflowerResultSaver implements IResultSaver {
@@ -32,6 +33,10 @@ public class QuiltflowerResultSaver implements IResultSaver {
 
     @Override
     public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {
+        if (content == null) {
+            return;
+        }
+
         Path file = outputPath.resolve(path).resolve(entryName);
         try {
             if (!Files.exists(file.getParent())) {

--- a/buildSrc/src/main/java/quilt/internal/tasks/build/EraseBytecodeTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/EraseBytecodeTask.java
@@ -1,0 +1,75 @@
+package quilt.internal.tasks.build;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.quiltmc.draftsman.asm.DraftsmanClassTransformer;
+import quilt.internal.Constants;
+import quilt.internal.tasks.DefaultMappingsTask;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class EraseBytecodeTask extends DefaultMappingsTask {
+    private final RegularFileProperty jarFile;
+    private final DirectoryProperty output;
+
+    public EraseBytecodeTask() {
+        super(Constants.Groups.BUILD_MAPPINGS_GROUP);
+        jarFile = getProject().getObjects().fileProperty();
+        output = getProject().getObjects().directoryProperty();
+    }
+
+    @InputFile
+    public RegularFileProperty getJarFile() {
+        return jarFile;
+    }
+
+    @OutputDirectory
+    public DirectoryProperty getOutput() {
+        return output;
+    }
+
+    @TaskAction
+    public void erase() throws IOException {
+        Map<String, byte[]> classFiles = new HashMap<>();
+        try (ZipFile zipFile = new ZipFile(jarFile.getAsFile().get())) {
+            List<? extends ZipEntry> entries = Collections.list(zipFile.entries());
+            for (ZipEntry entry : entries) {
+                String name = entry.getName();
+                if (name.endsWith(".class")) {
+                    try (InputStream stream = zipFile.getInputStream(entry)) {
+                        classFiles.put(name, stream.readAllBytes());
+                    }
+                }
+            }
+        }
+
+        Map<String, byte[]> transformedClassFiles = new HashMap<>();
+        for (String name : classFiles.keySet()) {
+            DraftsmanClassTransformer transformer = new DraftsmanClassTransformer(classFiles.get(name), false);
+            byte[] transformed = transformer.transform();
+            transformedClassFiles.put(name, transformed);
+        }
+
+        for (String name : transformedClassFiles.keySet()) {
+            Path path = output.getAsFile().get().toPath().resolve(name);
+            if (!Files.exists(path.getParent())) {
+                Files.createDirectories(path.getParent());
+            }
+
+            Files.write(path, transformedClassFiles.get(name));
+        }
+    }
+}

--- a/buildSrc/src/main/java/quilt/internal/tasks/build/InvertPerVersionMappingsTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/InvertPerVersionMappingsTask.java
@@ -18,6 +18,7 @@ public class InvertPerVersionMappingsTask extends DefaultMappingsTask {
 
     public InvertPerVersionMappingsTask() {
         super(Constants.Groups.BUILD_MAPPINGS_GROUP);
+        dependsOn(DownloadPerVersionMappingsTask.TASK_NAME);
 
         outputsNeverUpToDate();
     }

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -26,7 +26,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
     @Override
     public String provideClassJavadoc(String className, boolean isRecord) {
         MappingTree.ClassMapping mapping = tree.getClass(className, namespaceId);
-        if (mapping != null && mapping.getComment() != null) {
+        if (mapping != null) {
             StringBuilder javadoc;
             if (mapping.getComment() != null) {
                 javadoc = new StringBuilder(mapping.getComment());

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -1,0 +1,73 @@
+package quilt.internal.util;
+
+import net.fabricmc.mappingio.format.Tiny2Reader;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+import quilt.internal.decompile.javadoc.ClassJavadocProvider;
+import quilt.internal.decompile.javadoc.FieldJavadocProvider;
+import quilt.internal.decompile.javadoc.MethodJavadocProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+
+public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavadocProvider, MethodJavadocProvider {
+    private final MemoryMappingTree tree = new MemoryMappingTree();
+    private final int namespaceId;
+
+    public MappingsJavadocProvider(File mappingsFile, String namespace) throws IOException {
+        try (Reader reader = Files.newBufferedReader(mappingsFile.toPath())) {
+            Tiny2Reader.read(reader, tree);
+        }
+        namespaceId = tree.getNamespaceId(namespace);
+    }
+
+    @Override
+    public String provideClassJavadoc(String className, boolean isRecord) {
+        MappingTree.ClassMapping mapping = tree.getClass(className, namespaceId);
+        if (mapping != null) {
+            return mapping.getComment();
+        }
+
+        return null;
+    }
+
+    @Override
+    public String provideFieldJavadoc(String fieldName, String descriptor, String owner) {
+        MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
+        if (ownerMapping != null) {
+            MappingTree.FieldMapping fieldMapping = ownerMapping.getField(fieldName, descriptor, namespaceId);
+            if (fieldMapping != null) {
+                return fieldMapping.getComment();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String provideMethodJavadoc(String methodName, String descriptor, String owner) {
+        MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
+        if (ownerMapping != null) {
+            MappingTree.MethodMapping methodMapping = ownerMapping.getMethod(methodName, descriptor, namespaceId);
+            if (methodMapping != null) {
+                StringBuilder argComments = new StringBuilder();
+                for (MappingTree.MethodArgMapping argMapping : methodMapping.getArgs()) {
+                    if (argMapping.getComment() != null) {
+                        argComments.append("@param ").append(argMapping.getName(namespaceId)).append(" ").append(argMapping.getComment());
+                        argComments.append("\n");
+                    }
+                }
+
+                if (!argComments.isEmpty()) {
+                    return methodMapping.getComment() + "\n" + argComments;
+                }
+
+                return methodMapping.getComment();
+            }
+        }
+
+        return null;
+    }
+}

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -26,8 +26,20 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
     @Override
     public String provideClassJavadoc(String className, boolean isRecord) {
         MappingTree.ClassMapping mapping = tree.getClass(className, namespaceId);
-        if (mapping != null) {
-            return mapping.getComment();
+        if (mapping != null && mapping.getComment() != null) {
+            StringBuilder javadoc = new StringBuilder(mapping.getComment());
+            javadoc.append("\n");
+
+            // Add mapping info
+            for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
+                String namespace = tree.getNamespaceName(i);
+                String name = mapping.getName(namespace);
+                javadoc.append("@mapping {@literal ");
+                javadoc.append(namespace).append(" ").append(name).append("}");
+                javadoc.append("\n");
+            }
+
+            return javadoc.toString();
         }
 
         return null;
@@ -38,8 +50,20 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
         MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
         if (ownerMapping != null) {
             MappingTree.FieldMapping fieldMapping = ownerMapping.getField(fieldName, descriptor, namespaceId);
-            if (fieldMapping != null) {
-                return fieldMapping.getComment();
+            if (fieldMapping != null && fieldMapping.getComment() != null) {
+                StringBuilder javadoc = new StringBuilder(fieldMapping.getComment());
+                javadoc.append("\n");
+
+                // Add mapping info
+                for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
+                    String namespace = tree.getNamespaceName(i);
+                    String name = fieldMapping.getName(namespace);
+                    javadoc.append("@mapping {@literal ");
+                    javadoc.append(namespace).append(" ").append(name).append("}");
+                    javadoc.append("\n");
+                }
+
+                return javadoc.toString();
             }
         }
 
@@ -51,7 +75,10 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
         MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
         if (ownerMapping != null) {
             MappingTree.MethodMapping methodMapping = ownerMapping.getMethod(methodName, descriptor, namespaceId);
-            if (methodMapping != null) {
+            if (methodMapping != null && methodMapping.getComment() != null) {
+                StringBuilder javadoc = new StringBuilder(methodMapping.getComment());
+
+                // Generate @param tags
                 StringBuilder argComments = new StringBuilder();
                 for (MappingTree.MethodArgMapping argMapping : methodMapping.getArgs()) {
                     if (argMapping.getComment() != null) {
@@ -61,10 +88,22 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 }
 
                 if (!argComments.isEmpty()) {
-                    return methodMapping.getComment() + "\n" + argComments;
+                    javadoc.append("\n");
+                    javadoc.append(argComments);
                 }
 
-                return methodMapping.getComment();
+                javadoc.append("\n");
+
+                // Add mapping info
+                for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
+                    String namespace = tree.getNamespaceName(i);
+                    String name = methodMapping.getName(namespace);
+                    javadoc.append("@mapping {@literal ");
+                    javadoc.append(namespace).append(" ").append(name).append("}");
+                    javadoc.append("\n");
+                }
+
+                return javadoc.toString();
             }
         }
 

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -30,7 +30,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
             StringBuilder javadoc;
             if (mapping.getComment() != null) {
                 javadoc = new StringBuilder(mapping.getComment());
-                javadoc.append("\n");
+                javadoc.append("\n\n");
             } else {
                 javadoc = new StringBuilder();
             }
@@ -44,7 +44,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 javadoc.append("\n");
             }
 
-            return javadoc.toString();
+            return javadoc.toString().trim();
         }
 
         return "Mapping not found";
@@ -59,7 +59,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 StringBuilder javadoc;
                 if (fieldMapping.getComment() != null) {
                     javadoc = new StringBuilder(fieldMapping.getComment());
-                    javadoc.append("\n");
+                    javadoc.append("\n\n");
                 } else {
                     javadoc = new StringBuilder();
                 }
@@ -74,7 +74,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                     javadoc.append("\n");
                 }
 
-                return javadoc.toString();
+                return javadoc.toString().trim();
             }
         }
 
@@ -90,6 +90,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 StringBuilder javadoc;
                 if (methodMapping.getComment() != null) {
                     javadoc = new StringBuilder(methodMapping.getComment());
+                    javadoc.append("\n\n");
                 } else {
                     javadoc = new StringBuilder();
                 }
@@ -104,11 +105,9 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 }
 
                 if (!argComments.isEmpty()) {
-                    javadoc.append("\n");
                     javadoc.append(argComments);
+                    javadoc.append("\n");
                 }
-
-                javadoc.append("\n");
 
                 // Add mapping info
                 for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
@@ -120,7 +119,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                     javadoc.append("\n");
                 }
 
-                return javadoc.toString();
+                return javadoc.toString().trim();
             }
         }
 

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -58,8 +58,9 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
                     String namespace = tree.getNamespaceName(i);
                     String name = fieldMapping.getName(namespace);
+                    String selector = "L" + ownerMapping.getName(namespace) + ";" + name + ":" + fieldMapping.getDesc(namespace);
                     javadoc.append("@mapping {@literal ");
-                    javadoc.append(namespace).append(" ").append(name).append("}");
+                    javadoc.append(namespace).append(" ").append(name).append(" ").append(selector).append("}");
                     javadoc.append("\n");
                 }
 
@@ -98,8 +99,9 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
                 for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
                     String namespace = tree.getNamespaceName(i);
                     String name = methodMapping.getName(namespace);
+                    String selector = "L" + ownerMapping.getName(namespace) + ";" + name + methodMapping.getDesc(namespace);
                     javadoc.append("@mapping {@literal ");
-                    javadoc.append(namespace).append(" ").append(name).append("}");
+                    javadoc.append(namespace).append(" ").append(name).append(" ").append(selector).append("}");
                     javadoc.append("\n");
                 }
 

--- a/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
+++ b/buildSrc/src/main/java/quilt/internal/util/MappingsJavadocProvider.java
@@ -27,8 +27,13 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
     public String provideClassJavadoc(String className, boolean isRecord) {
         MappingTree.ClassMapping mapping = tree.getClass(className, namespaceId);
         if (mapping != null && mapping.getComment() != null) {
-            StringBuilder javadoc = new StringBuilder(mapping.getComment());
-            javadoc.append("\n");
+            StringBuilder javadoc;
+            if (mapping.getComment() != null) {
+                javadoc = new StringBuilder(mapping.getComment());
+                javadoc.append("\n");
+            } else {
+                javadoc = new StringBuilder();
+            }
 
             // Add mapping info
             for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
@@ -42,7 +47,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
             return javadoc.toString();
         }
 
-        return null;
+        return "Mapping not found";
     }
 
     @Override
@@ -50,9 +55,14 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
         MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
         if (ownerMapping != null) {
             MappingTree.FieldMapping fieldMapping = ownerMapping.getField(fieldName, descriptor, namespaceId);
-            if (fieldMapping != null && fieldMapping.getComment() != null) {
-                StringBuilder javadoc = new StringBuilder(fieldMapping.getComment());
-                javadoc.append("\n");
+            if (fieldMapping != null) {
+                StringBuilder javadoc;
+                if (fieldMapping.getComment() != null) {
+                    javadoc = new StringBuilder(fieldMapping.getComment());
+                    javadoc.append("\n");
+                } else {
+                    javadoc = new StringBuilder();
+                }
 
                 // Add mapping info
                 for (int i = tree.getMinNamespaceId(); i < tree.getMaxNamespaceId(); i++) {
@@ -68,7 +78,7 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
             }
         }
 
-        return null;
+        return "Mapping not found";
     }
 
     @Override
@@ -76,8 +86,13 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
         MappingTree.ClassMapping ownerMapping = tree.getClass(owner, namespaceId);
         if (ownerMapping != null) {
             MappingTree.MethodMapping methodMapping = ownerMapping.getMethod(methodName, descriptor, namespaceId);
-            if (methodMapping != null && methodMapping.getComment() != null) {
-                StringBuilder javadoc = new StringBuilder(methodMapping.getComment());
+            if (methodMapping != null) {
+                StringBuilder javadoc;
+                if (methodMapping.getComment() != null) {
+                    javadoc = new StringBuilder(methodMapping.getComment());
+                } else {
+                    javadoc = new StringBuilder();
+                }
 
                 // Generate @param tags
                 StringBuilder argComments = new StringBuilder();
@@ -109,6 +124,6 @@ public class MappingsJavadocProvider implements ClassJavadocProvider, FieldJavad
             }
         }
 
-        return null;
+        return "Mapping not found";
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,9 +13,9 @@ pluginManagement {
 	}
 }
 
-// This check is done here before any plugins that may require java 16 are able to load.
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-	throw new UnsupportedOperationException("Quilt Mappings's buildscript requires Java 16 or higher.")
+// This check is done here before any plugins that may require java 17 are able to load.
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+	throw new UnsupportedOperationException("Quilt Mappings's buildscript requires Java 17 or higher.")
 }
 
 rootProject.name = "quilt-mappings"

--- a/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
+++ b/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
@@ -1,15 +1,19 @@
 /*
  * This file is free for everyone to use under the Creative Commons Zero license.
  */
+
 package quilt.internal.taglet;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.LiteralTree;
+import com.sun.source.doctree.UnknownBlockTagTree;
 import jdk.javadoc.doclet.Taglet;
 
 import javax.lang.model.element.Element;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class MappingTaglet implements Taglet {
@@ -33,6 +37,37 @@ public class MappingTaglet implements Taglet {
 
     @Override
     public String toString(List<? extends DocTree> tags, Element element) {
-        return null;
+        StringBuilder content = new StringBuilder();
+        content.append("""
+                <dt>Mappings:</dt>
+                <dd><div class="quilt"><table class="mapping" summary="Mapping data">
+                    <thead>
+                        <th>Namespace</th>
+                        <th>Name</th>
+                    </thead>
+                    <tbody>
+                """);
+
+        for (DocTree tag : tags) {
+            String body = ((UnknownBlockTagTree) tag).getContent().stream().map(t -> ((LiteralTree) t).getBody().getBody()).collect(Collectors.joining());
+            String[] split = body.split(" +", 2);
+            String namespace = split[0];
+            String name = split[1];
+
+            content.append(String.format("""
+                            <tr>
+                                <td>%s</td>
+                                <td><span class="copyable"><code>%s</code></span></td>
+                            </tr>
+                    """, namespace, name));
+        }
+
+        content.append("""
+                    </tbody>
+                    </table></div>
+                </dd>
+                """);
+
+        return content.toString();
     }
 }

--- a/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
+++ b/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
@@ -10,6 +10,7 @@ import com.sun.source.doctree.UnknownBlockTagTree;
 import jdk.javadoc.doclet.Taglet;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -37,29 +38,34 @@ public class MappingTaglet implements Taglet {
 
     @Override
     public String toString(List<? extends DocTree> tags, Element element) {
+        boolean elementIsType = element instanceof TypeElement;
+
         StringBuilder content = new StringBuilder();
-        content.append("""
+        content.append(String.format("""
                 <dt>Mappings:</dt>
                 <dd><div class="quilt"><table class="mapping" summary="Mapping data">
                     <thead>
                         <th>Namespace</th>
-                        <th>Name</th>
+                        <th>Name</th>%s
                     </thead>
                     <tbody>
-                """);
+                """,
+                elementIsType ? "" : "\n<th>Mixin selector</th>"));
 
         for (DocTree tag : tags) {
             String body = ((UnknownBlockTagTree) tag).getContent().stream().map(t -> ((LiteralTree) t).getBody().getBody()).collect(Collectors.joining());
-            String[] split = body.split(" +", 2);
-            String namespace = split[0];
-            String name = split[1];
+            String[] split = body.split(" +", 3);
+            String namespace = escapeHtml(split[0]);
+            String name = escapeHtml(split[1]);
+            String selector = elementIsType ? "" : escapeHtml(split[2]);
 
             content.append(String.format("""
                             <tr>
                                 <td>%s</td>
-                                <td><span class="copyable"><code>%s</code></span></td>
+                                <td><span class="copyable"><code>%s</code></span></td>%s
                             </tr>
-                    """, namespace, name));
+                    """, namespace, name,
+                    elementIsType ? "" : String.format("<td><span class=\"copyable\"><code>%s</code></span></td>", selector)));
         }
 
         content.append("""
@@ -69,5 +75,20 @@ public class MappingTaglet implements Taglet {
                 """);
 
         return content.toString();
+    }
+
+    private static String escapeHtml(String s) {
+        // Escape html characters
+        StringBuilder result = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c > 127 || c == '"' || c == '\'' || c == '<' || c == '>' || c == '&') {
+                result.append("&#").append((int) c).append(';');
+            } else {
+                result.append(c);
+            }
+        }
+
+        return result.toString();
     }
 }

--- a/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
+++ b/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
@@ -1,3 +1,6 @@
+/*
+ * This file is free for everyone to use under the Creative Commons Zero license.
+ */
 package quilt.internal.taglet;
 
 import com.sun.source.doctree.DocTree;

--- a/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
+++ b/src/doclet/java/quilt/internal/taglet/MappingTaglet.java
@@ -1,0 +1,35 @@
+package quilt.internal.taglet;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+import javax.lang.model.element.Element;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public class MappingTaglet implements Taglet {
+    // Required by javadoc, see TagletManager#addCustomTag
+    public MappingTaglet() {}
+
+    @Override
+    public Set<Location> getAllowedLocations() {
+        return EnumSet.of(Location.CONSTRUCTOR, Location.FIELD, Location.METHOD, Location.TYPE);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "mapping";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return null;
+    }
+}

--- a/src/doclet/resources/copy_on_click.js
+++ b/src/doclet/resources/copy_on_click.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 FabricMC
+ * Copyright (c) 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+document.onreadystatechange = function() {
+  if (document.readyState == "complete") {
+    const items = document.querySelectorAll(".copyable");
+    items.forEach(item => {
+      item.title = "Click to copy";
+      item.style["cursor"] = "pointer";
+      item.onclick = function() {
+        var range = document.createRange();
+        range.selectNode(item);
+        window.getSelection().addRange(range);
+        document.execCommand("copy");
+        window.getSelection().removeRange(range);
+        console.log("Copied to clipboard");
+      };
+    });
+  }
+};

--- a/src/doclet/resources/javadoc_header.txt
+++ b/src/doclet/resources/javadoc_header.txt
@@ -1,0 +1,1 @@
+<script src="{@docRoot}/copy_on_click.js"></script>

--- a/src/doclet/resources/style.css
+++ b/src/doclet/resources/style.css
@@ -1,0 +1,39 @@
+.quilt {
+  font: 400 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  color: #111;
+  background-color: #fdfdfd;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-feature-settings: "kern" 1;
+  -moz-font-feature-settings: "kern" 1;
+  -o-font-feature-settings: "kern" 1;
+  font-feature-settings: "kern" 1;
+  font-kerning: normal;
+  display: flex;
+  flex-direction: column;
+}
+
+.quilt table {
+  width: 100%;
+  text-align: left;
+  color: #3f3f3f;
+  border-collapse: collapse;
+  border: 1px solid #e8e8e8;
+}
+
+.quilt table tr:nth-child(even) {
+  background-color: #f7f7f7;
+}
+
+.quilt table th, table td {
+  padding: 1px 10px;
+}
+
+.quilt table th {
+  background-color: #f0f0f0;
+  border: 1px solid #dedede;
+  border-bottom-color: #c9c9c9;
+}
+
+.quilt table td {
+  border: 1px solid #e8e8e8;
+}


### PR DESCRIPTION
Closes #33. Updates required java to 17 because that's what Minecraft uses, and we need to recompile it (kinda). Removes dependency on MappingPoet, everything used has been moved, but I haven't implemented namespace tables yet