### PR TITLE
Fix broken parameter names in RootSystemFeature

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.0.7
+enigma_version=1.0.8
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.0.7
+enigma_version=1.0.8
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9

--- a/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
@@ -25,7 +25,6 @@ CLASS net/minecraft/unmapped/C_pcuhrnzr net/minecraft/world/gen/feature/RootSyst
 		ARG 3 x
 		ARG 4 z
 		ARG 5 mutablePos
-		ARG 6 mutablePos
 	METHOD m_qpnjiepb generateDirt (Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_ldkphtbr;Lnet/minecraft/unmapped/C_njmhlimm;Ljava/util/Random;)V
 		ARG 0 pos
 		ARG 1 maxY
@@ -36,4 +35,3 @@ CLASS net/minecraft/unmapped/C_pcuhrnzr net/minecraft/world/gen/feature/RootSyst
 		ARG 0 world
 		ARG 1 config
 		ARG 2 pos
-		ARG 3 pos

--- a/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
@@ -13,7 +13,6 @@ CLASS net/minecraft/unmapped/C_pcuhrnzr net/minecraft/world/gen/feature/RootSyst
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 mutablePos
-		ARG 5 mutablePos
 	METHOD m_ikbynztx isAirOrWater (Lnet/minecraft/unmapped/C_txtbiemp;II)Z
 		ARG 0 state
 		ARG 1 height

--- a/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/RootSystemFeature.mapping
@@ -9,10 +9,10 @@ CLASS net/minecraft/unmapped/C_pcuhrnzr net/minecraft/world/gen/feature/RootSyst
 		ARG 6 pos
 	METHOD m_fkvndpww generateHangingRoots (Lnet/minecraft/unmapped/C_ldkphtbr;Lnet/minecraft/unmapped/C_njmhlimm;Ljava/util/Random;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;)V
 		ARG 0 world
-		ARG 1 world
-		ARG 2 config
-		ARG 3 random
-		ARG 4 pos
+		ARG 1 config
+		ARG 2 random
+		ARG 3 pos
+		ARG 4 mutablePos
 		ARG 5 mutablePos
 	METHOD m_ikbynztx isAirOrWater (Lnet/minecraft/unmapped/C_txtbiemp;II)Z
 		ARG 0 state
@@ -34,6 +34,6 @@ CLASS net/minecraft/unmapped/C_pcuhrnzr net/minecraft/world/gen/feature/RootSyst
 		ARG 4 random
 	METHOD m_vabsmbje hasSpaceForTree (Lnet/minecraft/unmapped/C_ldkphtbr;Lnet/minecraft/unmapped/C_njmhlimm;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 world
-		ARG 1 world
-		ARG 2 config
+		ARG 1 config
+		ARG 2 pos
 		ARG 3 pos


### PR DESCRIPTION
Fixes broken parameter names in RootSystemFeature.mapping, looks like the parameters shifted because the methods were changed to static