### PR TITLE
Add usage instructions to the QM README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,43 @@
 Quilt Mappings is a set of open, unencumbered Minecraft mappings, free for everyone to use under the Creative Commons Zero license. The intention is to let 
 everyone mod Minecraft freely and openly, while also being able to innovate and process the mappings as they see fit.
 
+Unlike previous mapping sets, Quilt Mappings allows referencing the official Mojang mappings, which speeds up creating new mappings for Minecraft, and improves name quality and accuracy.
+
 To see the current version being targeted, check the branch name!
 
 ## Usage
-To use Quilt Mappings-deobfuscated Minecraft for Minecraft modding or as a dependency in a Java project, you can use [quilt-gradle](https://github.com/quiltmc/quilt-gradle) Gradle plugin. See [fabric wiki tutorial](https://fabricmc.net/wiki/tutorial:setup) for more information.
+### A Minecraft mod using Loom
+To use Quilt Mappings in a Fabric or Quilt mod, use the official [Quilt Mappings on Loom](https://github.com/QuiltMC/quilt-mappings-on-loom) Gradle plugin.
 
+`settings.gradle`:
+```groovy
+pluginManagement {
+    repositories {
+        maven { url = "https://maven.quiltmc.org/repository/release" }
+    }
+}
+```
+`build.gradle`:
+```groovy
+plugins {
+  // ...
+  id "org.quiltmc.quilt-mappings-on-loom" version "QMoL_VERSION"
+}
+
+// ...
+
+dependencies {
+   mappings(loom.layered {
+      addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${minecraft_version}+build.${project.quilt_mappings}:v2"))
+   })
+}
+```
+Replace `QMoL_VERSION` with the version corresponding to the version of Loom being used:
+| Loom Version | QMoL Version |
+| - | - |
+| 0.10 | 3.1.2 |
+| 0.11 | 4.0.0 |
+### Something else
 To obtain a deobfuscated Minecraft jar, [`./gradlew mapNamedJar`](#mapNamedJar) will generate a jar named like `<minecraft version>-named.jar`, which can be sent to a decompiler for deobfuscated code.
 
 Please note to run the Quilt Mappings build script **Java 17** or higher is required!

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
    })
 }
 ```
-Replace `QMoL_VERSION` with the version corresponding to the version of Loom being used:
+Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the version of Loom being used:
 | Loom Version | QMoL Version |
 | - | - |
 | 0.10 | 3.1.2 |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Quilt Mappings is a set of open, unencumbered Minecraft mappings, free for everyone to use under the Creative Commons Zero license. The intention is to let 
 everyone mod Minecraft freely and openly, while also being able to innovate and process the mappings as they see fit.
 
-Unlike previous mapping sets, Quilt Mappings allows referencing the official Mojang mappings, which speeds up creating new mappings for Minecraft, and improves name quality and accuracy.
+Unlike previous mapping sets, Quilt Mappings allows referencing the official Mojang mappings, which speeds up creating new mappings for Minecraft and improves name quality and accuracy.
 
 To see the current version being targeted, check the branch name!
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins {
 
 dependencies {
    mappings(loom.layered {
-      addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${minecraft_version}+build.${project.quilt_mappings}:v2"))
+      addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${project.minecraft_version}+build.${project.quilt_mappings}:v2"))
    })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ To see the current version being targeted, check the branch name!
 
 ## Usage
 ### A Minecraft mod using Loom
-To use Quilt Mappings in a Fabric or Quilt mod, use the official [Quilt Mappings on Loom](https://github.com/QuiltMC/quilt-mappings-on-loom) Gradle plugin.
+To use Quilt Mappings in a Fabric or Quilt mod use the official [Quilt Mappings on Loom](https://github.com/QuiltMC/quilt-mappings-on-loom) (QMoL) Gradle plugin.
+
+### Fabric-Loom support
+This extra code is only needed if you are using Fabric Loom; the QMoL plugin is applied by default on Quilt.
 
 `settings.gradle`:
 ```groovy
@@ -26,16 +29,18 @@ plugins {
   // Check the Quilt Mappings on Loom README for the correct version to use
   id "org.quiltmc.quilt-mappings-on-loom" version "QMoL_VERSION"
 }
-
-// ...
-
+```
+See [here](https://github.com/quiltmc/quilt-mappings-on-loom/blob/master/README.md#qmol-versions) for the correct `QMoL_VERSION` to use.
+### Common code
+This code is added to your buildscript regardless of if you are using Fabric or Quilt Loom.
+```groovy
 dependencies {
    mappings(loom.layered {
       addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${project.minecraft_version}+build.${project.quilt_mappings}:v2"))
    })
 }
 ```
-See [here](https://github.com/quiltmc/quilt-mappings-on-loom/blob/master/README.md#qmol-versions) for the correct `QMoL_VERSION` to use.
+
 
 ### Something else
 To obtain a deobfuscated Minecraft jar, [`./gradlew mapNamedJar`](#mapNamedJar) will generate a jar named like `<minecraft version>-named.jar`, which can be sent to a decompiler for deobfuscated code.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pluginManagement {
 ```groovy
 plugins {
   // ...
+  // Check the Quilt Mappings on Loom README for the correct version to use
   id "org.quiltmc.quilt-mappings-on-loom" version "QMoL_VERSION"
 }
 
@@ -34,11 +35,8 @@ dependencies {
    })
 }
 ```
-Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the version of Loom being used:
-| Loom Version | QMoL Version |
-| - | - |
-| 0.10 | 3.1.2 |
-| 0.11 | 4.0.0 |
+See [here](https://github.com/quiltmc/quilt-mappings-on-loom/blob/master/README.md#qmol-versions) for the correct `QMoL_VERSION` to use.
+
 ### Something else
 To obtain a deobfuscated Minecraft jar, [`./gradlew mapNamedJar`](#mapNamedJar) will generate a jar named like `<minecraft version>-named.jar`, which can be sent to a decompiler for deobfuscated code.
 


### PR DESCRIPTION
It's currently very difficult to figure out how to actually use QM. The README now links to the Quilt Mappings On Loom project.

I also added code snippets. Even though you have to actually go to the QMoL repo to get the correct version (otherwise we'd have to update every branch each time a new Loom version comes out), putting it here too makes the section flashy and very difficult to miss.

I added a one-line blurb about why you should use QM, similar to the QMoL README, but without mentioning Yarn by name.

One of the links will not work until https://github.com/QuiltMC/quilt-mappings-on-loom/pull/7 is merged