### PR TITLE
fixes to piston related mappings

### DIFF
--- a/mappings/net/minecraft/block/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/PistonBlock.mapping
@@ -31,6 +31,6 @@ CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/PistonBlock
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos
-		ARG 3 dir
+		ARG 3 direction
 		ARG 4 canBreak
 		ARG 5 pistonFacing

--- a/mappings/net/minecraft/block/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/PistonBlock.mapping
@@ -17,8 +17,8 @@ CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/PistonBlock
 	METHOD m_jpjefmzi move (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Z)Z
 		ARG 1 world
 		ARG 2 pos
-		ARG 3 dir
-		ARG 4 retract
+		ARG 3 facing
+		ARG 4 extend
 	METHOD m_jsosnkga tryMove (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
@@ -26,11 +26,11 @@ CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/PistonBlock
 	METHOD m_kbjhhmlf shouldExtend (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 world
 		ARG 2 pos
-		ARG 3 pistonFace
+		ARG 3 facing
 	METHOD m_ybsqicni isMovable (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;ZLnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos
-		ARG 3 direction
+		ARG 3 dir
 		ARG 4 canBreak
-		ARG 5 pistonDir
+		ARG 5 pistonFacing

--- a/mappings/net/minecraft/block/PistonExtensionBlock.mapping
+++ b/mappings/net/minecraft/block/PistonExtensionBlock.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/unmapped/C_yqbibfrg net/minecraft/block/PistonExtensionBlock
 	METHOD m_vksmmlah createBlockEntityPiston (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;ZZ)Lnet/minecraft/unmapped/C_kvegafmh;
 		ARG 0 pos
 		ARG 1 state
-		ARG 2 pushedBlock
+		ARG 2 movedState
 		ARG 3 facing
 		ARG 4 extending
 		ARG 5 source

--- a/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
@@ -66,6 +66,6 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 	METHOD m_szmbtwln finish ()V
 	METHOD m_tlxmitvb getRenderOffsetX (F)F
 		ARG 1 tickDelta
-	METHOD m_usuotmqt getMoveDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
+	METHOD m_usuotmqt getMovementDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_wsirbeyt isExtending ()Z
 	METHOD m_zqowmlcs getHeadBlockState ()Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 	FIELD f_kuqnpbhp progress F
 	FIELD f_qviclatw source Z
 	FIELD f_rbuxpdya facing Lnet/minecraft/unmapped/C_xpuuihxf;
-	FIELD f_rvkdkxam pushedBlock Lnet/minecraft/unmapped/C_txtbiemp;
+	FIELD f_rvkdkxam movedState Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_wpwkhlxx extending Z
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos
@@ -13,7 +13,7 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;ZZ)V
 		ARG 1 pos
 		ARG 2 state
-		ARG 3 pushedBlock
+		ARG 3 movedState
 		ARG 4 facing
 		ARG 5 extending
 		ARG 6 source
@@ -32,7 +32,7 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 	METHOD m_fcrbddkq isSource ()Z
 	METHOD m_froifngc getFacing ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_gnbgcwpf getIntersectionSize (Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_hbcjzgoe;)D
-	METHOD m_hlnudkkk isPushingHoneyBlock ()Z
+	METHOD m_hlnudkkk isMovingHoneyBlock ()Z
 	METHOD m_hsrsrqug getCollisionShape (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 world
 		ARG 2 pos
@@ -43,7 +43,7 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 		ARG 3 blockEntity
 	METHOD m_jrueqioa (Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 entity
-	METHOD m_jyvwmixj getPushedBlock ()Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_jyvwmixj getMovedBlockState ()Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_ktfnieqa canMoveEntity (Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 box
 		ARG 1 entity
@@ -66,6 +66,6 @@ CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEn
 	METHOD m_szmbtwln finish ()V
 	METHOD m_tlxmitvb getRenderOffsetX (F)F
 		ARG 1 tickDelta
-	METHOD m_usuotmqt getMovementDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
+	METHOD m_usuotmqt getMoveDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_wsirbeyt isExtending ()Z
 	METHOD m_zqowmlcs getHeadBlockState ()Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/piston/PistonHandler.mapping
+++ b/mappings/net/minecraft/block/piston/PistonHandler.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/unmapped/C_kiwhhgkl net/minecraft/block/piston/PistonHandler
 	FIELD f_cpztarfh world Lnet/minecraft/unmapped/C_cdctfzbn;
-	FIELD f_egaxlscd posFrom Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_egaxlscd pistonPos Lnet/minecraft/unmapped/C_hynzadkk;
 	FIELD f_ofyqsuej movedBlocks Ljava/util/List;
-	FIELD f_ooartndh retracted Z
-	FIELD f_ouwfaiom posTo Lnet/minecraft/unmapped/C_hynzadkk;
-	FIELD f_tigpjmri pistonDirection Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_ooartndh extend Z
+	FIELD f_ouwfaiom firstMovePos Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_tigpjmri pistonFacing Lnet/minecraft/unmapped/C_xpuuihxf;
 	FIELD f_uhnjerye MAX_MOVABLE_BLOCKS I
 	FIELD f_wzxxvvzs brokenBlocks Ljava/util/List;
-	FIELD f_xdacxrqj motionDirection Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_xdacxrqj moveDirection Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Z)V
 		ARG 1 world
-		ARG 2 pos
-		ARG 3 dir
-		ARG 4 retracted
+		ARG 2 pistonPos
+		ARG 3 pistonFacing
+		ARG 4 extend
 	METHOD m_cshqlkwc tryMoveAdjacentBlock (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 pos
 	METHOD m_gosynevj getMovedBlocks ()Ljava/util/List;
@@ -25,7 +25,7 @@ CLASS net/minecraft/unmapped/C_kiwhhgkl net/minecraft/block/piston/PistonHandler
 	METHOD m_mbnaomnz setMovedBlocks (II)V
 		ARG 1 from
 		ARG 2 to
-	METHOD m_padquoyg getMotionDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
+	METHOD m_padquoyg getMoveDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_uuftxlvq isBlockSticky (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_xwbdlqyr getBrokenBlocks ()Ljava/util/List;

--- a/mappings/net/minecraft/block/piston/PistonHandler.mapping
+++ b/mappings/net/minecraft/block/piston/PistonHandler.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/unmapped/C_kiwhhgkl net/minecraft/block/piston/PistonHandler
 	FIELD f_tigpjmri pistonFacing Lnet/minecraft/unmapped/C_xpuuihxf;
 	FIELD f_uhnjerye MAX_MOVABLE_BLOCKS I
 	FIELD f_wzxxvvzs brokenBlocks Ljava/util/List;
-	FIELD f_xdacxrqj moveDirection Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_xdacxrqj movementDirection Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Z)V
 		ARG 1 world
 		ARG 2 pistonPos
@@ -25,7 +25,7 @@ CLASS net/minecraft/unmapped/C_kiwhhgkl net/minecraft/block/piston/PistonHandler
 	METHOD m_mbnaomnz setMovedBlocks (II)V
 		ARG 1 from
 		ARG 2 to
-	METHOD m_padquoyg getMoveDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
+	METHOD m_padquoyg getMovementDirection ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_uuftxlvq isBlockSticky (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_xwbdlqyr getBrokenBlocks ()Ljava/util/List;

--- a/mappings/net/minecraft/block/piston/PistonHandler.mapping
+++ b/mappings/net/minecraft/block/piston/PistonHandler.mapping
@@ -29,4 +29,4 @@ CLASS net/minecraft/unmapped/C_kiwhhgkl net/minecraft/block/piston/PistonHandler
 	METHOD m_uuftxlvq isBlockSticky (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_xwbdlqyr getBrokenBlocks ()Ljava/util/List;
-	METHOD m_zyuauuev calculatePush ()Z
+	METHOD m_zyuauuev calculateMovement ()Z


### PR DESCRIPTION
This PR fixes a handful of issues in piston related mappings. There were a few instances where the names were wrong (e.g. `retract` -> `extend`) or half-wrong (e.g. `pushedBlock` -> `movedState`). There were also a few changes for the sake of consistency or where the given name was quite vague (mostly for `Direction` fields/parameters, to distinguish between the piston's facing direction and the movement direction). 