### PR TITLE
Fix #92

### DIFF
--- a/mappings/net/minecraft/block/BubbleColumnBlock.mapping
+++ b/mappings/net/minecraft/block/BubbleColumnBlock.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_eopzqcts net/minecraft/block/BubbleColumnBlock
 	FIELD f_jarlnoge SCHEDULED_TICK_DELAY I
 	FIELD f_oylcoxnk DRAG Lnet/minecraft/unmapped/C_xhwijdsd;
-	METHOD m_agslpkrg canBubbleColumnExistIn (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_agslpkrg canBeBubbleColumn (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_fydgtfwy update (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 0 world

--- a/mappings/net/minecraft/block/BubbleColumnBlock.mapping
+++ b/mappings/net/minecraft/block/BubbleColumnBlock.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_eopzqcts net/minecraft/block/BubbleColumnBlock
 	FIELD f_jarlnoge SCHEDULED_TICK_DELAY I
 	FIELD f_oylcoxnk DRAG Lnet/minecraft/unmapped/C_xhwijdsd;
-	METHOD m_agslpkrg isStillWater (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_agslpkrg canBubbleColumnExistIn (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_fydgtfwy update (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 0 world

--- a/mappings/net/minecraft/fluid/Fluid.mapping
+++ b/mappings/net/minecraft/fluid/Fluid.mapping
@@ -65,5 +65,5 @@ CLASS net/minecraft/unmapped/C_rxhyurmy net/minecraft/fluid/Fluid
 		ARG 3 pos
 	METHOD m_ytkqcfqu getTickRate (Lnet/minecraft/unmapped/C_eemzphbi;)I
 		ARG 1 world
-	METHOD m_zcckkdqh isStill (Lnet/minecraft/unmapped/C_xqketiuf;)Z
+	METHOD m_zcckkdqh isSource (Lnet/minecraft/unmapped/C_xqketiuf;)Z
 		ARG 1 state

--- a/mappings/net/minecraft/fluid/FluidState.mapping
+++ b/mappings/net/minecraft/fluid/FluidState.mapping
@@ -45,7 +45,7 @@ CLASS net/minecraft/unmapped/C_xqketiuf net/minecraft/fluid/FluidState
 		ARG 1 tag
 			COMMENT the tag key
 	METHOD m_suhektew isEmpty ()Z
-	METHOD m_ufhvfxpy isStill ()Z
+	METHOD m_ufhvfxpy isSource ()Z
 	METHOD m_urtbgxch getLevel ()I
 	METHOD m_vnpinqqs getHeight (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)F
 		ARG 1 world


### PR DESCRIPTION
Fixes #92. Not entirely sure whether `m_agslpkrg` should be simplified to Mojang's name, `canExistIn`.