### PR TITLE
Fix javadoc generation when running locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,15 +206,9 @@ task eraseBytecode(type: TransformJarClassesTask, dependsOn: mapNamedJar) {
 	} }
 }
 
-task zipErasedBytecode(type: Zip, dependsOn: eraseBytecode) {
-	from eraseBytecode.output
-	archiveName = "erased-classes.jar"
-	destinationDirectory = mappings.fileConstants.tempDir
-}
-
 def fakeSourceDir = file(".gradle/temp/fakeSource")
-task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, zipErasedBytecode]) {
-	input = zipErasedBytecode.outputs.getFiles().getSingleFile()
+task genFakeSource(type: DecompileTask, dependsOn: [mergeTinyV2, eraseBytecode]) {
+	input = eraseBytecode.output.asFile.get()
 	output = fakeSourceDir
 	decompiler = Decompilers.QUILTFLOWER
 	libraries = files(mappings.fileConstants.libraries)

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,11 +1,11 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.3
+enigma_version=1.1.4
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9
-quiltflower_version=1.7.0
+quiltflower_version=1.8.0
 
 # Javadoc generation/linking
 fabric_loader_version=0.11.6

--- a/buildSrc/src/main/java/quilt/internal/tasks/build/TransformJarClassesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/TransformJarClassesTask.java
@@ -1,5 +1,6 @@
 package quilt.internal.tasks.build;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
@@ -8,10 +9,10 @@ import org.gradle.api.tasks.TaskAction;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
-import org.quiltmc.draftsman.asm.DraftsmanClassTransformer;
 import quilt.internal.Constants;
 import quilt.internal.tasks.DefaultMappingsTask;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -77,8 +78,13 @@ public class TransformJarClassesTask extends DefaultMappingsTask {
             transformedClassFiles.put(name, writer.toByteArray());
         }
 
+        // Ensure the output directory is empty
+        File outputFile = output.getAsFile().get();
+        FileUtils.deleteDirectory(outputFile);
+        Path outputPath = outputFile.toPath();
+
         for (String name : transformedClassFiles.keySet()) {
-            Path path = output.getAsFile().get().toPath().resolve(name);
+            Path path = outputPath.resolve(name);
             if (!Files.exists(path.getParent())) {
                 Files.createDirectories(path.getParent());
             }

--- a/buildSrc/src/main/java/quilt/internal/tasks/decompile/DecompileTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/decompile/DecompileTask.java
@@ -4,7 +4,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
@@ -87,7 +87,7 @@ public class DecompileTask extends DefaultMappingsTask {
         this.decompilerOptions = decompilerOptions;
     }
 
-    @InputFile
+    @InputFiles
     public RegularFileProperty getInput() {
         return input;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.3
+enigma_version=1.1.4
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.9
-quiltflower_version=1.7.0
+quiltflower_version=1.8.0
 
 # Javadoc generation/linking
 fabric_loader_version=0.11.6


### PR DESCRIPTION
Fixes javadoc generation failing when running locally because of leftovers from previous runs. Removes `zipErasedBytecode` task, which should make fake source generation ~5s faster. Also updates Enigma and Quiltflower