### PR TITLE
Switch inaccurate BuiltInStructureSets to MojMap's StructureSetKeys

### DIFF
--- a/mappings/net/minecraft/world/gen/structure/StructureSetKeys.mapping
+++ b/mappings/net/minecraft/world/gen/structure/StructureSetKeys.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/unmapped/C_vreaftov net/minecraft/world/gen/structure/BuiltInStructureSets
+CLASS net/minecraft/unmapped/C_vreaftov net/minecraft/world/gen/structure/StructureSetKeys
 	METHOD m_nehwwprb register (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
 		ARG 0 id


### PR DESCRIPTION
I think I did this pr correctly but lmk if it is wrong. Basically, this class holds only registry keys for structure sets. Not the actual structure sets (the class StructureSets holds the structure sets). This makes the original name no good. Solution, switch to MojMap name that is more clear that it is holding keys.

(change will need to be propagated to snapshot versions too. Do I need to make a pr for snapshot too?)