### PR TITLE
Fix proposed parameter names in output mappings

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.5
+enigma_version=1.1.6
 enigma_plugin_version=1.1.0
 stitch_version=0.6.1
 unpick_version=3.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.5
-enigma_plugin_version=1.0.2
+enigma_version=1.1.6
+enigma_plugin_version=1.1.0
 stitch_version=0.6.1
 unpick_version=3.0.0-SNAPSHOT
 cfr_version=0.0.9


### PR DESCRIPTION
Updates enigma to 1.1.6, which actually adds proposed parameter names to the mappings