### PR TITLE
Refactor and make boolean return wording more consistent.

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -124,7 +124,7 @@ Name screen coordinates `x` and `y`, rather than `left` and `top`.
 
 Write sentences for class, method and field javadocs, starting with an uppercase and ending with a period. Start method docs with verbs, like `Gets` or `Called`. Use HTML tags such as `<p>` if the docs have several paragraphs, as line wraps are converted to spaces in the generated documentation. Feel free to start a new line whenever you feel the current line is too long.
 
-Parameter and `@return` documentation should use quick descriptions without initial capitalization or punctuation, such as `{@code true} if the block placement was successful, {@code false} otherwise`. `{@return}` used in the first sentence can duplicate enclosed text to the return description.
+Parameter and `@return` documentation should use quick descriptions without initial capitalization or punctuation, such as `{@code true} if the block placement was successful, or {@code false} otherwise`. `{@return}` used in the first sentence can duplicate enclosed text to the return description.
 
 Use `{@index}` to allow enclosed text to be indexed by the Javadoc search.
 

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -71,7 +71,7 @@ CLASS net/minecraft/unmapped/C_fxiqpxaf net/minecraft/client/gui/Element
 		COMMENT Checks if the mouse position is within the bound
 		COMMENT of the element.
 		COMMENT
-		COMMENT @return {@code true} if the mouse is within the bound of the element, otherwise {@code false}
+		COMMENT @return {@code true} if the mouse is within the bound of the element, or {@code false} otherwise
 		ARG 1 mouseX
 			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY

--- a/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
@@ -5,4 +5,4 @@ CLASS net/minecraft/unmapped/C_gwgaryan net/minecraft/client/render/entity/featu
 		COMMENT <p>This method is present on the server but without implementing this client-sided interface,
 		COMMENT and may be used in the overlay owner's internal logic in order to get the condition state.
 		COMMENT
-		COMMENT @return {@code true} if the condition behind overlay rendering is met, {@code false} otherwise.
+		COMMENT @return {@code true} if the condition behind overlay rendering is met, or {@code false} otherwise

--- a/mappings/net/minecraft/client/render/entity/model/ModelWithHat.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ModelWithHat.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/unmapped/C_fsdmetpo net/minecraft/client/render/entity/model
 	METHOD m_qxaaonij setHatVisible (Z)V
 		COMMENT Sets whether the hat is visible or not.
 		ARG 1 visible
-			COMMENT {@code true} if the hat is visible, otherwise {@code false}
+			COMMENT {@code true} if the hat is visible, or {@code false} otherwise

--- a/mappings/net/minecraft/client/render/model/json/ModelVariantMap.mapping
+++ b/mappings/net/minecraft/client/render/model/json/ModelVariantMap.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/unmapped/C_hsdreiyy net/minecraft/client/render/model/json/M
 	METHOD m_ayxnpbmj containsVariant (Ljava/lang/String;)Z
 		COMMENT Checks if there's a variant under the {@code key} in this map.
 		COMMENT
-		COMMENT @return {@code true} if the {@code key} has a variant, {@code false} otherwise
+		COMMENT @return {@code true} if the {@code key} has a variant, or {@code false} otherwise
 		ARG 1 key
 			COMMENT the variant's key
 	METHOD m_chnfmqsx getMultipartModel ()Lnet/minecraft/unmapped/C_ktggvsoz;

--- a/mappings/net/minecraft/entity/passive/CatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CatEntity.mapping
@@ -32,7 +32,7 @@ CLASS net/minecraft/unmapped/C_rxtmregr net/minecraft/entity/passive/CatEntity
 	METHOD m_ohnwkpyq setInSleepingPose (Z)V
 		COMMENT Sets whether this cat is in a sleeping pose or not.
 		ARG 1 sleeping
-			COMMENT {@code true} if this cat is in a sleeping pose, otherwise {@code false}
+			COMMENT {@code true} if this cat is in a sleeping pose, or {@code false} otherwise
 	METHOD m_pedhhxbx getSleepAnimation (F)F
 		ARG 1 tickDelta
 	METHOD m_sklrirdg hiss ()V

--- a/mappings/net/minecraft/item/map/MapState.mapping
+++ b/mappings/net/minecraft/item/map/MapState.mapping
@@ -93,7 +93,7 @@ CLASS net/minecraft/unmapped/C_nvpllgmg net/minecraft/item/map/MapState
 	METHOD m_vzmkvyyc putColor (IIB)Z
 		COMMENT Sets the color at the specified coordinates if the current color is different.
 		COMMENT
-		COMMENT @return {@code true} if the color has been updated, else {@code false}
+		COMMENT @return {@code true} if the color has been updated, or {@code false} otherwise
 		ARG 1 x
 		ARG 2 z
 		ARG 3 color

--- a/mappings/net/minecraft/nbt/NbtCompound.mapping
+++ b/mappings/net/minecraft/nbt/NbtCompound.mapping
@@ -45,7 +45,7 @@ CLASS net/minecraft/unmapped/C_hhlwcnih net/minecraft/nbt/NbtCompound
 		COMMENT <p>
 		COMMENT The type restriction can also be {@link NbtElement#NUMBER_TYPE NUMBER_TYPE}, which only allows any type of number.
 		COMMENT
-		COMMENT @return {@code true} if the key exists and the element type is equivalent to the given {@code type}, else {@code false}
+		COMMENT @return {@code true} if the key exists and the element type is equivalent to the given {@code type}, or {@code false} otherwise
 		ARG 1 key
 		ARG 2 type
 	METHOD m_jedcpeht getIntArray (Ljava/lang/String;)[I
@@ -132,7 +132,7 @@ CLASS net/minecraft/unmapped/C_hhlwcnih net/minecraft/nbt/NbtCompound
 	METHOD m_xnfnxggh contains (Ljava/lang/String;)Z
 		COMMENT Determines whether the NBT compound object contains the specified key.
 		COMMENT
-		COMMENT @return {@code true} if the key exists, else {@code false}
+		COMMENT @return {@code true} if the key exists, or {@code false} otherwise
 		ARG 1 key
 	METHOD m_ydoxcvdj containsUuid (Ljava/lang/String;)Z
 		COMMENT Returns {@code true} if this {@code NbtCompound} contains a valid UUID representation associated with the given key.

--- a/mappings/net/minecraft/nbt/NbtHelper.mapping
+++ b/mappings/net/minecraft/nbt/NbtHelper.mapping
@@ -59,7 +59,7 @@ CLASS net/minecraft/unmapped/C_scnprxmz net/minecraft/nbt/NbtHelper
 		ARG 0 nbt
 		ARG 1 withArrayContents
 			COMMENT {@code true} if the contents of {@link NbtByteArray}, {@link NbtIntArray}
-			COMMENT and {@link NbtLongArray} should be included, otherwise {@code false}
+			COMMENT and {@link NbtLongArray} should be included, or {@code false} otherwise
 	METHOD m_pxvpkbfz fromUuid (Ljava/util/UUID;)Lnet/minecraft/unmapped/C_qkxiqejc;
 		COMMENT Serializes a {@link UUID} into its equivalent NBT representation.
 		COMMENT

--- a/mappings/net/minecraft/nbt/NbtType.mapping
+++ b/mappings/net/minecraft/nbt/NbtType.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/unmapped/C_ueidorcc net/minecraft/nbt/NbtType
 		COMMENT The mutability of an NBT type means the held value can be modified
 		COMMENT after the NBT element is instantiated.
 		COMMENT
-		COMMENT @return {@code true} if this NBT type is immutable, else {@code false}
+		COMMENT @return {@code true} if this NBT type is immutable, or {@code false} otherwise
 	METHOD m_hxfuaaoy getCommandFeedbackName ()Ljava/lang/String;
 	METHOD m_poctbjiy read (Ljava/io/DataInput;ILnet/minecraft/unmapped/C_fozrrtcx;)Lnet/minecraft/unmapped/C_oivssbvb;
 		ARG 1 input

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -187,7 +187,7 @@ CLASS net/minecraft/server/MinecraftServer net/minecraft/server/MinecraftServer
 	METHOD m_hlglehvn save (ZZZ)Z
 		COMMENT Saves both the server data and the player data to the data storage device.
 		COMMENT
-		COMMENT @return {@code true} if saving was successful, otherwise {@code false}
+		COMMENT @return {@code true} if saving was successful, or {@code false} otherwise
 		ARG 1 suppressLogs
 		ARG 2 flush
 			COMMENT if it should immediately write all data to storage device
@@ -385,7 +385,7 @@ CLASS net/minecraft/server/MinecraftServer net/minecraft/server/MinecraftServer
 		COMMENT <p>
 		COMMENT To store the player data in addition to server data, call {@link #save} instead.
 		COMMENT
-		COMMENT @return {@code true} if saving was successful, otherwise {@code false}
+		COMMENT @return {@code true} if saving was successful, or {@code false} otherwise
 		ARG 1 suppressLogs
 		ARG 2 flush
 			COMMENT if it should immediately write all data to storage device

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -52,7 +52,7 @@ CLASS net/minecraft/unmapped/C_digmgtxw net/minecraft/server/PlayerManager
 	METHOD m_dggepnnr getUserData ()Lnet/minecraft/unmapped/C_hhlwcnih;
 		COMMENT Gets the user data of the player hosting the Minecraft server.
 		COMMENT
-		COMMENT @return the user data of the host of the server if the server is an integrated server, otherwise {@code null}
+		COMMENT @return the user data of the host of the server if the server is an integrated server, or {@code null} otherwise
 	METHOD m_ebjlmucj reloadWhitelist ()V
 	METHOD m_eglbulud removeFromOperators (Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 profile

--- a/mappings/net/minecraft/world/HeightLimitView.mapping
+++ b/mappings/net/minecraft/world/HeightLimitView.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/unmapped/C_qpninoyb net/minecraft/world/HeightLimitView
 	METHOD m_bumyozur isOutOfHeightLimit (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		COMMENT Checks if {@code pos} is out of the height limit of this view.
 		COMMENT
-		COMMENT @return {@code true} if {@code pos} is out of bounds, {@code false} otherwise.
+		COMMENT @return {@code true} if {@code pos} is out of bounds, or {@code false} otherwise
 		COMMENT @see #isOutOfHeightLimit(int)
 		ARG 1 pos
 			COMMENT the position to check
@@ -58,7 +58,7 @@ CLASS net/minecraft/unmapped/C_qpninoyb net/minecraft/world/HeightLimitView
 		COMMENT <p>{@code y} is out of bounds if it's lower than the {@linkplain #getBottomY
 		COMMENT bottom} or higher than or equal to the {@linkplain #getTopY() top}.
 		COMMENT
-		COMMENT @return {@code true} if {@code y} is out of bounds, {@code false} otherwise.
+		COMMENT @return {@code true} if {@code y} is out of bounds, or {@code false} otherwise
 		ARG 1 y
 			COMMENT the Y level to check
 	METHOD m_tnwxczli countVerticalSections ()I

--- a/mappings/net/minecraft/world/WorldDataVersion.mapping
+++ b/mappings/net/minecraft/world/WorldDataVersion.mapping
@@ -12,11 +12,11 @@ CLASS net/minecraft/unmapped/C_enlieprc net/minecraft/world/WorldDataVersion
 	METHOD m_nzifeqaq isUnstable ()Z
 		COMMENT Returns whether this world data version is "unstable", as-in it's not in the main series.
 		COMMENT
-		COMMENT @return {@code true} if this world data version is unstable, else {@code false}
+		COMMENT @return {@code true} if this world data version is unstable, or {@code false} otherwise
 	METHOD m_vmfdinxr isCompatible (Lnet/minecraft/unmapped/C_enlieprc;)Z
 		COMMENT Returns whether or not this world version is compatible with the given world version.
 		COMMENT
-		COMMENT @return {@code true} if the world versions are compatible, else {@code false}
+		COMMENT @return {@code true} if the world versions are compatible, or {@code false} otherwise
 		ARG 1 other
 	METHOD m_xfuxfldc getSeries ()Ljava/lang/String;
 		COMMENT Returns the series of this version.


### PR DESCRIPTION
One day we got a talk about how boolean returns/param javadocs should be worded.

We talked and talked, we threw a `else {@code false}` but no that's not English! We threw `otherwise {@code false}` but that's still wrong!

We ended up with the `or {@code false} otherwise` wording, it's very explicit, and more exact in the context of the English language.

And here we are, finally applying this to known documentation that used the "old" wording.

I'm honestly surprised by the few changes, tbh I went with a replace function so maybe I missed cases that I wasn't aware of.