### PR TITLE
Add simple type field auto mapping

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,8 +1,8 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.6
-enigma_plugin_version=1.1.0
+enigma_version=1.1.7
+enigma_plugin_version=1.2.0
 stitch_version=0.6.1
 unpick_version=3.0.0-SNAPSHOT
 cfr_version=0.0.9

--- a/enigma_profile.json
+++ b/enigma_profile.json
@@ -11,7 +11,8 @@
         "jar_indexer": {
             "id": "quiltmc:jar_index",
             "args": {
-                "custom_codecs": "net/minecraft/unmapped/C_fgetofav, net/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc, net/minecraft/unmapped/C_qosrsbdy, net/minecraft/unmapped/C_tyjpezxh$C_cuphesbl, net/minecraft/unmapped/C_tyjpezxh$C_shczgrzo, net/minecraft/unmapped/C_tyjpezxh$C_utmdutep, net/minecraft/unmapped/C_wbhfljwo"
+                "custom_codecs": "net/minecraft/unmapped/C_fgetofav, net/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc, net/minecraft/unmapped/C_qosrsbdy, net/minecraft/unmapped/C_tyjpezxh$C_cuphesbl, net/minecraft/unmapped/C_tyjpezxh$C_shczgrzo, net/minecraft/unmapped/C_tyjpezxh$C_utmdutep, net/minecraft/unmapped/C_wbhfljwo",
+                "simple_type_field_names_path": "./simple_type_field_names.json5"
             }
         },
         "obfuscation_test": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=1.1.6
-enigma_plugin_version=1.1.0
+enigma_version=1.1.7
+enigma_plugin_version=1.2.0
 stitch_version=0.6.1
 unpick_version=3.0.0-SNAPSHOT
 cfr_version=0.0.9

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -191,7 +191,6 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	METHOD m_taedfzyx shouldFilterMessagesSentTo (Lnet/minecraft/unmapped/C_mxrobsgg;)Z
 		ARG 1 player
 	METHOD m_tsbczhxe isInTeleportationState ()Z
-	METHOD m_ttfujhny (Lnet/minecraft/unmapped/C_fapzqefz;Lnet/minecraft/unmapped/C_hasnsypd$C_iocvgdxe;)V
 	METHOD m_ujyxsuep onDisconnect ()V
 	METHOD m_ulcuzxzs updateScores (Lnet/minecraft/unmapped/C_adsgsrpw;I)V
 		ARG 1 criterion

--- a/simple_type_field_names.json5
+++ b/simple_type_field_names.json5
@@ -3,6 +3,7 @@
   "com/mojang/serialization/Codec": "codec",
   // DFU
   "com/mojang/datafixers/schemas/Schema": "schema",
+  "com/mojang/datafixers/DataFixer": "dataFixer",
   // Brigadier
   "com/mojang/brigadier/StringReader": "reader",
 

--- a/simple_type_field_names.json5
+++ b/simple_type_field_names.json5
@@ -1,0 +1,132 @@
+{
+  // Codec
+  "com/mojang/serialization/Codec": "codec",
+  // DFU
+  "com/mojang/datafixers/schemas/Schema": "schema",
+  // Brigadier
+  "com/mojang/brigadier/StringReader": "reader",
+
+  // Registries
+  "net/minecraft/unmapped/C_tqxyjqsk": "registry",
+  "net/minecraft/unmapped/C_xhhleach": "registryKey",
+
+  // Client
+  "net/minecraft/unmapped/C_ayfeobid": "client", // MinecraftClient
+  "net/minecraft/unmapped/C_cnszsxvd": "matrices", // MatrixStack
+  "net/minecraft/unmapped/C_igrgeffe": "vertexConsumers", // VertexConsumerProvider
+  "net/minecraft/unmapped/C_mavozmpp": "textRenderer",
+
+  // Pos
+  "net/minecraft/unmapped/C_hynzadkk": "pos", // BlockPos
+  "net/minecraft/unmapped/C_hynzadkk$C_egqitdjk": {
+    local_name: "pos",
+    "fallback": [
+      "mutablePos"
+    ]
+  },
+  "net/minecraft/unmapped/C_ovcqqyqp": "globalPos", // GlobalPos
+
+  // Common
+  "net/minecraft/unmapped/C_rlomrsco": "random", // RandomGenerator
+  "net/minecraft/unmapped/C_xpuuihxf": "direction",
+  "net/minecraft/unmapped/C_eslcbfsq": "profiler",
+
+  // States
+  "net/minecraft/unmapped/C_txtbiemp": { // BlockState
+    local_name: "state",
+    exclusive: true,
+    fallback: [
+      "blockState"
+    ]
+  },
+  "net/minecraft/unmapped/C_xqketiuf": { // FluidState
+    local_name: "state",
+    exclusive: true,
+    fallback: [
+      "fluidState"
+    ]
+  },
+
+  // Block
+  "net/minecraft/unmapped/C_mmxmpdoq": "block",
+
+  // Item
+  "net/minecraft/unmapped/C_sddaxwyk": "stack", // ItemStack
+
+  // Entity
+  "net/minecraft/unmapped/C_rjqjaxef": "brain",
+  "net/minecraft/unmapped/C_uzzvxofv": {
+    local_name: "reason",
+    fallback: [
+      "spawnReason"
+    ]
+  },
+
+  // Resources
+  "net/minecraft/unmapped/C_tmnrpasf": "resourceManager",
+  "net/minecraft/unmapped/C_carvbxzj": { // AutoCloseableResourceManager
+    local_name: "resourceManager",
+    fallback: [
+      "autoCloseableResourceManager"
+    ]
+  },
+  "net/minecraft/unmapped/C_migzkpst": "resources", // ServerReloadableResources
+
+  // World
+  "net/minecraft/unmapped/C_cdctfzbn": "world",
+  "net/minecraft/unmapped/C_agsukcmb": { // TestableWorld
+    local_name: "world",
+    fallback: [
+      "testableWorld"
+    ]
+  },
+  "net/minecraft/unmapped/C_bdwnwhiu": { // ServerWorld
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "serverWorld"
+    ]
+  },
+  "net/minecraft/unmapped/C_ghdnlrrw": { // ClientWorld
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "clientWorld"
+    ]
+  },
+  "net/minecraft/unmapped/C_eemzphbi": { // WorldView
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "worldView"
+    ]
+  },
+  "net/minecraft/unmapped/C_peaveboq": { // BlockView
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "blockView"
+    ]
+  },
+  "net/minecraft/unmapped/C_vxzrjtdu": { // CollisionView
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "collisionView"
+    ]
+  },
+  "net/minecraft/unmapped/C_qpninoyb": { // HeightLimitView
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "heightLimitView"
+    ]
+  },
+  "net/minecraft/unmapped/C_xjeuupup": { // BlockRenderView
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "blockRenderView"
+    ]
+  }
+}


### PR DESCRIPTION
Adds a name proposal service which maps fields and parameters with a simple type, using the names in the file. See QuiltMC/quilt-enigma-plugin#3. Uses the sample file, with additions for `View` classes