### PR TITLE
Map ChatNarratorManager and fix some stuff.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,22 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [17-jdk]
-    runs-on: ubuntu-20.04
+        java: [17, 18]
+    runs-on: ubuntu-latest
     container:
       image: openjdk:${{ matrix.java }}
       options: --user root
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build javadocJar --stacktrace
       - name: Build artifacts
-        if: ${{ matrix.java == '17-jdk' }}
+        if: ${{ matrix.java == 17 }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 enigma_version=1.1.7
 enigma_plugin_version=1.2.0
 stitch_version=0.6.1
-unpick_version=3.0.0-SNAPSHOT
+unpick_version=3.0.1-SNAPSHOT
 cfr_version=0.0.9
 quiltflower_version=1.8.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 enigma_version=1.1.7
 enigma_plugin_version=1.2.0
 stitch_version=0.6.1
-unpick_version=3.0.0-SNAPSHOT
+unpick_version=3.0.1-SNAPSHOT
 cfr_version=0.0.9
 quiltflower_version=1.8.0
 

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	FIELD f_cfilflga sessionService Lcom/mojang/authlib/minecraft/MinecraftSessionService;
 	FIELD f_cipivcjw particleManager Lnet/minecraft/unmapped/C_ttbvlsde;
 	FIELD f_cnbjrnkz fontManager Lnet/minecraft/unmapped/C_hoztwset;
-	FIELD f_cngdjofb textRenderer Lnet/minecraft/unmapped/C_mavozmpp;
+	FIELD f_cqulrbtp chatNarratorManager Lnet/minecraft/unmapped/C_qwmxzagq;
 	FIELD f_cuhqrghd worldGenProgressTracker Ljava/util/concurrent/atomic/AtomicReference;
 	FIELD f_dhfmekui dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD f_dhiyhtdj pausedTickDelta F
@@ -140,6 +140,7 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	FIELD f_svhtflji worldRenderer Lnet/minecraft/unmapped/C_sfkkabhx;
 	FIELD f_swbnzydi creativeHotbarStorage Lnet/minecraft/unmapped/C_twtdhnqb;
 	FIELD f_tuotfkjg nextDebugInfoUpdateTime J
+	FIELD f_tygfsvlj realmsDataFetcher Lnet/minecraft/unmapped/C_yyprjalz;
 	FIELD f_udhptfsg keyboard Lnet/minecraft/unmapped/C_csolnszv;
 	FIELD f_ujkvfbva isDemo Z
 	FIELD f_ukgauwzj REGIONAL_COMPLIANCIES_ID Lnet/minecraft/unmapped/C_ncpywfca;
@@ -162,7 +163,6 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	FIELD f_yiluvghr targetedEntity Lnet/minecraft/unmapped/C_astfners;
 	FIELD f_yjhobbqr renderTickCounter Lnet/minecraft/unmapped/C_ewnwsuig;
 	FIELD f_ypxesqvh instance Lnet/minecraft/unmapped/C_ayfeobid;
-	FIELD f_ypxxahyx LOGGER Lorg/slf4j/Logger;
 	FIELD f_yqtqkajc thread Ljava/lang/Thread;
 	FIELD f_ytluawot blockRenderManager Lnet/minecraft/unmapped/C_vdyoclwy;
 	FIELD f_yzkvrtzp UNICODE_FONT_ID Lnet/minecraft/unmapped/C_ncpywfca;
@@ -411,6 +411,7 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	METHOD m_xthkfemp isConnectedToServer ()Z
 	METHOD m_xutfzscx initializeSearchableContainers ()V
 	METHOD m_yadnzivw isDemo ()Z
+	METHOD m_ymfxsgvs getChatNarratorManager ()Lnet/minecraft/unmapped/C_qwmxzagq;
 	METHOD m_yxvsqbme hasReducedDebugInfo ()Z
 	METHOD m_yyiisqrp isWindowFocused ()Z
 	METHOD m_yzemtvye createTelemetryManager ()Lnet/minecraft/unmapped/C_cgkxybww;

--- a/mappings/net/minecraft/client/option/NarratorMode.mapping
+++ b/mappings/net/minecraft/client/option/NarratorMode.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/unmapped/C_ekczyczh net/minecraft/client/option/NarratorMode
 		ARG 3 id
 		ARG 4 name
 	METHOD m_cbrezehp getName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_gifirmom canNarrateChat ()Z
+	METHOD m_sxeyqcgh canNarrateSystemMessages ()Z
 	METHOD m_tfewomex byId (I)Lnet/minecraft/unmapped/C_ekczyczh;
 		ARG 0 id
 	METHOD m_wtxxkrks getId ()I

--- a/mappings/net/minecraft/client/util/ChatNarratorManager.mapping
+++ b/mappings/net/minecraft/client/util/ChatNarratorManager.mapping
@@ -1,0 +1,37 @@
+CLASS net/minecraft/unmapped/C_qwmxzagq net/minecraft/client/util/ChatNarratorManager
+	COMMENT Represents the chat narrator manager.
+	FIELD f_ekscokqe NO_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_azbwwowi narrateChatMessage (Ljava/util/function/Supplier;)V
+		COMMENT Narrates the given chat message.
+		ARG 1 message
+			COMMENT the message to narrate
+	METHOD m_cddzpxtn getNarrationMode ()Lnet/minecraft/unmapped/C_ekczyczh;
+		COMMENT {@return the narration mode}
+	METHOD m_hsjlayar isActive ()Z
+		COMMENT {@return {@code true} if the narrator is active, or {@code false} otherwise}
+	METHOD m_jhznbxcw clear ()V
+		COMMENT Clears all the narration messages from the queue.
+	METHOD m_mefulwdr close ()V
+		COMMENT Closes the narrator.
+	METHOD m_rdfgzelk narrate (Ljava/lang/String;)V
+		COMMENT Narrates the given system message.
+		COMMENT <p>
+		COMMENT Respects the narration mode of the client.
+		COMMENT
+		COMMENT @see #narrate(Text)
+		ARG 1 message
+			COMMENT the message to narrate
+	METHOD m_wnnchpxz narrate (Lnet/minecraft/unmapped/C_rdaqiwdt;)V
+		COMMENT Narrates the given system message.
+		COMMENT <p>
+		COMMENT Respects the narration mode of the client.
+		COMMENT
+		COMMENT @see #narrate(String)
+		ARG 1 message
+			COMMENT the message to narrate
+	METHOD m_xwyjnbhv debugLogNarration (Ljava/lang/String;)V
+		ARG 1 message
+	METHOD m_zfaglcrh onNarrationModeChanged (Lnet/minecraft/unmapped/C_ekczyczh;)V
+		COMMENT Called when the narration mode is changed.
+		ARG 1 newMode
+			COMMENT the new narration mode

--- a/simple_type_field_names.json5
+++ b/simple_type_field_names.json5
@@ -16,6 +16,7 @@
   "net/minecraft/unmapped/C_cnszsxvd": "matrices", // MatrixStack
   "net/minecraft/unmapped/C_igrgeffe": "vertexConsumers", // VertexConsumerProvider
   "net/minecraft/unmapped/C_mavozmpp": "textRenderer",
+  "com/mojang/text2speech/Narrator": "narrator",
 
   // Pos
   "net/minecraft/unmapped/C_hynzadkk": "pos", // BlockPos


### PR DESCRIPTION
 - updated to use more proper tooling and so Gradle 7.5 doesn't die
 - updated unpick to support Java 18
 - some variables got removed in MinecraftClient, they are auto-mapped
 - mapped ChatNarratorManager