### PR TITLE
Map back textRenderer and its new variant, map networking changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ javadoc {
 
 	def docletResources = sourceSets.doclet.resources.asFileTree
 
-	failOnError = false
+	failOnError = true // Failing on error is important to ensure that a Javadoc jar is available.
 	maxMemory = '2G'
 
 	// verbose = true // enable to debug

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -57,10 +57,13 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	FIELD f_cfebutjv videoWarningManager Lnet/minecraft/unmapped/C_giiyufuh;
 	FIELD f_cfilflga sessionService Lcom/mojang/authlib/minecraft/MinecraftSessionService;
 	FIELD f_cgwjrlry antiFishyTextRenderer Lnet/minecraft/unmapped/C_mavozmpp;
-		COMMENT Represents the safe (anti-fishy) text renderer.
+		COMMENT Represents the anti-malicious text renderer.
 		COMMENT <p>
-		COMMENT Disallows some fishy glyphs advances to, for example,
-		COMMENT avoid 3rd-parties hiding text that an user is writing
+		COMMENT Disallows some malicious (fishy) glyphs advances to, for example,
+		COMMENT avoid 3rd-parties hiding text that an user is writing.
+		COMMENT <p>
+		COMMENT Malicious glyphs are defined as having a negative advance
+		COMMENT or having an advance greater than {@value net.minecraft.client.font.FontStorage#MAX_GLYPH_ADVANCE}.
 		COMMENT
 		COMMENT @see #textRenderer
 	FIELD f_cipivcjw particleManager Lnet/minecraft/unmapped/C_ttbvlsde;

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -56,8 +56,19 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	FIELD f_cesulxxt textureManager Lnet/minecraft/unmapped/C_rglkduer;
 	FIELD f_cfebutjv videoWarningManager Lnet/minecraft/unmapped/C_giiyufuh;
 	FIELD f_cfilflga sessionService Lcom/mojang/authlib/minecraft/MinecraftSessionService;
+	FIELD f_cgwjrlry antiFishyTextRenderer Lnet/minecraft/unmapped/C_mavozmpp;
+		COMMENT Represents the safe (anti-fishy) text renderer.
+		COMMENT <p>
+		COMMENT Disallows some fishy glyphs advances to, for example,
+		COMMENT avoid 3rd-parties hiding text that an user is writing
+		COMMENT
+		COMMENT @see #textRenderer
 	FIELD f_cipivcjw particleManager Lnet/minecraft/unmapped/C_ttbvlsde;
 	FIELD f_cnbjrnkz fontManager Lnet/minecraft/unmapped/C_hoztwset;
+	FIELD f_cngdjofb textRenderer Lnet/minecraft/unmapped/C_mavozmpp;
+		COMMENT Represents the text renderer.
+		COMMENT
+		COMMENT @see #antiFishyTextRenderer
 	FIELD f_cqulrbtp chatNarratorManager Lnet/minecraft/unmapped/C_qwmxzagq;
 	FIELD f_cuhqrghd worldGenProgressTracker Ljava/util/concurrent/atomic/AtomicReference;
 	FIELD f_dhfmekui dataFixer Lcom/mojang/datafixers/DataFixer;

--- a/mappings/net/minecraft/client/font/FontManager.mapping
+++ b/mappings/net/minecraft/client/font/FontManager.mapping
@@ -15,7 +15,19 @@ CLASS net/minecraft/unmapped/C_hoztwset net/minecraft/client/font/FontManager
 	METHOD m_fusljlhu (Lnet/minecraft/unmapped/C_zhhoxunt;)V
 		ARG 0 fontStorage
 	METHOD m_gbjzgnfa createTextRenderer ()Lnet/minecraft/unmapped/C_mavozmpp;
+		COMMENT Creates a new text renderer devoid of any constraint.
+		COMMENT
+		COMMENT @see #createAntiFishyTextRenderer
 	METHOD m_rsldpzgj getResourceReloadListener ()Lnet/minecraft/unmapped/C_msqwzogj;
+	METHOD m_ufulkvsb createAntiFishyTextRenderer ()Lnet/minecraft/unmapped/C_mavozmpp;
+		COMMENT Creates a new safe (anti-fishy) text renderer.
+		COMMENT <p>
+		COMMENT The text renderer disallows some fishy glyphs advances to, for example,
+		COMMENT avoid 3rd-parties hiding text that an user is writing
+		COMMENT
+		COMMENT @see #createTextRenderer
+	METHOD m_wraffzbu (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_zhhoxunt;
+		ARG 1 id
 	METHOD m_xzzwhxig setIdOverrides (Ljava/util/Map;)V
 		ARG 1 overrides
 	CLASS C_ldvuvijd

--- a/mappings/net/minecraft/client/font/FontManager.mapping
+++ b/mappings/net/minecraft/client/font/FontManager.mapping
@@ -20,10 +20,13 @@ CLASS net/minecraft/unmapped/C_hoztwset net/minecraft/client/font/FontManager
 		COMMENT @see #createAntiFishyTextRenderer
 	METHOD m_rsldpzgj getResourceReloadListener ()Lnet/minecraft/unmapped/C_msqwzogj;
 	METHOD m_ufulkvsb createAntiFishyTextRenderer ()Lnet/minecraft/unmapped/C_mavozmpp;
-		COMMENT Creates a new safe (anti-fishy) text renderer.
+		COMMENT Creates an anti-malicious text renderer.
 		COMMENT <p>
-		COMMENT The text renderer disallows some fishy glyphs advances to, for example,
-		COMMENT avoid 3rd-parties hiding text that an user is writing
+		COMMENT Disallows some malicious (fishy) glyphs advances to, for example,
+		COMMENT avoid 3rd-parties hiding text that an user is writing.
+		COMMENT <p>
+		COMMENT Malicious glyphs are defined as having a negative advance
+		COMMENT or having an advance greater than {@value net.minecraft.client.font.FontStorage#MAX_GLYPH_ADVANCE}.
 		COMMENT
 		COMMENT @see #createTextRenderer
 	METHOD m_wraffzbu (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_zhhoxunt;

--- a/mappings/net/minecraft/client/font/FontStorage.mapping
+++ b/mappings/net/minecraft/client/font/FontStorage.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/unmapped/C_zhhoxunt net/minecraft/client/font/FontStorage
 	FIELD f_rzdttaxr blankGlyphRenderer Lnet/minecraft/unmapped/C_wrqtxozz;
 	FIELD f_tehtajjp glyphAtlases Ljava/util/List;
 	FIELD f_whiqfyvx charactersByWidth Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD f_wrcgchkf MAX_GLYPH_ADVANCE F
+		COMMENT The maximum advance allowed for a glyph before it being considered fishy, whose value is {@value}.
 	FIELD f_wszhfshh id Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_wzaqlovb whiteRectangleGlyphRenderer Lnet/minecraft/unmapped/C_wrqtxozz;
 	FIELD f_zzorrupa textureManager Lnet/minecraft/unmapped/C_rglkduer;
@@ -15,9 +17,12 @@ CLASS net/minecraft/unmapped/C_zhhoxunt net/minecraft/client/font/FontStorage
 	METHOD close close ()V
 	METHOD m_abmbjzev getGlyph (IZ)Lnet/minecraft/unmapped/C_sxmfadan;
 		ARG 1 codePoint
+		ARG 2 filterFishyGlyphs
 	METHOD m_eiqitttg bakeGlyph (I)Lnet/minecraft/unmapped/C_wrqtxozz;
 		ARG 1 codePoint
 	METHOD m_fgqbwuuf closeFonts ()V
+	METHOD m_jyqartmo isGlyphFishy (Lnet/minecraft/unmapped/C_sxmfadan;)Z
+		ARG 0 glyph
 	METHOD m_nclahpgg getRectangleRenderer ()Lnet/minecraft/unmapped/C_wrqtxozz;
 	METHOD m_prqyajrl getObfuscatedGlyphRenderer (Lnet/minecraft/unmapped/C_sxmfadan;)Lnet/minecraft/unmapped/C_wrqtxozz;
 		ARG 1 glyph
@@ -32,3 +37,7 @@ CLASS net/minecraft/unmapped/C_zhhoxunt net/minecraft/client/font/FontStorage
 		ARG 3 i
 	METHOD m_xoqfcpqv findGlyph (I)Lnet/minecraft/unmapped/C_zhhoxunt$C_kklzxalg;
 		ARG 1 codePoint
+	CLASS C_kklzxalg GlyphInfoFilter
+		FIELD f_vkvmtfqr MISSING Lnet/minecraft/unmapped/C_zhhoxunt$C_kklzxalg;
+		METHOD m_wfudztfw select (Z)Lnet/minecraft/unmapped/C_sxmfadan;
+			ARG 1 filerFishyGlyphs

--- a/mappings/net/minecraft/client/font/FontStorage.mapping
+++ b/mappings/net/minecraft/client/font/FontStorage.mapping
@@ -7,7 +7,8 @@ CLASS net/minecraft/unmapped/C_zhhoxunt net/minecraft/client/font/FontStorage
 	FIELD f_tehtajjp glyphAtlases Ljava/util/List;
 	FIELD f_whiqfyvx charactersByWidth Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD f_wrcgchkf MAX_GLYPH_ADVANCE F
-		COMMENT The maximum advance allowed for a glyph before it being considered fishy, whose value is {@value}.
+		COMMENT The maximum advance allowed for a glyph before it being considered malicious,
+		COMMENT whose value is {@value}.
 	FIELD f_wszhfshh id Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_wzaqlovb whiteRectangleGlyphRenderer Lnet/minecraft/unmapped/C_wrqtxozz;
 	FIELD f_zzorrupa textureManager Lnet/minecraft/unmapped/C_rglkduer;

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -9,10 +9,14 @@ CLASS net/minecraft/unmapped/C_mavozmpp net/minecraft/client/font/TextRenderer
 	FIELD f_eewsyjvi random Lnet/minecraft/unmapped/C_rlomrsco;
 	FIELD f_gdulearj handler Lnet/minecraft/unmapped/C_wtqrualh;
 	FIELD f_kpfbvghh FORWARD_SHIFT Lnet/minecraft/unmapped/C_zviwfwgf;
+	FIELD f_neyverfp filterFishyGlyphs Z
 	FIELD f_pslhooyu STYLE_Z_DEPTH F
 	FIELD f_tlwizsry fontHeight I
 		COMMENT The font height of the text that is rendered by the text renderer.
 	FIELD f_xwtzpwjg ALPHA_CUTOFF I
+	METHOD <init> (Ljava/util/function/Function;Z)V
+		ARG 1 fontStorageAccessor
+		ARG 2 filterFishyGlyphs
 	METHOD m_adetgpyq draw (Lnet/minecraft/unmapped/C_cnszsxvd;Ljava/lang/String;FFI)I
 		ARG 1 matrices
 		ARG 2 text

--- a/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
@@ -38,11 +38,13 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/CyclingB
 		ARG 1 off
 	METHOD m_jsgmqbgj onOffBuilder (Z)Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 		COMMENT Creates a builder for a cycling button widget that only has {@linkplain Boolean#TRUE}
-		COMMENT and {@linkplain Boolean#FALSE} values. It displays
-		COMMENT {@link net.minecraft.client.gui.screen.ScreenTexts#ON} for {@code true} and
-		COMMENT {@link net.minecraft.client.gui.screen.ScreenTexts#OFF} for {@code false}.
-		COMMENT Its current initial value is set to {@code initialValue}.
+		COMMENT and {@linkplain Boolean#FALSE} values.
+		COMMENT It displays {@link net.minecraft.text.ScreenTexts#ON} for {@code true},
+		COMMENT and {@link net.minecraft.text.ScreenTexts#OFF} for {@code false}.
+		COMMENT <p>
+		COMMENT Its current initial value is {@code initialValue}.
 		ARG 0 initialValue
+			COMMENT the initial value
 	METHOD m_jwrniozw composeGenericOptionText (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 1 value
 	METHOD m_mxugbexk getValue (I)Ljava/lang/Object;
@@ -64,9 +66,10 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/CyclingB
 		ARG 1 value
 	METHOD m_wymfsxew onOffBuilder ()Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 		COMMENT Creates a builder for a cycling button widget that only has {@linkplain Boolean#TRUE}
-		COMMENT and {@linkplain Boolean#FALSE} values. It displays
-		COMMENT {@link net.minecraft.client.gui.screen.ScreenTexts#ON} for {@code true} and
-		COMMENT {@link net.minecraft.client.gui.screen.ScreenTexts#OFF} for {@code false}.
+		COMMENT and {@linkplain Boolean#FALSE} values.
+		COMMENT It displays {@link net.minecraft.text.ScreenTexts#ON} for {@code true},
+		COMMENT and {@link net.minecraft.text.ScreenTexts#OFF} for {@code false}.
+		COMMENT <p>
 		COMMENT Its current initial value is {@code true}.
 	METHOD m_zbsldwum (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;Ljava/lang/Boolean;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 2 value

--- a/mappings/net/minecraft/network/ClientConnection.mapping
+++ b/mappings/net/minecraft/network/ClientConnection.mapping
@@ -49,6 +49,7 @@ CLASS net/minecraft/unmapped/C_oasmcckk net/minecraft/network/ClientConnection
 	METHOD m_akpgjfcu sendQueuedPackets ()V
 	METHOD m_bgcagbfi sendImmediately (Lnet/minecraft/unmapped/C_zyjtrjrl;Lnet/minecraft/unmapped/C_zddpfpkk;)V
 		ARG 1 packet
+		ARG 2 listener
 	METHOD m_bhwloxoc getPacketListener ()Lnet/minecraft/unmapped/C_tkgdawqw;
 	METHOD m_bjjkjdwd (Lorg/slf4j/Marker;)V
 		ARG 0 marker
@@ -85,6 +86,9 @@ CLASS net/minecraft/unmapped/C_oasmcckk net/minecraft/network/ClientConnection
 	METHOD m_rgronykr handlePacket (Lnet/minecraft/unmapped/C_zyjtrjrl;Lnet/minecraft/unmapped/C_tkgdawqw;)V
 		ARG 0 packet
 		ARG 1 listener
+	METHOD m_rsirbonf send (Lnet/minecraft/unmapped/C_zyjtrjrl;Lnet/minecraft/unmapped/C_zddpfpkk;)V
+		ARG 1 packet
+		ARG 2 listener
 	METHOD m_sigcqeza getAddress ()Ljava/net/SocketAddress;
 	METHOD m_tulexlec tick ()V
 	METHOD m_uhgukhmf getAveragePacketsSent ()F
@@ -107,9 +111,12 @@ CLASS net/minecraft/unmapped/C_oasmcckk net/minecraft/network/ClientConnection
 		ARG 1 useEpoll
 	METHOD m_vyytglie sendInternal (Lnet/minecraft/unmapped/C_zyjtrjrl;Lnet/minecraft/unmapped/C_zddpfpkk;Lnet/minecraft/unmapped/C_kxdobmrm;Lnet/minecraft/unmapped/C_kxdobmrm;)V
 		ARG 1 packet
+		ARG 2 listener
 		ARG 3 newNetworkState
 		ARG 4 currentNetworkState
 	METHOD m_wlmhzfek handleDisconnection ()V
+	METHOD m_wrnibrta (Lnet/minecraft/unmapped/C_zddpfpkk;Lio/netty/util/concurrent/Future;)V
+		ARG 2 future
 	METHOD m_wrxqepoa isLocal ()Z
 	METHOD m_wzyhrrka (Lorg/slf4j/Marker;)V
 		ARG 0 marker

--- a/mappings/net/minecraft/network/PacketSendListener.mapping
+++ b/mappings/net/minecraft/network/PacketSendListener.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/unmapped/C_zddpfpkk net/minecraft/network/PacketSendListener
+	COMMENT Represents a listener of packets queued for sending.
+	METHOD m_fmiahmzw getFailurePacket ()Lnet/minecraft/unmapped/C_zyjtrjrl;
+		COMMENT {@return the packet to send on failure, or {@code null} if there is none}
+	METHOD m_gmgcztoy alwaysRun (Ljava/lang/Runnable;)Lnet/minecraft/unmapped/C_zddpfpkk;
+		COMMENT {@return a listener that always runs the given {@code runnable} no matter the outcome}
+		ARG 0 runnable
+	METHOD m_hbxtgwlb onSuccess ()V
+		COMMENT Called when a packet is sent successfully.
+	METHOD m_kqiwzqbq toSendIfFailed (Ljava/util/function/Supplier;)Lnet/minecraft/unmapped/C_zddpfpkk;
+		COMMENT {@return a listener that sends the supplied packet when failed}
+		ARG 0 failurePacketSupplier
+			COMMENT the supplier of the packet to send in case of a failure

--- a/mappings/net/minecraft/util/math/noise/InterpolatedNoiseSampler.mapping
+++ b/mappings/net/minecraft/util/math/noise/InterpolatedNoiseSampler.mapping
@@ -3,7 +3,9 @@ CLASS net/minecraft/unmapped/C_uuzbvycz net/minecraft/util/math/noise/Interpolat
 	FIELD f_ffkkrkfh verticalScale D
 	FIELD f_kklakles maxValue D
 	FIELD f_ojosutch interpolationNoise Lnet/minecraft/unmapped/C_hsivpyol;
+	FIELD f_rpwruyia SCALE_RANGE_CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_splhrcet CODEC Lnet/minecraft/unmapped/C_ircwepir;
+	FIELD f_xqyyjdwq DATA_CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_xzeltcni lowerInterpolatedNoise Lnet/minecraft/unmapped/C_hsivpyol;
 	FIELD f_ynprhwyn upperInterpolatedNoise Lnet/minecraft/unmapped/C_hsivpyol;
 	METHOD m_ywupujlm addDebugInfo (Ljava/lang/StringBuilder;)V

--- a/mappings/net/minecraft/world/gen/DensityFunctions.mapping
+++ b/mappings/net/minecraft/world/gen/DensityFunctions.mapping
@@ -214,6 +214,7 @@ CLASS net/minecraft/unmapped/C_mdkmcezi net/minecraft/world/gen/DensityFunctions
 	CLASS C_reffwscv Spline
 		FIELD f_billgkqm DATA_CODEC Lcom/mojang/serialization/MapCodec;
 		FIELD f_cdtfwlwb CODEC Lnet/minecraft/unmapped/C_ircwepir;
+		FIELD f_nibtqpmf SPLINE_CODEC Lcom/mojang/serialization/Codec;
 		FIELD f_qwfptbmn spline Lnet/minecraft/unmapped/C_cjntsjzo;
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 p

--- a/mappings/net/minecraft/world/gen/feature/IcebergFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/IcebergFeature.mapping
@@ -16,8 +16,9 @@ CLASS net/minecraft/unmapped/C_yxklrpfi net/minecraft/world/gen/feature/IcebergF
 		ARG 5 offsetX
 		ARG 6 offsetY
 		ARG 7 offsetZ
-		ARG 10 placeSnow
+		ARG 10 lessSnow
 		ARG 12 randomSine
+		ARG 14 placeSnow
 		ARG 15 state
 	METHOD m_fgkeoswy heightDependentRadiusSteep (Lnet/minecraft/unmapped/C_rlomrsco;III)I
 		ARG 1 random


### PR DESCRIPTION
Soooo.

This:
 - fixes javadoc entirely so it finally builds!
 - maps back text renderer because Mojang did a funni and literally ruined my auto mapping in MinecraftClient
 - maps all the 🚫🐟 text rendering
 - maps the networking changes
 
 Looked into some yarn PRs and into mojmap for lot of theses.
 
 If anyone has an issue with the 🚫🐟 wording, please consider:
 - `safeTextRenderer` is even less descriptive
 - yarn's proposal (`defaultFontTextRenderer`) is EVEN less descriptive
 - `filteredTextRenderer` is meh, still doesn't describe well, like, filter what?
 
 Marking this critical too as it would ease a lot QSL development.