### PR TITLE
Update BrewingRecipeRegistry.mapping

### DIFF
--- a/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
+++ b/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
@@ -6,8 +6,8 @@ CLASS net/minecraft/unmapped/C_ilssplzn net/minecraft/recipe/BrewingRecipeRegist
 	METHOD m_azuxpboh (Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 0 stack
 	METHOD m_cwnwpxhs craft (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
-		ARG 0 input
-		ARG 1 ingredient
+		ARG 0 ingredient
+		ARG 1 input
 	METHOD m_fdkgeuuc hasItemRecipe (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 0 input
 		ARG 1 ingredient


### PR DESCRIPTION
The parameter names on `craft(ItemStack, ItemStack)` were flipped.