### PR TITLE
Update a few stack/slot related method names and parameters.

### DIFF
--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -131,7 +131,7 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 		COMMENT Called when another {@link ItemStack} is placed on an {@link ItemStack} of this item.
 		COMMENT
 		COMMENT @see ItemStack#onClicked
-		COMMENT @see #onClickedOnOhter
+		COMMENT @see #onClickedOnOther
 		COMMENT @return whether an action was performed
 		ARG 1 thisStack
 		ARG 2 otherStack

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -117,15 +117,19 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 	METHOD m_obcnhrty damage (Lnet/minecraft/unmapped/C_sbxfkpyv;)Z
 		COMMENT {@return whether this item can be damaged by the given {@link DamageSource source}}
 		ARG 1 source
-	METHOD m_pfwgoldc onStackClicked (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
-		ARG 1 stack
-		ARG 2 slot
+	METHOD m_pfwgoldc onThisClickedOnStack (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
+		COMMENT Called when an {@link ItemStack} of this item is placed on another {@link ItemStack} in a slot.
+		COMMENT {@return whether an action was performed.}
+		ARG 1 thisStack
+		ARG 2 otherSlot
 		ARG 3 clickType
 		ARG 4 player
-	METHOD m_pktzlvtx onClicked (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
-		ARG 1 stack
+	METHOD m_pktzlvtx onStackClickedOnThis (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
+		COMMENT Called when another {@link ItemStack} is placed on an {@link ItemStack} of this item.
+		COMMENT {@return whether an action was performed.}
+		ARG 1 thisStack
 		ARG 2 otherStack
-		ARG 3 slot
+		ARG 3 thisSlot
 		ARG 4 clickType
 		ARG 5 player
 		ARG 6 cursorStackReference

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -131,7 +131,7 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 		COMMENT Called when another {@link ItemStack} is placed on an {@link ItemStack} of this item.
 		COMMENT
 		COMMENT @see ItemStack#onClicked
-		COMMENT @See #onClickedOnOhter
+		COMMENT @see #onClickedOnOhter
 		COMMENT @return whether an action was performed
 		ARG 1 thisStack
 		ARG 2 otherStack

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -117,16 +117,22 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 	METHOD m_obcnhrty damage (Lnet/minecraft/unmapped/C_sbxfkpyv;)Z
 		COMMENT {@return whether this item can be damaged by the given {@link DamageSource source}}
 		ARG 1 source
-	METHOD m_pfwgoldc onThisClickedOnStack (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
+	METHOD m_pfwgoldc onClickedOnOther (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 		COMMENT Called when an {@link ItemStack} of this item is placed on another {@link ItemStack} in a slot.
-		COMMENT {@return whether an action was performed.}
+		COMMENT
+		COMMENT @see ItemStack#onClickedOnOther
+		COMMENT @see #onClicked
+		COMMENT @return whether an action was performed
 		ARG 1 thisStack
 		ARG 2 otherSlot
 		ARG 3 clickType
 		ARG 4 player
-	METHOD m_pktzlvtx onStackClickedOnThis (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
+	METHOD m_pktzlvtx onClicked (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
 		COMMENT Called when another {@link ItemStack} is placed on an {@link ItemStack} of this item.
-		COMMENT {@return whether an action was performed.}
+		COMMENT
+		COMMENT @see ItemStack#onClicked
+		COMMENT @See #onClickedOnOhter
+		COMMENT @return whether an action was performed
 		ARG 1 thisStack
 		ARG 2 otherStack
 		ARG 3 thisSlot

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -196,8 +196,10 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		COMMENT @return the custom NBT of this item stack
 		COMMENT
 		COMMENT @see <a href="#nbt-operations">Item Stack NBT Operations</a>
-	METHOD m_hmrpegvi onStackClicked (Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
-		ARG 1 slot
+	METHOD m_hmrpegvi onThisClickedOnStack (Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
+		COMMENT Called when the stack is placed on another {@link ItemStack} in a slot.
+		COMMENT {@return whether an action was performed.}
+		ARG 1 otherSlot
 		ARG 2 clickType
 		ARG 3 player
 	METHOD m_iadyttua usageTick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;I)V
@@ -288,6 +290,7 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		ARG 1 nbt
 			COMMENT the NBT compound to write to
 	METHOD m_qxfxfsuy getItem ()Lnet/minecraft/unmapped/C_vorddnax;
+		COMMENT Called when another {@link ItemStack} is placed on this stack.
 	METHOD m_rdrbrcjp addAttributeModifier (Lnet/minecraft/unmapped/C_ppzfbbsy;Lnet/minecraft/unmapped/C_hdbqsqsm;Lnet/minecraft/unmapped/C_yuycoehb;)V
 		ARG 1 attribute
 		ARG 2 modifier
@@ -313,9 +316,11 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 	METHOD m_tcgbrtym isInFrame ()Z
 	METHOD m_uglewown getCount ()I
 		COMMENT {@return the count of items in this item stack}
-	METHOD m_uhghycli onClicked (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
-		ARG 1 stack
-		ARG 2 slot
+	METHOD m_uhghycli onStackClickedOnThis (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
+		COMMENT Called when another {@link ItemStack} is placed on this stack.
+		COMMENT {@return whether an action was performed.}
+		ARG 1 otherStack
+		ARG 2 thisSlot
 		ARG 3 clickType
 		ARG 4 player
 		ARG 5 cursorStackReference

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -196,9 +196,12 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		COMMENT @return the custom NBT of this item stack
 		COMMENT
 		COMMENT @see <a href="#nbt-operations">Item Stack NBT Operations</a>
-	METHOD m_hmrpegvi onThisClickedOnStack (Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
+	METHOD m_hmrpegvi onClickedOnOther (Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 		COMMENT Called when the stack is placed on another {@link ItemStack} in a slot.
-		COMMENT {@return whether an action was performed.}
+		COMMENT
+		COMMENT @see Item#onClickedOnOther
+		COMMENT @see #onClicked
+		COMMENT @return whether an action was performed
 		ARG 1 otherSlot
 		ARG 2 clickType
 		ARG 3 player
@@ -316,9 +319,12 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 	METHOD m_tcgbrtym isInFrame ()Z
 	METHOD m_uglewown getCount ()I
 		COMMENT {@return the count of items in this item stack}
-	METHOD m_uhghycli onStackClickedOnThis (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
+	METHOD m_uhghycli onClicked (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_xkkpnyvk;)Z
 		COMMENT Called when another {@link ItemStack} is placed on this stack.
-		COMMENT {@return whether an action was performed.}
+		COMMENT
+		COMMENT @see Item#onClicked
+		COMMENT @See #onClickedOnOhter
+		COMMENT @return whether an action was performed
 		ARG 1 otherStack
 		ARG 2 thisSlot
 		ARG 3 clickType

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -322,7 +322,7 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		COMMENT Called when another {@link ItemStack} is placed on this stack.
 		COMMENT
 		COMMENT @see Item#onClicked
-		COMMENT @See #onClickedOnOhter
+		COMMENT @see #onClickedOnOhter
 		COMMENT @return whether an action was performed
 		ARG 1 otherStack
 		ARG 2 thisSlot

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -322,7 +322,7 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		COMMENT Called when another {@link ItemStack} is placed on this stack.
 		COMMENT
 		COMMENT @see Item#onClicked
-		COMMENT @see #onClickedOnOhter
+		COMMENT @see #onClickedOnOther
 		COMMENT @return whether an action was performed
 		ARG 1 otherStack
 		ARG 2 thisSlot

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -290,7 +290,6 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		ARG 1 nbt
 			COMMENT the NBT compound to write to
 	METHOD m_qxfxfsuy getItem ()Lnet/minecraft/unmapped/C_vorddnax;
-		COMMENT Called when another {@link ItemStack} is placed on this stack.
 	METHOD m_rdrbrcjp addAttributeModifier (Lnet/minecraft/unmapped/C_ppzfbbsy;Lnet/minecraft/unmapped/C_hdbqsqsm;Lnet/minecraft/unmapped/C_yuycoehb;)V
 		ARG 1 attribute
 		ARG 2 modifier

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -109,9 +109,9 @@ CLASS net/minecraft/unmapped/C_mkrkudpa net/minecraft/screen/ScreenHandler
 		ARG 2 button
 		ARG 3 actionType
 		ARG 4 player
-	METHOD m_oujzgmbb transferSlot (Lnet/minecraft/unmapped/C_jzrpycqo;I)Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_oujzgmbb quickTransfer (Lnet/minecraft/unmapped/C_jzrpycqo;I)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 1 player
-		ARG 2 index
+		ARG 2 fromIndex
 	METHOD m_owkqkrmv copySharedSlots (Lnet/minecraft/unmapped/C_mkrkudpa;)V
 		ARG 1 handler
 	METHOD m_pmldxlql canInsertIntoSlot (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nhvqfffd;)Z


### PR DESCRIPTION
Related to #222. Expecting some changes as there seemed to not be a common census when I asked on the Discord. Parameter names use `otherStack`, `thisStack`, etc. to be clear.