### PR TITLE
Shorten FCP length

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Triage member or another Mappings Team member.
 
 **Final Comment Period**:
 - Snapshots: 1 day
-- Releases: 4 days
+- Releases: 3 days
 
 **Special cases**:
 - If the PR adds new mappings needed by QSL, the Final Comment Period is shortened to 12 hours.
@@ -73,8 +73,8 @@ Triage member or another Mappings Team member.
 Triage member or another Mappings Team member.
 
 **Final Comment Period**:
-- Snapshots: 4 days
-- Releases: 8 days
+- Snapshots: 3 days
+- Releases: 6 days
 
 ### `T: documentation`
 
@@ -86,7 +86,7 @@ Triage member or another Mappings Team member.
 
 **Final Comment Period**:
 - Snapshots: 3 days
-- Releases: 7 days
+- Releases: 5 days
 
 ### `T: toolchain changes`
 
@@ -98,7 +98,7 @@ and/or tools used.
 
 **Final Comment Period**:
 - Snapshots: 1 day
-- Releases: 3 days
+- Releases: 2 days
 
 ### Other
 Trivial fixes that do not require review (e.g. typos) are exempt from this policy. Mappings team members should

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Triage member or another Mappings Team member.
 
 **Final Comment Period**:
 - Snapshots: 1 day
-- Releases: 3 days
+- Releases: 2 days
 
 **Special cases**:
 - If the PR adds new mappings needed by QSL, the Final Comment Period is shortened to 12 hours.
@@ -85,8 +85,8 @@ Triage member or another Mappings Team member.
 Triage member or another Mappings Team member.
 
 **Final Comment Period**:
-- Snapshots: 3 days
-- Releases: 5 days
+- Snapshots: 2 days
+- Releases: 4 days
 
 ### `T: toolchain changes`
 


### PR DESCRIPTION
Shortens the current FCP length for all triage categories. The current length is quite excessive, and just delays updates.

- `t: new`
  - Releases: 4 -> 2 days
- `t: refactor`
  - Snapshots: 4 -> 3 days
  - Releases: 8 -> 6 days
- `t: documentation`
  - Snapshots: 3 -> 2 days
  - Releases: 7 -> 4 days
- `t: toolchain`
  - Releases: 3 -> 2 days