### PR TITLE
Fix javadocs for 22w42a

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -103,8 +103,6 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 2 stack
 	METHOD m_fcwpdfta appendStacks (Lnet/minecraft/unmapped/C_lnokcayd;Lnet/minecraft/unmapped/C_rnrfftze;)V
 		COMMENT Appends the stacks of this block shown in the item group to the list.
-		COMMENT
-		COMMENT @see net.minecraft.item.BlockItem#appendStacks(ItemGroup, DefaultedList)
 		ARG 1 group
 		ARG 2 stacks
 	METHOD m_fgtteebr hasDynamicBounds ()Z

--- a/mappings/net/minecraft/client/multiplayer/chat/ChatLog.mapping
+++ b/mappings/net/minecraft/client/multiplayer/chat/ChatLog.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/unmapped/C_udbfbmhx net/minecraft/client/multiplayer/chat/ChatLog
-	COMMENT A chat log holds received message entries with sequential indices, where newer entries receive bigger indices.
-	COMMENT <p>
-	COMMENT An implementation using fixed-size array is available at {@link ChatLogImpl}.
-	COMMENT <p>
-	COMMENT There are two types of entries. {@link LoggedChatMessageLink} is an entry containing only
-	COMMENT the message's header, and is used for censored messages.
-	COMMENT {@link LoggedChatMessage} is an entry for full chat or game messages.
+	COMMENT A chat log holds a fixed number of received message entries with sequential indices,
+	COMMENT where newer entries receive bigger indices, until reaching an "overflow", in which
+	COMMENT case the index starts from 0 again and newer entries replace older ones.
+	FIELD f_lsbdmhpt events [Lnet/minecraft/unmapped/C_nanhbbwb;
+	FIELD f_xzcesoso nextId I
+	METHOD <init> (I)V
+		ARG 1 maxEvents
 	METHOD m_nfymlukk get (I)Lnet/minecraft/unmapped/C_nanhbbwb;
 		COMMENT {@return the event with index {@code id}, or {@code null} if there is no
 		COMMENT such event in the log}
@@ -13,3 +13,7 @@ CLASS net/minecraft/unmapped/C_udbfbmhx net/minecraft/client/multiplayer/chat/Ch
 			COMMENT the event index
 	METHOD m_qiuhvfnw add (Lnet/minecraft/unmapped/C_nanhbbwb;)V
 		ARG 1 event
+	METHOD m_uvupkufo getIndex (I)I
+		ARG 1 count
+	METHOD m_vrsxbkij getStartId ()I
+	METHOD m_yskyvyoa getEndId ()I

--- a/mappings/net/minecraft/world/RegistryWorldView.mapping
+++ b/mappings/net/minecraft/world/RegistryWorldView.mapping
@@ -1,5 +1,1 @@
 CLASS net/minecraft/unmapped/C_gokrnymh net/minecraft/world/RegistryWorldView
-	COMMENT A world view or {@link World}'s superinterface that exposes access to
-	COMMENT a registry manager.
-	COMMENT
-	COMMENT @see #getRegistryManager()


### PR DESCRIPTION
Also map stuff in `ChatLog`. As for #251, I just removed the javadoc, it still needs a new name