### PR TITLE
Feature Flag Mapping

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	FIELD f_dwtggipc randomTicks Z
 	FIELD f_eagudpej slipperiness F
+	FIELD f_gtipwtfw requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 	FIELD f_hcgxjldr jumpVelocityMultiplier F
 	FIELD f_hflsieep lootTableId Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_hpfrgdhl velocityMultiplier F
@@ -555,6 +556,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		FIELD f_kbodklmq mapColorProvider Ljava/util/function/Function;
 		FIELD f_lbohsgfq slipperiness F
 		FIELD f_lfwsqmni hardness F
+		FIELD f_lznwhdle requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 		FIELD f_mpcyvbbz stateToOffsetFunction Ljava/util/function/Function;
 		FIELD f_mpvjzlvv allowsSpawningPredicate Lnet/minecraft/unmapped/C_triydqro$C_knnwryez;
 		FIELD f_mtvcolqn soundGroup Lnet/minecraft/unmapped/C_aevintex;
@@ -579,6 +581,8 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 1 predicate
 		METHOD m_ccdwjkad (Lnet/minecraft/unmapped/C_ifcgjcqy;Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_ifcgjcqy;
 			ARG 1 state
+		METHOD m_cfcitqhx requiredFlags ([Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+			ARG 1 flags
 		METHOD m_cfevbjmt (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 			ARG 0 state
 			ARG 1 world

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -209,6 +209,9 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	METHOD m_bteytekh render (Z)V
 		ARG 1 tick
 	METHOD m_bzxkzdli getGame ()Lnet/minecraft/unmapped/C_vakgxuad;
+	METHOD m_cbjyfsge refreshSearch (Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;Ljava/util/List;)V
+		ARG 1 key
+		ARG 2 searchables
 	METHOD m_cfvjiijv cancelRecorder ()V
 	METHOD m_crapepyd getEntityModelLoader ()Lnet/minecraft/unmapped/C_qncyfzro;
 	METHOD m_denzhwko getStatusEffectSpriteManager ()Lnet/minecraft/unmapped/C_ucgueons;

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_nuofrxvi net/minecraft/client/network/ClientPlayN
 	FIELD f_beytxqxu dataQueryHandler Lnet/minecraft/unmapped/C_kiomtpcs;
 	FIELD f_biurfzzv worldKeys Ljava/util/Set;
 	FIELD f_bpwcjaiw profile Lcom/mojang/authlib/GameProfile;
+	FIELD f_bsnhfuqe enabledFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 	FIELD f_cxwctjfx client Lnet/minecraft/unmapped/C_ayfeobid;
 	FIELD f_fjkxpgbq DISCONNECT_LOST_TEXT Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_fmcklieu LOGGER Lorg/slf4j/Logger;
@@ -48,7 +49,9 @@ CLASS net/minecraft/unmapped/C_nuofrxvi net/minecraft/client/network/ClientPlayN
 		ARG 1 x
 		ARG 2 z
 		ARG 3 data
+	METHOD m_miklwign refreshCreativeInventoryForFeatureFlags ()V
 	METHOD m_nnthzfll getCommandDispatcher ()Lcom/mojang/brigadier/CommandDispatcher;
+	METHOD m_ojepywax enabledFlags ()Lnet/minecraft/unmapped/C_czxxrbcp;
 	METHOD m_owpxqxbm getPlayerListEntry (Ljava/lang/String;)Lnet/minecraft/unmapped/C_rdnfmxue;
 		ARG 1 profileName
 	METHOD m_oyjilzsc updateLighting (IILnet/minecraft/unmapped/C_ksposksb;Lnet/minecraft/unmapped/C_fhvlmqtw;Ljava/util/BitSet;Ljava/util/BitSet;Ljava/util/Iterator;Z)V

--- a/mappings/net/minecraft/client/search/SearchManager.mapping
+++ b/mappings/net/minecraft/client/search/SearchManager.mapping
@@ -3,8 +3,13 @@ CLASS net/minecraft/unmapped/C_zqzigdge net/minecraft/client/search/SearchManage
 	FIELD f_hpwjudey ITEM_TOOLTIP Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;
 	FIELD f_jivcozuv ITEM_TAG Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;
 	FIELD f_xowozfgq instances Ljava/util/Map;
+	METHOD m_jmupjdnd (Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;)Lnet/minecraft/unmapped/C_zqzigdge$C_lpzuavsm;
+		ARG 1 key
 	METHOD m_jrasqirm put (Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;Lnet/minecraft/unmapped/C_zqzigdge$C_faknnetb;)V
 		ARG 1 key
 	METHOD m_xgrlmmoi get (Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;)Lnet/minecraft/unmapped/C_inuoeylq;
 		ARG 1 key
+	METHOD m_yhcpnstp refreshSearch (Lnet/minecraft/unmapped/C_zqzigdge$C_gvofkqkn;Ljava/util/List;)V
+		ARG 1 key
+		ARG 2 searchables
 	CLASS C_gvofkqkn Key

--- a/mappings/net/minecraft/entity/EntityType.mapping
+++ b/mappings/net/minecraft/entity/EntityType.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/unmapped/C_ogavsvbr net/minecraft/entity/EntityType
 	FIELD f_kniifuwr name Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_lgiidgzb HORSE_MODEL_WIDTH F
 	FIELD f_lltgieqe dimensions Lnet/minecraft/unmapped/C_sszpscpo;
+	FIELD f_mjmkeute requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 	FIELD f_nmhdwoib saveable Z
 	FIELD f_rbjzcosu summonable Z
 	FIELD f_sjefpzeu lootTableId Lnet/minecraft/unmapped/C_ncpywfca;
@@ -16,6 +17,18 @@ CLASS net/minecraft/unmapped/C_ogavsvbr net/minecraft/entity/EntityType
 	FIELD f_yohcyxht fireImmune Z
 	FIELD f_zebtzdfg factory Lnet/minecraft/unmapped/C_ogavsvbr$C_pasczndl;
 	FIELD f_znyuwmdh LOGGER Lorg/slf4j/Logger;
+	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr$C_pasczndl;Lnet/minecraft/unmapped/C_ormqdxci;ZZZZLcom/google/common/collect/ImmutableSet;Lnet/minecraft/unmapped/C_sszpscpo;IILnet/minecraft/unmapped/C_czxxrbcp;)V
+		ARG 1 factory
+		ARG 2 spawnGroup
+		ARG 3 saveable
+		ARG 4 summonable
+		ARG 5 fireImmune
+		ARG 6 spawnableFarFromPLayer
+		ARG 7 canSpawnInside
+		ARG 8 dimensions
+		ARG 9 maxTrackDistance
+		ARG 10 trackTickInterval
+		ARG 11 requiredFlags
 	METHOD m_aaapctbf getSpawnGroup ()Lnet/minecraft/unmapped/C_ormqdxci;
 	METHOD m_acyrwvoa getBuiltInRegistryHolder ()Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;
 	METHOD m_baavaxmk getName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
@@ -113,6 +126,7 @@ CLASS net/minecraft/unmapped/C_ogavsvbr net/minecraft/entity/EntityType
 		FIELD f_akcgsfjm fireImmune Z
 		FIELD f_byplxilj summonable Z
 		FIELD f_cbcdynbb dimensions Lnet/minecraft/unmapped/C_sszpscpo;
+		FIELD f_ccpuhtsn requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 		FIELD f_kboywape canSpawnInside Lcom/google/common/collect/ImmutableSet;
 		FIELD f_lkhvewcl maxTrackingRange I
 		FIELD f_lwhqlwvm factory Lnet/minecraft/unmapped/C_ogavsvbr$C_pasczndl;
@@ -136,6 +150,8 @@ CLASS net/minecraft/unmapped/C_ogavsvbr net/minecraft/entity/EntityType
 		METHOD m_ffxlqdpi maxTrackingRange (I)Lnet/minecraft/unmapped/C_ogavsvbr$C_mopkbakb;
 			ARG 1 maxTrackingRange
 		METHOD m_itrwpmjb makeFireImmune ()Lnet/minecraft/unmapped/C_ogavsvbr$C_mopkbakb;
+		METHOD m_jqfjjilu requiredFlags ([Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_ogavsvbr$C_mopkbakb;
+			ARG 1 flags
 		METHOD m_jzibjjne create (Lnet/minecraft/unmapped/C_ogavsvbr$C_pasczndl;Lnet/minecraft/unmapped/C_ormqdxci;)Lnet/minecraft/unmapped/C_ogavsvbr$C_mopkbakb;
 			ARG 0 factory
 			ARG 1 spawnGroup

--- a/mappings/net/minecraft/feature_flags/FeatureFlag.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureFlag.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/unmapped/C_kksdgidr net/minecraft/feature_flags/FeatureFlag
+	FIELD f_cmzcfsxk mask J
+	FIELD f_ontbcdmg group Lnet/minecraft/unmapped/C_uvqagymr;
+	METHOD <init> (Lnet/minecraft/unmapped/C_uvqagymr;I)V
+		ARG 1 group
+		ARG 2 mask

--- a/mappings/net/minecraft/feature_flags/FeatureFlagBitSet.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureFlagBitSet.mapping
@@ -1,0 +1,27 @@
+CLASS net/minecraft/unmapped/C_czxxrbcp net/minecraft/feature_flags/FeatureFlagBitSet
+	FIELD f_bhvxgytk MAX_FLAGS I
+	FIELD f_iicricgb group Lnet/minecraft/unmapped/C_uvqagymr;
+	FIELD f_ncxhouea EMPTY Lnet/minecraft/unmapped/C_czxxrbcp;
+	FIELD f_slsbiqgu flags J
+	METHOD <init> (Lnet/minecraft/unmapped/C_uvqagymr;J)V
+		ARG 1 group
+		ARG 2 flags
+	METHOD m_braspyen oofFlags (Lnet/minecraft/unmapped/C_kksdgidr;[Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 0 first
+		ARG 1 others
+	METHOD m_bykvotir empty ()Lnet/minecraft/unmapped/C_czxxrbcp;
+	METHOD m_dryclhpj union (Lnet/minecraft/unmapped/C_czxxrbcp;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 1 other
+	METHOD m_imqfaqzd ofCollection (Lnet/minecraft/unmapped/C_uvqagymr;Ljava/util/Collection;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 0 group
+		ARG 1 flags
+	METHOD m_kmtbhwxe hasFlag (Lnet/minecraft/unmapped/C_kksdgidr;)Z
+		ARG 1 flag
+	METHOD m_muhronzh addFlags (Lnet/minecraft/unmapped/C_uvqagymr;JLjava/lang/Iterable;)J
+		ARG 0 group
+		ARG 1 bits
+		ARG 3 flags
+	METHOD m_tbqmanuw ofFlag (Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 0 flag
+	METHOD m_ysykbuyp isIn (Lnet/minecraft/unmapped/C_czxxrbcp;)Z
+		ARG 1 bitset

--- a/mappings/net/minecraft/feature_flags/FeatureFlagGroup.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureFlagGroup.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_uvqagymr net/minecraft/feature_flags/FeatureFlagGroup
+	FIELD f_zzvcklqh id Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 id

--- a/mappings/net/minecraft/feature_flags/FeatureFlagRegistry.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureFlagRegistry.mapping
@@ -1,0 +1,41 @@
+CLASS net/minecraft/unmapped/C_asecsefi net/minecraft/feature_flags/FeatureFlagRegistry
+	FIELD f_cnzvdbkw group Lnet/minecraft/unmapped/C_uvqagymr;
+	FIELD f_coujmlxd flags Ljava/util/Map;
+	FIELD f_pclawvoq all Lnet/minecraft/unmapped/C_czxxrbcp;
+	METHOD <init> (Lnet/minecraft/unmapped/C_uvqagymr;Lnet/minecraft/unmapped/C_czxxrbcp;Ljava/util/Map;)V
+		ARG 1 group
+		ARG 2 all
+		ARG 3 flags
+	METHOD m_armlhdku bitsetOf ([Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 1 flags
+	METHOD m_bhjfcdcm (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 1 ids
+	METHOD m_dtidqoeu containedIn (Lnet/minecraft/unmapped/C_czxxrbcp;)Z
+		ARG 1 set
+	METHOD m_eqojtxdi createCodec ()Lcom/mojang/serialization/Codec;
+	METHOD m_gxognmoj (Lnet/minecraft/unmapped/C_czxxrbcp;)Ljava/util/List;
+		ARG 1 bitset
+	METHOD m_jbuobrqg (Lnet/minecraft/unmapped/C_czxxrbcp;Ljava/util/Set;Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_kksdgidr;)V
+		ARG 2 id
+		ARG 3 flag
+	METHOD m_nmjrlnxh (Lnet/minecraft/unmapped/C_ncpywfca;)V
+		ARG 0 id
+	METHOD m_swclprtn getFlagIds (Lnet/minecraft/unmapped/C_czxxrbcp;)Ljava/util/Set;
+		ARG 1 set
+	METHOD m_wassdtyk checkedBitsetOf (Ljava/lang/Iterable;Ljava/util/function/Consumer;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 1 ids
+		ARG 2 missingCallback
+	METHOD m_whuzviac setOf ()Lnet/minecraft/unmapped/C_czxxrbcp;
+	METHOD m_yugyuwot bitsetOf (Ljava/lang/Iterable;)Lnet/minecraft/unmapped/C_czxxrbcp;
+		ARG 1 ids
+	CLASS C_nqdiqnnu Builder
+		FIELD f_lpduubqm flags Ljava/util/Map;
+		FIELD f_psalnlvs group Lnet/minecraft/unmapped/C_uvqagymr;
+		FIELD f_ssjknnis index I
+		METHOD <init> (Ljava/lang/String;)V
+			ARG 1 groupId
+		METHOD m_cabkinsm createFlag (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_kksdgidr;
+			ARG 1 id
+		METHOD m_isuoezkm build ()Lnet/minecraft/unmapped/C_asecsefi;
+		METHOD m_txqseqan createVanillaFlag (Ljava/lang/String;)Lnet/minecraft/unmapped/C_kksdgidr;
+			ARG 1 name

--- a/mappings/net/minecraft/feature_flags/FeatureFlags.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureFlags.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/unmapped/C_ozbmlrmw net/minecraft/feature_flags/FeatureFlags
+	FIELD f_frgxzoxk BUNDLE Lnet/minecraft/unmapped/C_kksdgidr;
+	FIELD f_gouzolrt DEFAULT_SET Lnet/minecraft/unmapped/C_czxxrbcp;
+	FIELD f_lwmwbyqg VANILLA_SET Lnet/minecraft/unmapped/C_czxxrbcp;
+	FIELD f_vgooiicl VANILLA Lnet/minecraft/unmapped/C_kksdgidr;
+	FIELD f_xstdghyj MAIN_REGISTRY Lnet/minecraft/unmapped/C_asecsefi;
+	FIELD f_zbxsstmp UPDATE_1_20 Lnet/minecraft/unmapped/C_kksdgidr;
+	METHOD m_iacybqqj containsDefault (Lnet/minecraft/unmapped/C_czxxrbcp;)Z
+		ARG 0 set
+	METHOD m_jfpmedjk showMissing (Lnet/minecraft/unmapped/C_asecsefi;Lnet/minecraft/unmapped/C_czxxrbcp;Lnet/minecraft/unmapped/C_czxxrbcp;)Ljava/lang/String;
+		ARG 0 registry
+		ARG 1 setA
+		ARG 2 setB
+	METHOD m_uboylmom (Ljava/util/Set;Lnet/minecraft/unmapped/C_ncpywfca;)Z
+		ARG 1 id
+	METHOD m_zbonxpht showMissing (Lnet/minecraft/unmapped/C_czxxrbcp;Lnet/minecraft/unmapped/C_czxxrbcp;)Ljava/lang/String;
+		ARG 0 setA
+		ARG 1 setB

--- a/mappings/net/minecraft/feature_flags/FeatureGated.mapping
+++ b/mappings/net/minecraft/feature_flags/FeatureGated.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_ytmffdxu net/minecraft/feature_flags/FeatureGated
+	FIELD f_jrhycdty FILTERED_REGISTRIES Ljava/util/Set;
+	METHOD m_ejwyjlam enabledIn (Lnet/minecraft/unmapped/C_czxxrbcp;)Z
+		ARG 1 set
+	METHOD m_gsnyyecf getRequiredFlags ()Lnet/minecraft/unmapped/C_czxxrbcp;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 	FIELD f_bkclyjsj MAX_DURABILITY_BAR_WIDTH I
 	FIELD f_ewqskwyi ATTACK_DAMAGE_MODIFIER_ID Ljava/util/UUID;
 	FIELD f_heedcfbq rarity Lnet/minecraft/unmapped/C_mqmixksm;
+	FIELD f_hqzbeglm requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 	FIELD f_jphyibzg LOGGER Lorg/slf4j/Logger;
 	FIELD f_kdmqzdxr translationKey Ljava/lang/String;
 	FIELD f_lfoqoljh recipeRemainder Lnet/minecraft/unmapped/C_vorddnax;
@@ -230,6 +231,7 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 			COMMENT the hand used
 	CLASS C_bfrytpdl Settings
 		FIELD f_emilnckp recipeRemainder Lnet/minecraft/unmapped/C_vorddnax;
+		FIELD f_gjqaneav requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 		FIELD f_kwbsetju fireproof Z
 		FIELD f_kzcrollt rarity Lnet/minecraft/unmapped/C_mqmixksm;
 		FIELD f_oyiluwcv maxCount I
@@ -272,6 +274,8 @@ CLASS net/minecraft/unmapped/C_vorddnax net/minecraft/item/Item
 			COMMENT @return this instance
 			ARG 1 maxDamage
 				COMMENT maximum durability of an ItemStack using an item with this Item.Settings instance
+		METHOD m_tsalbwou requiredFlags ([Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_vorddnax$C_bfrytpdl;
+			ARG 1 flags
 		METHOD m_wuwttdfr food (Lnet/minecraft/unmapped/C_cgikuact;)Lnet/minecraft/unmapped/C_vorddnax$C_bfrytpdl;
 			COMMENT When set, any item configured with this Settings instance will be edible based on the provided {@link FoodComponent}.
 			COMMENT

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -1,11 +1,21 @@
 CLASS net/minecraft/unmapped/C_lnokcayd net/minecraft/item/ItemGroup
+	FIELD f_dutzqtyc visibleInTab Lnet/minecraft/unmapped/C_voakmxnc;
 	FIELD f_eftpytbk icon Lnet/minecraft/unmapped/C_sddaxwyk;
+	FIELD f_fhtvcyky visibleInSearch Lnet/minecraft/unmapped/C_voakmxnc;
 	FIELD f_miirnahq translationKey Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_ncvkfasf texture Ljava/lang/String;
 	FIELD f_sfwfnelq scrollbar Z
 	FIELD f_xkfcdxhm index I
 	FIELD f_ypvwgfta renderName Z
+	METHOD <init> (ILnet/minecraft/unmapped/C_rdaqiwdt;)V
+		ARG 1 index
+		ARG 2 translationKey
 	METHOD m_bvcnuvet isSpecial ()Z
+	METHOD m_bwauoqmb containsInSearch (Lnet/minecraft/unmapped/C_czxxrbcp;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
+		ARG 1 set
+	METHOD m_cfeptysp getStacks (Lnet/minecraft/unmapped/C_czxxrbcp;Z)Lnet/minecraft/unmapped/C_voakmxnc;
+		ARG 1 set
+		ARG 2 inSearch
 	METHOD m_dmxzmcbi createIcon ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_dnbejvnn hasScrollbar ()Z
 	METHOD m_frfpcrqq isTopRow ()Z
@@ -15,11 +25,44 @@ CLASS net/minecraft/unmapped/C_lnokcayd net/minecraft/item/ItemGroup
 		COMMENT <p>The name is rendered below the top row of item groups and above the inventory.
 	METHOD m_iwnppnlh setTexture (Ljava/lang/String;)Lnet/minecraft/unmapped/C_lnokcayd;
 		ARG 1 texture
+	METHOD m_mziozlja clear ()V
+	METHOD m_npmupqba fill (Lnet/minecraft/unmapped/C_czxxrbcp;Lnet/minecraft/unmapped/C_lnokcayd$C_wnogvxsu;)V
+		ARG 1 flags
+		ARG 2 collector
+	METHOD m_nsgpxdxb getStacksInSearch (Lnet/minecraft/unmapped/C_czxxrbcp;)Lnet/minecraft/unmapped/C_voakmxnc;
+		ARG 1 set
 	METHOD m_ojgukxpb setNoScrollbar ()Lnet/minecraft/unmapped/C_lnokcayd;
 	METHOD m_oxvpyaqs getTexture ()Ljava/lang/String;
+	METHOD m_qngoqhkn getStacksInTab (Lnet/minecraft/unmapped/C_czxxrbcp;)Lnet/minecraft/unmapped/C_voakmxnc;
+		ARG 1 set
 	METHOD m_qsfftnyy hideName ()Lnet/minecraft/unmapped/C_lnokcayd;
 		COMMENT Specifies that when this item group is selected, the name of the item group should not be rendered.
 	METHOD m_tcbipafs getTranslationKey ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_tkahlerj getColumn ()I
 	METHOD m_uprbbsoi getIcon ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_uribjksx getIndex ()I
+	CLASS C_qjyuivjw GatedItemCollector
+		FIELD f_alfldgtl requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
+		FIELD f_ewkqlato visibleInSearch Lnet/minecraft/unmapped/C_voakmxnc;
+		FIELD f_gynphoyu visibleInParent Lnet/minecraft/unmapped/C_voakmxnc;
+		FIELD f_tufxymik owner Lnet/minecraft/unmapped/C_lnokcayd;
+		METHOD <init> (Lnet/minecraft/unmapped/C_lnokcayd;Lnet/minecraft/unmapped/C_czxxrbcp;)V
+			ARG 1 owner
+			ARG 2 requiredFlags
+		METHOD m_fxchunju getVisibleInSearch ()Lnet/minecraft/unmapped/C_voakmxnc;
+		METHOD m_zlibfjti getVisibleInParent ()Lnet/minecraft/unmapped/C_voakmxnc;
+	CLASS C_tndlmady ItemVisibility
+	CLASS C_wnogvxsu ItemCollector
+		METHOD m_cgfqmabm addAll (Ljava/util/Collection;)V
+			ARG 1 stacks
+		METHOD m_hohqtcue add (Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_lnokcayd$C_tndlmady;)V
+			ARG 1 item
+			ARG 2 visibility
+		METHOD m_jghywfri add (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_lnokcayd$C_tndlmady;)V
+			ARG 2 visibility
+		METHOD m_jljrlzid addAll (Ljava/util/Collection;Lnet/minecraft/unmapped/C_lnokcayd$C_tndlmady;)V
+			ARG 1 stacks
+			ARG 2 visibility
+		METHOD m_lhspmles add (Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		METHOD m_rgrwuewj add (Lnet/minecraft/unmapped/C_gmbqjnle;)V
+			ARG 1 item

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -142,6 +142,8 @@ CLASS net/minecraft/unmapped/C_rbfddnlp net/minecraft/network/listener/ClientPla
 		ARG 1 packet
 	METHOD m_sbqpzauw onPlayerPositionLook (Lnet/minecraft/unmapped/C_pvzlatim;)V
 		ARG 1 packet
+	METHOD m_skjqayqa onSynchronizeFeatureFlags (Lnet/minecraft/unmapped/C_ntpuzsvr;)V
+		ARG 1 packet
 	METHOD m_smligavv onCommandTree (Lnet/minecraft/unmapped/C_vzeoulff;)V
 		ARG 1 packet
 	METHOD m_sqdxxbhd onOpenScreen (Lnet/minecraft/unmapped/C_newmzmzw;)V

--- a/mappings/net/minecraft/packet/s2c/play/SynchronizeEnabledFeatureFlagsS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/s2c/play/SynchronizeEnabledFeatureFlagsS2CPacket.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_ntpuzsvr net/minecraft/packet/s2c/play/SynchronizeEnabledFeatureFlagsS2CPacket
+	FIELD f_fpaqqwwa flagIds Ljava/util/Set;

--- a/mappings/net/minecraft/server/world/FeatureAndDataSettings.mapping
+++ b/mappings/net/minecraft/server/world/FeatureAndDataSettings.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_yknpgzdr net/minecraft/server/world/FeatureAndDataSettings
+	FIELD f_ehifmuti ENABLED_FEATURES_KEY Ljava/lang/String;
+	FIELD f_gvkotwzk MINIMAL Lnet/minecraft/unmapped/C_yknpgzdr;
+	METHOD m_hgeegkaw (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD m_upuzyphb withAddedFlags (Lnet/minecraft/unmapped/C_czxxrbcp;)Lnet/minecraft/unmapped/C_yknpgzdr;
+		ARG 1 set

--- a/mappings/net/minecraft/unmapped/UnsizedItemStackSet.mapping
+++ b/mappings/net/minecraft/unmapped/UnsizedItemStackSet.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_voakmxnc net/minecraft/unmapped/UnsizedItemStackSet
+	FIELD f_bbmejudb STRATEGY Lit/unimi/dsi/fastutil/Hash$Strategy;

--- a/mappings/net/minecraft/util/HolderLookup.mapping
+++ b/mappings/net/minecraft/util/HolderLookup.mapping
@@ -11,3 +11,14 @@ CLASS net/minecraft/unmapped/C_vtbxyypo net/minecraft/util/HolderLookup
 		FIELD f_zpcryuuw registry Lnet/minecraft/unmapped/C_tqxyjqsk;
 		METHOD <init> (Lnet/minecraft/unmapped/C_tqxyjqsk;)V
 			ARG 1 registry
+		METHOD m_cplftviu filtered (Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_vtbxyypo;
+			ARG 1 predicate
+		METHOD m_kqnidhqe filteredByFlags (Lnet/minecraft/unmapped/C_czxxrbcp;)Lnet/minecraft/unmapped/C_vtbxyypo;
+			ARG 1 set
+		METHOD m_pjiyqhtq (Lnet/minecraft/unmapped/C_czxxrbcp;Ljava/lang/Object;)Z
+			ARG 1 gatedObject
+		CLASS C_epoknvca
+			METHOD m_siwozrxd (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)Z
+				ARG 1 arg
+			METHOD m_ysslswxl (Ljava/util/function/Predicate;Ljava/util/Map$Entry;)Z
+				ARG 1 entry

--- a/mappings/net/minecraft/world/SaveProperties.mapping
+++ b/mappings/net/minecraft/world/SaveProperties.mapping
@@ -12,6 +12,8 @@ CLASS net/minecraft/unmapped/C_jkevluio net/minecraft/world/SaveProperties
 		ARG 1 locked
 	METHOD m_hgxsrhud getDragonFight ()Lnet/minecraft/unmapped/C_hhlwcnih;
 	METHOD m_iktkysbz getVersion ()I
+	METHOD m_jmqkuqhe setFeatureAndDataSettings (Lnet/minecraft/unmapped/C_yknpgzdr;)V
+		ARG 1 settings
 	METHOD m_jvjmdqna getDifficulty ()Lnet/minecraft/unmapped/C_mpbjgxic;
 	METHOD m_mnrjghmc getFormatName (I)Ljava/lang/String;
 		ARG 1 id
@@ -27,7 +29,9 @@ CLASS net/minecraft/unmapped/C_jkevluio net/minecraft/world/SaveProperties
 	METHOD m_ocjagmlc getLifecycle ()Lcom/mojang/serialization/Lifecycle;
 	METHOD m_oewbipwe isModded ()Z
 	METHOD m_phiwwied getLevelInfo ()Lnet/minecraft/unmapped/C_tmnkpzlg;
+	METHOD m_qucbceol getEnabledFlags ()Lnet/minecraft/unmapped/C_czxxrbcp;
 	METHOD m_qyxytalo areCommandsAllowed ()Z
+	METHOD m_rabnvpan getFeatureAndDataSettings ()Lnet/minecraft/unmapped/C_yknpgzdr;
 	METHOD m_ruodywwf getGameRules ()Lnet/minecraft/unmapped/C_xmldumst;
 	METHOD m_vzluryjf setDifficulty (Lnet/minecraft/unmapped/C_mpbjgxic;)V
 		ARG 1 difficulty

--- a/mappings/net/minecraft/world/WorldView.mapping
+++ b/mappings/net/minecraft/world/WorldView.mapping
@@ -47,6 +47,7 @@ CLASS net/minecraft/unmapped/C_eemzphbi net/minecraft/world/WorldView
 	METHOD m_lhpibwaq getChunk (II)Lnet/minecraft/unmapped/C_lwzmmmqr;
 		ARG 1 chunkX
 		ARG 2 chunkZ
+	METHOD m_mttajusw enabledFlags ()Lnet/minecraft/unmapped/C_czxxrbcp;
 	METHOD m_naecjaeg getChunk (IILnet/minecraft/unmapped/C_kogtzhzt;)Lnet/minecraft/unmapped/C_lwzmmmqr;
 		ARG 1 chunkX
 		ARG 2 chunkZ
@@ -56,6 +57,7 @@ CLASS net/minecraft/unmapped/C_eemzphbi net/minecraft/world/WorldView
 		ARG 2 max
 	METHOD m_ogigqbxw getLightLevel (Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 pos
+	METHOD m_ozgszpob filteredLookup (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_vtbxyypo;
 	METHOD m_qdcvrgsy getBrightness (Lnet/minecraft/unmapped/C_hynzadkk;)F
 		ARG 1 pos
 	METHOD m_ucheokld isSkyVisibleAllowingSea (Lnet/minecraft/unmapped/C_hynzadkk;)Z
@@ -74,6 +76,7 @@ CLASS net/minecraft/unmapped/C_eemzphbi net/minecraft/world/WorldView
 		ARG 1 biomeX
 		ARG 2 biomeY
 		ARG 3 biomeZ
+	METHOD m_zmumzdjx getRegistryManager ()Lnet/minecraft/unmapped/C_wqxmvzdq;
 	METHOD m_ztjkuhbv getTopY (Lnet/minecraft/unmapped/C_ybztoekc$C_wkdeqzbn;II)I
 		ARG 1 heightmap
 		ARG 2 x

--- a/mappings/net/minecraft/world/level/LevelInfo.mapping
+++ b/mappings/net/minecraft/world/level/LevelInfo.mapping
@@ -1,19 +1,32 @@
 CLASS net/minecraft/unmapped/C_tmnkpzlg net/minecraft/world/level/LevelInfo
 	FIELD f_dczuebzs hardcore Z
+	FIELD f_eptdpwdn featureAndDataSettings Lnet/minecraft/unmapped/C_yknpgzdr;
 	FIELD f_ggtamjbh allowCommands Z
 	FIELD f_grufxcps name Ljava/lang/String;
 	FIELD f_mroyqsfx gameMode Lnet/minecraft/unmapped/C_lghcpyvl;
 	FIELD f_mynxrmyp gameRules Lnet/minecraft/unmapped/C_xmldumst;
 	FIELD f_ylkkcrgx difficulty Lnet/minecraft/unmapped/C_mpbjgxic;
+	METHOD <init> (Ljava/lang/String;Lnet/minecraft/unmapped/C_lghcpyvl;ZLnet/minecraft/unmapped/C_mpbjgxic;ZLnet/minecraft/unmapped/C_xmldumst;Lnet/minecraft/unmapped/C_yknpgzdr;)V
+		ARG 1 name
+		ARG 2 gameMode
+		ARG 3 hardcodre
+		ARG 4 difficulty
+		ARG 5 allowCommands
+		ARG 6 gameRules
+		ARG 7 featureAndDataSettings
 	METHOD m_ackskuhh getDifficulty ()Lnet/minecraft/unmapped/C_mpbjgxic;
 	METHOD m_cqmszqoo withDifficulty (Lnet/minecraft/unmapped/C_mpbjgxic;)Lnet/minecraft/unmapped/C_tmnkpzlg;
 		ARG 1 difficulty
+	METHOD m_ivrndkyz getFeatureAndDataSettings ()Lnet/minecraft/unmapped/C_yknpgzdr;
 	METHOD m_nwnowglu isHardcore ()Z
 	METHOD m_phhrrlya getLevelName ()Ljava/lang/String;
 	METHOD m_qbubrzxc getGameRules ()Lnet/minecraft/unmapped/C_xmldumst;
 	METHOD m_tbeonhhz getGameMode ()Lnet/minecraft/unmapped/C_lghcpyvl;
 	METHOD m_vscahehr withCopiedGameRules ()Lnet/minecraft/unmapped/C_tmnkpzlg;
 	METHOD m_xvkjdzrm areCommandsAllowed ()Z
+	METHOD m_zexmvkbz withFeatureAndDataSettings (Lnet/minecraft/unmapped/C_yknpgzdr;)Lnet/minecraft/unmapped/C_tmnkpzlg;
+		ARG 1 settings
+	METHOD m_zgjsltvf fromDynamic (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/unmapped/C_yknpgzdr;)Lnet/minecraft/unmapped/C_tmnkpzlg;
+		ARG 1 featureAndDataSettings
 	METHOD m_zkhyjhyf withGameMode (Lnet/minecraft/unmapped/C_lghcpyvl;)Lnet/minecraft/unmapped/C_tmnkpzlg;
 		ARG 1 mode
-	METHOD m_zgjsltvf fromDynamic (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/unmapped/C_yknpgzdr;)Lnet/minecraft/unmapped/C_tmnkpzlg;


### PR DESCRIPTION
Maps feature flag related code - `FeatureFlag`, `FeatureFlagBitSet`, `FeatureGroup`, and friends. Also maps the sync packet, a number of usages of feature flags, and some creative tab code that interacts with them.

Marking as draft because I'm not confident in some names (like `FeatureFlagBitSet`) and because the creative tab mappings might be unnecessary for this PR.