### PR TITLE
restore playSound mapping in World

### DIFF
--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -48,6 +48,12 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 1 pos
 		ARG 2 entity
 		ARG 3 direction
+	METHOD m_cibeiktq playSound (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_pqzizukq;FF)V
+		ARG 1 entity
+		ARG 3 sound
+		ARG 4 category
+		ARG 5 volume
+		ARG 6 pitch
 	METHOD m_cnpexxbj setLightningTicksLeft (I)V
 		ARG 1 lightningTicksLeft
 	METHOD m_cosjeaoq isEmittingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -29,6 +29,12 @@ CLASS net/minecraft/unmapped/C_vdvbsyle net/minecraft/world/WorldAccess
 		ARG 2 eventId
 		ARG 3 pos
 		ARG 4 data
+	METHOD m_ktoxvfib playSound (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_pqzizukq;FF)V
+		ARG 1 player
+		ARG 3 sound
+		ARG 4 category
+		ARG 5 volume
+		ARG 6 pitch
 	METHOD m_lfhqrehv createTick (Lnet/minecraft/unmapped/C_hynzadkk;Ljava/lang/Object;I)Lnet/minecraft/unmapped/C_bokjrzyn;
 		ARG 1 pos
 		ARG 2 type


### PR DESCRIPTION
the `playSound` mapping in `World` was lost with 22w42a, this pull request returns it
note: I might make a more extensive pull request for the `World` class in the future, as it now has a lot of unmapped fields and methods