### PR TITLE
Rename `ConditionalOverlayOwner` to `EnergySwirlOwner`

### DIFF
--- a/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/ConditionalOverlayOwner.mapping
@@ -1,8 +1,0 @@
-CLASS net/minecraft/unmapped/C_gwgaryan net/minecraft/client/render/entity/feature/ConditionalOverlayOwner
-	METHOD m_hdnslihu isOverlayConditionMet ()Z
-		COMMENT Returns whenever the entity's condition has been met to render its overlay.
-		COMMENT
-		COMMENT <p>This method is present on the server but without implementing this client-sided interface,
-		COMMENT and may be used in the overlay owner's internal logic in order to get the condition state.
-		COMMENT
-		COMMENT @return {@code true} if the condition behind overlay rendering is met, or {@code false} otherwise

--- a/mappings/net/minecraft/client/render/entity/feature/EnergySwirlOwner.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/EnergySwirlOwner.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_gwgaryan net/minecraft/client/render/entity/feature/EnergySwirlOwner
+	METHOD m_hdnslihu isEnergySwirlActive ()Z
+		COMMENT {@return {@code true} if the entity's entity swirl is active, or {@code false} otherwise}
+		COMMENT <p>
+		COMMENT Examples of energy swirl owners include (charged) creepers and (armored) withers.
+		COMMENT
+		COMMENT @see net.minecraft.client.render.entity.feature.EnergySwirlOverlayFeatureRenderer


### PR DESCRIPTION
Fixes #247 by narrowing down the pretty generic name into the one that reflects Mojang's intentions. This is prompted by the inclusion of it on the server-side as well;

The outdated javadoc has also been updated in order to reflect this change