### PR TITLE
GenerationSettings mappings

### DIFF
--- a/mappings/net/minecraft/world/biome/GenerationSettings.mapping
+++ b/mappings/net/minecraft/world/biome/GenerationSettings.mapping
@@ -26,5 +26,27 @@ CLASS net/minecraft/unmapped/C_qbjpvmph net/minecraft/world/biome/GenerationSett
 	METHOD m_yztnozcz (Lnet/minecraft/unmapped/C_qbjpvmph;)Ljava/util/Map;
 		ARG 0 settings
 	CLASS C_bwxzcdhs Builder
+		FIELD f_agwsfyrx features Lnet/minecraft/unmapped/C_pzdchrcy;
+		FIELD f_tfsvocsj carvers Lnet/minecraft/unmapped/C_pzdchrcy;
+		METHOD <init> (Lnet/minecraft/unmapped/C_pzdchrcy;Lnet/minecraft/unmapped/C_pzdchrcy;)V
+			ARG 1 features
+			ARG 2 carvers
 		METHOD m_jtwrhufd carver (Lnet/minecraft/unmapped/C_rdrmebyw$C_smrpgmrn;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_qbjpvmph$C_bwxzcdhs;
 			ARG 1 carverStep
+		METHOD m_qhxraujc feature (Lnet/minecraft/unmapped/C_rdrmebyw$C_eibovkzt;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_qbjpvmph$C_bwxzcdhs;
+			ARG 1 featureStep
+	CLASS C_thdznmut PlainBuilder
+		FIELD f_butdfpqn features Ljava/util/List;
+		FIELD f_efnbqovo carvers Ljava/util/Map;
+		METHOD m_bkbvlpsc feature (ILnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_qbjpvmph$C_thdznmut;
+			ARG 1 ordinal
+			ARG 2 feature
+		METHOD m_iabqmqxj addFeatureStepsTo (I)V
+			ARG 1 ordinal
+		METHOD m_lgyxrfpk feature (Lnet/minecraft/unmapped/C_rdrmebyw$C_eibovkzt;Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_qbjpvmph$C_thdznmut;
+			ARG 1 featureStep
+			ARG 2 feature
+		METHOD m_vmphwdbx build ()Lnet/minecraft/unmapped/C_qbjpvmph;
+		METHOD m_xiktqhbo carver (Lnet/minecraft/unmapped/C_rdrmebyw$C_smrpgmrn;Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_qbjpvmph$C_thdznmut;
+			ARG 1 carverStep
+			ARG 2 carver


### PR DESCRIPTION
Due to a bug in something involving remapping, this PR is **required** for QSL 1.19.3.

`PlainBuilder` is just `Builder` but for situations when you don't have access to HolderProviders for features and carvers. I dont like the name but I dont have any better ideas either.