### PR TITLE
map VariantProvider and clean up variant <-> type distinction

### DIFF
--- a/mappings/net/minecraft/client/render/entity/BoatEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BoatEntityRenderer.mapping
@@ -4,13 +4,13 @@ CLASS net/minecraft/unmapped/C_gkybhjrd net/minecraft/client/render/entity/BoatE
 		ARG 1 context
 		ARG 2 isChest
 	METHOD m_hotljizv getTexture (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;Z)Ljava/lang/String;
-		ARG 0 type
+		ARG 0 variant
 		ARG 1 isChest
 	METHOD m_mzsflpas getModel (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;Z)Lnet/minecraft/unmapped/C_ejjaplya;
 		ARG 1 context
-		ARG 2 type
+		ARG 2 variant
 		ARG 3 isChest
 	METHOD m_qcfeiacg (ZLnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lcom/mojang/datafixers/util/Pair;
-		ARG 3 type
+		ARG 3 variant
 	METHOD m_roieycfi (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
-		ARG 0 boatType
+		ARG 0 boatVariant

--- a/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
@@ -44,14 +44,16 @@ CLASS net/minecraft/unmapped/C_ikhmhinf net/minecraft/client/render/entity/model
 	FIELD f_yckzdcej WITHER_SKELETON_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_yoielsqn ARMOR_STAND_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_zbcxjqdc PLAYER_SLIM_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
+	METHOD m_eeaxgaqc createRaft (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lnet/minecraft/unmapped/C_rghfgwax;
+		ARG 0 variant
 	METHOD m_ilopctbx createOuterArmor (Ljava/lang/String;)Lnet/minecraft/unmapped/C_rghfgwax;
 		ARG 0 id
 	METHOD m_mtvgvqdw createChestBoat (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lnet/minecraft/unmapped/C_rghfgwax;
-		ARG 0 type
+		ARG 0 variant
 	METHOD m_ndqspgdp registerMain (Ljava/lang/String;)Lnet/minecraft/unmapped/C_rghfgwax;
 		ARG 0 id
 	METHOD m_nzrcywgy createBoat (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lnet/minecraft/unmapped/C_rghfgwax;
-		ARG 0 type
+		ARG 0 variant
 	METHOD m_qkfhnizl createHangingSign (Lnet/minecraft/unmapped/C_xlaykyai;)Lnet/minecraft/unmapped/C_rghfgwax;
 		ARG 0 type
 	METHOD m_tespmniz getLayers ()Ljava/util/stream/Stream;
@@ -65,3 +67,5 @@ CLASS net/minecraft/unmapped/C_ikhmhinf net/minecraft/client/render/entity/model
 	METHOD m_wknrqjjy register (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_rghfgwax;
 		ARG 0 id
 		ARG 1 layer
+	METHOD m_zzwzzxue createChestRaft (Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;)Lnet/minecraft/unmapped/C_rghfgwax;
+		ARG 0 variant

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -115,7 +115,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_zesrveqd pitch F
 	FIELD f_zntizrau AIR Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_cdctfzbn;)V
-		ARG 1 type
+		ARG 1 variant
 		ARG 2 world
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/entity/VariantProvider.mapping
+++ b/mappings/net/minecraft/entity/VariantProvider.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/unmapped/C_wqfchtuq net/minecraft/entity/VariantProvider
 	METHOD m_bpcmxtop getVariant ()Ljava/lang/Object;
 	METHOD m_ysfktfkp setVariant (Ljava/lang/Object;)V
-		ARG 1 type
+		ARG 1 variant

--- a/mappings/net/minecraft/entity/VariantProvider.mapping
+++ b/mappings/net/minecraft/entity/VariantProvider.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_wqfchtuq net/minecraft/entity/VariantProvider
+	METHOD m_bpcmxtop getVariant ()Ljava/lang/Object;
+	METHOD m_ysfktfkp setVariant (Ljava/lang/Object;)V
+		ARG 1 type

--- a/mappings/net/minecraft/entity/passive/AxolotlEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AxolotlEntity.mapping
@@ -83,19 +83,23 @@ CLASS net/minecraft/unmapped/C_dkiorddu net/minecraft/entity/passive/AxolotlEnti
 			ARG 3 maxYawDifference
 	CLASS C_wibhmvyi Variant
 		FIELD f_bsgarvwt id I
-		FIELD f_hxixfkzl name Ljava/lang/String;
+		FIELD f_hxixfkzl key Ljava/lang/String;
 		FIELD f_ujjymvcq VARIANTS Ljava/util/function/IntFunction;
 		FIELD f_ykasltgf natural Z
 		METHOD <init> (Ljava/lang/String;IILjava/lang/String;Z)V
 			ARG 3 id
-			ARG 4 name
+			ARG 4 key
 			ARG 5 natural
 		METHOD m_biatcobk getRandomNatural (Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_dkiorddu$C_wibhmvyi;
 			ARG 0 random
-		METHOD m_mfptbgae getId ()I
+		METHOD m_dgvlsyym get (I)Lnet/minecraft/unmapped/C_dkiorddu$C_wibhmvyi;
+			ARG 0 id
+		METHOD m_khmanwnl (ZLnet/minecraft/unmapped/C_dkiorddu$C_wibhmvyi;)Z
+			ARG 1 variant
+		METHOD m_mfptbgae id ()I
 		METHOD m_rccogdrt getRandom (Lnet/minecraft/unmapped/C_rlomrsco;Z)Lnet/minecraft/unmapped/C_dkiorddu$C_wibhmvyi;
 			ARG 0 random
 			ARG 1 natural
-		METHOD m_tvtpucta getName ()Ljava/lang/String;
+		METHOD m_tvtpucta key ()Ljava/lang/String;
 		METHOD m_wnfsspzw getRandomUnnatural (Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_dkiorddu$C_wibhmvyi;
 			ARG 0 random

--- a/mappings/net/minecraft/entity/passive/CatVariant.mapping
+++ b/mappings/net/minecraft/entity/passive/CatVariant.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_jpfecwuz net/minecraft/entity/passive/CatType
+CLASS net/minecraft/unmapped/C_jpfecwuz net/minecraft/entity/passive/CatVariant
 	METHOD m_dudxidne register (Lnet/minecraft/unmapped/C_tqxyjqsk;Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/String;)Lnet/minecraft/unmapped/C_jpfecwuz;
 		ARG 2 id
 	METHOD m_uciodmnu register (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;

--- a/mappings/net/minecraft/entity/passive/FoxEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FoxEntity.mapping
@@ -153,16 +153,21 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 	CLASS C_oqqulucz MateGoal
 		METHOD <init> (Lnet/minecraft/unmapped/C_axinhusn;D)V
 			ARG 2 chance
-	CLASS C_qecgztkz Type
+	CLASS C_qecgztkz Variant
 		FIELD f_bxpylffo id I
-		FIELD f_kbrphrzk TYPES Ljava/util/function/IntFunction;
+		FIELD f_kbrphrzk VARIANTS Ljava/util/function/IntFunction;
+		FIELD f_nominicp CODEC Lnet/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc;
 		FIELD f_urgveasv key Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+			ARG 3 id
+			ARG 4 key
 		METHOD m_ctthuzef byName (Ljava/lang/String;)Lnet/minecraft/unmapped/C_axinhusn$C_qecgztkz;
 			ARG 0 name
 		METHOD m_ewvkjtwd getId ()I
-		METHOD m_tjiyhbmu fromId (I)Lnet/minecraft/unmapped/C_axinhusn$C_qecgztkz;
+		METHOD m_tjiyhbmu get (I)Lnet/minecraft/unmapped/C_axinhusn$C_qecgztkz;
 			ARG 0 id
 		METHOD m_xpfnsyaf fromBiome (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_axinhusn$C_qecgztkz;
+			ARG 0 biome
 	CLASS C_qzrtkgez AttackGoal
 		METHOD <init> (Lnet/minecraft/unmapped/C_axinhusn;DZ)V
 			ARG 2 speed

--- a/mappings/net/minecraft/entity/passive/FrogEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FrogEntity.mapping
@@ -20,6 +20,9 @@ CLASS net/minecraft/unmapped/C_gcfircge net/minecraft/entity/passive/FrogEntity
 	METHOD m_lfkqipai setTargetEntity (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 entity
 	METHOD m_tqkfedkt isNotSwimming ()Z
+	METHOD m_yoqmukqg canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_uzzvxofv;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
+		ARG 0 entity
+		ARG 1 world
 	METHOD m_ypwnwidu isSwimming ()Z
 	CLASS C_ioluwgbh SwimNavigation
 		METHOD <init> (Lnet/minecraft/unmapped/C_gcfircge;Lnet/minecraft/unmapped/C_cdctfzbn;)V

--- a/mappings/net/minecraft/entity/passive/FrogVariant.mapping
+++ b/mappings/net/minecraft/entity/passive/FrogVariant.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_idxitzip net/minecraft/entity/passive/FrogType
+CLASS net/minecraft/unmapped/C_idxitzip net/minecraft/entity/passive/FrogVariant
 	FIELD f_cqaiamli id Lnet/minecraft/unmapped/C_ncpywfca;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ncpywfca;)V
 		ARG 1 id

--- a/mappings/net/minecraft/entity/passive/HorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HorseEntity.mapping
@@ -5,10 +5,10 @@ CLASS net/minecraft/unmapped/C_icbcebrx net/minecraft/entity/passive/HorseEntity
 		ARG 1 stack
 	METHOD m_fzatswvw setArmorTypeFromStack (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 stack
-	METHOD m_inoilhbe getVariant ()I
+	METHOD m_inoilhbe getHorseVariant ()I
 	METHOD m_olfxlvbq getArmorType ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_tjdewkmt getMarking ()Lnet/minecraft/unmapped/C_izltrckh;
-	METHOD m_xrmvcocl setVariant (I)V
+	METHOD m_xrmvcocl setHorseVariant (I)V
 		ARG 1 variant
 	METHOD m_zlkerelq setVariant (Lnet/minecraft/unmapped/C_pftaultf;Lnet/minecraft/unmapped/C_izltrckh;)V
 		ARG 1 color

--- a/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
@@ -28,6 +28,16 @@ CLASS net/minecraft/unmapped/C_jzrmkmyj net/minecraft/entity/passive/LlamaEntity
 	METHOD m_xockexqj follow (Lnet/minecraft/unmapped/C_jzrmkmyj;)V
 		ARG 1 llama
 	METHOD m_ziuntool hasFollower ()Z
+	CLASS C_bamxtdwv Variant
+		FIELD f_awosmvfj key Ljava/lang/String;
+		FIELD f_hjcijjth id I
+		FIELD f_qfglbuhf VARIANTS Ljava/util/function/IntFunction;
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+			ARG 3 id
+			ARG 4 key
+		METHOD m_rxkqawos get (I)Lnet/minecraft/unmapped/C_jzrmkmyj$C_bamxtdwv;
+			ARG 0 id
+		METHOD m_tgezfyjh id ()I
 	CLASS C_bmfhutoq ChaseWolvesGoal
 		METHOD <init> (Lnet/minecraft/unmapped/C_jzrmkmyj;)V
 			ARG 1 llama
@@ -35,6 +45,8 @@ CLASS net/minecraft/unmapped/C_jzrmkmyj net/minecraft/entity/passive/LlamaEntity
 			ARG 0 wolf
 	CLASS C_gofecpda LlamaData
 		FIELD f_yptbfzgb variant Lnet/minecraft/unmapped/C_jzrmkmyj$C_bamxtdwv;
+		METHOD <init> (Lnet/minecraft/unmapped/C_jzrmkmyj$C_bamxtdwv;)V
+			ARG 1 variant
 	CLASS C_nlxqeqaw SpitRevengeGoal
 		METHOD <init> (Lnet/minecraft/unmapped/C_jzrmkmyj;)V
 			ARG 1 llama

--- a/mappings/net/minecraft/entity/passive/MooshroomEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/MooshroomEntity.mapping
@@ -15,12 +15,13 @@ CLASS net/minecraft/unmapped/C_keggniig net/minecraft/entity/passive/MooshroomEn
 		ARG 1 world
 		ARG 2 spawnReason
 		ARG 3 pos
-	CLASS C_awkufnzt Type
+	CLASS C_awkufnzt Variant
 		FIELD f_cscdcfys mushroom Lnet/minecraft/unmapped/C_txtbiemp;
-		FIELD f_wwovdoct name Ljava/lang/String;
+		FIELD f_wopocyvh CODEC Lnet/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc;
+		FIELD f_wwovdoct key Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/unmapped/C_txtbiemp;)V
-			ARG 3 name
+			ARG 3 key
 			ARG 4 mushroom
-		METHOD m_ceufbtvl fromName (Ljava/lang/String;)Lnet/minecraft/unmapped/C_keggniig$C_awkufnzt;
+		METHOD m_ceufbtvl get (Ljava/lang/String;)Lnet/minecraft/unmapped/C_keggniig$C_awkufnzt;
 			ARG 0 name
 		METHOD m_vdbfohdx getMushroomState ()Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
@@ -33,5 +33,15 @@ CLASS net/minecraft/unmapped/C_ombdzkxc net/minecraft/entity/passive/ParrotEntit
 	CLASS C_otwutkqf
 		METHOD test test (Ljava/lang/Object;)Z
 			ARG 1 entity
+	CLASS C_vrrzomrk Variant
+		FIELD f_ionelagg VARIANTS Ljava/util/function/IntFunction;
+		FIELD f_lyjclikp key Ljava/lang/String;
+		FIELD f_plgymzwe id I
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+			ARG 3 id
+			ARG 4 key
+		METHOD m_jquwagcv get (I)Lnet/minecraft/unmapped/C_ombdzkxc$C_vrrzomrk;
+			ARG 0 id
+		METHOD m_mhaphmct id ()I
 	CLASS C_zeiqwbga ParrotWanderGoal
 		METHOD m_ablbecac getTreePos ()Lnet/minecraft/unmapped/C_vgpupfxx;

--- a/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
@@ -33,6 +33,8 @@ CLASS net/minecraft/unmapped/C_zejlzfny net/minecraft/entity/passive/RabbitEntit
 		ARG 1 world
 		ARG 2 spawnReason
 		ARG 3 pos
+	METHOD m_texxbhbe getRandomVariant (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zejlzfny$C_hyrbilka;
+		ARG 0 world
 	METHOD m_wngbocei setSpeed (D)V
 		ARG 1 speed
 	METHOD m_yzlxckwh getJumpSound ()Lnet/minecraft/unmapped/C_avavozay;
@@ -48,6 +50,16 @@ CLASS net/minecraft/unmapped/C_zejlzfny net/minecraft/entity/passive/RabbitEntit
 	CLASS C_bvvmvikj RabbitAttackGoal
 		METHOD <init> (Lnet/minecraft/unmapped/C_zejlzfny;)V
 			ARG 1 rabbit
+	CLASS C_hyrbilka Variant
+		FIELD f_jvhahmvu id I
+		FIELD f_smlixbbp key Ljava/lang/String;
+		FIELD f_zavpujzk VARIANTS Ljava/util/function/IntFunction;
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+			ARG 3 id
+			ARG 4 key
+		METHOD m_ioegbnty id ()I
+		METHOD m_lkrovrna get (I)Lnet/minecraft/unmapped/C_zejlzfny$C_hyrbilka;
+			ARG 0 id
 	CLASS C_jhwsykew EatCarrotCropGoal
 		FIELD f_iniddatz rabbit Lnet/minecraft/unmapped/C_zejlzfny;
 		FIELD f_swoqfjot hasTarget Z
@@ -68,6 +80,9 @@ CLASS net/minecraft/unmapped/C_zejlzfny net/minecraft/entity/passive/RabbitEntit
 		METHOD <init> (Lnet/minecraft/unmapped/C_zejlzfny;)V
 			ARG 1 owner
 	CLASS C_pirlsltk RabbitData
+		FIELD f_wwjtgasj variant Lnet/minecraft/unmapped/C_zejlzfny$C_hyrbilka;
+		METHOD <init> (Lnet/minecraft/unmapped/C_zejlzfny$C_hyrbilka;)V
+			ARG 1 variant
 	CLASS C_sjooogbf EscapeDangerGoal
 		FIELD f_rayxprhj rabbit Lnet/minecraft/unmapped/C_zejlzfny;
 		METHOD <init> (Lnet/minecraft/unmapped/C_zejlzfny;D)V

--- a/mappings/net/minecraft/entity/passive/TropicalFishEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TropicalFishEntity.mapping
@@ -5,10 +5,47 @@ CLASS net/minecraft/unmapped/C_mibzatdf net/minecraft/entity/passive/TropicalFis
 	FIELD f_xklcvktr BUCKET_VARIANT_TAG_KEY Ljava/lang/String;
 	METHOD m_bfgtpcox getToolTipForVariant (I)Ljava/lang/String;
 		ARG 0 variant
+	METHOD m_chlqwazt getVariantId ()I
+	METHOD m_dcanqpbj getBaseDyeColor ()Lnet/minecraft/unmapped/C_arllgqae;
+	METHOD m_emmjtynz getVariety (I)Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;
+		ARG 0 id
 	METHOD m_itvxyiwa getPatternDyeColor (I)Lnet/minecraft/unmapped/C_arllgqae;
 		ARG 0 variant
+	METHOD m_jhctuwse canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_uzzvxofv;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
+		ARG 0 type
+		ARG 1 world
 	METHOD m_mudywnov getBaseDyeColor (I)Lnet/minecraft/unmapped/C_arllgqae;
 		ARG 0 variant
+	METHOD m_tvhtfvrn getVariantIndex (Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;Lnet/minecraft/unmapped/C_arllgqae;Lnet/minecraft/unmapped/C_arllgqae;)I
+		ARG 0 variety
+		ARG 1 baseColor
+		ARG 2 patternColor
+	METHOD m_ugwtjmcb setVariantId (I)V
+		ARG 1 id
+	METHOD m_vbwibvxz getPatternDyeColor ()Lnet/minecraft/unmapped/C_arllgqae;
 	CLASS C_gdvfbafo Variety
+		FIELD f_bmdqbrvq text Lnet/minecraft/unmapped/C_rdaqiwdt;
+		FIELD f_eqtyyhhi key Ljava/lang/String;
+		FIELD f_hkbsdtuw id I
+		FIELD f_hlhtwwca VARIANTS Ljava/util/function/IntFunction;
 		FIELD f_wvmnoemd shape Lnet/minecraft/unmapped/C_mibzatdf$C_uoceamap;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/unmapped/C_mibzatdf$C_uoceamap;I)V
+			ARG 3 key
+			ARG 4 shape
+			ARG 5 sizedId
+		METHOD m_kvolmjcx id ()I
+		METHOD m_mwralrkv shape ()Lnet/minecraft/unmapped/C_mibzatdf$C_uoceamap;
+		METHOD m_sifvfqmy text ()Lnet/minecraft/unmapped/C_rdaqiwdt;
+		METHOD m_spwmhkjl get (I)Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;
+			ARG 0 id
+	CLASS C_kcnhsswx Variant
+		METHOD m_rjaxxoub index ()I
+	CLASS C_uoceamap Shape
+		FIELD f_bzskkewp id I
+		METHOD <init> (Ljava/lang/String;II)V
+			ARG 3 id
 	CLASS C_vhwuuxij TropicalFishData
+		FIELD f_mqkcgcer variant Lnet/minecraft/unmapped/C_mibzatdf$C_kcnhsswx;
+		METHOD <init> (Lnet/minecraft/unmapped/C_mibzatdf;Lnet/minecraft/unmapped/C_mibzatdf$C_kcnhsswx;)V
+			ARG 1 entity
+			ARG 2 variant

--- a/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
@@ -90,16 +90,18 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 	METHOD m_xwvweinm checkLocation ()Lnet/minecraft/unmapped/C_mpfuowct$C_tdpqooxn;
 	METHOD m_zrotxegv asItem ()Lnet/minecraft/unmapped/C_vorddnax;
 	METHOD m_ztgkeriq getDamageWobbleSide ()I
-	CLASS C_jyahrrif Type
-		FIELD f_vbzpbykb name Ljava/lang/String;
+	CLASS C_jyahrrif Variant
+		FIELD f_haecscok CODEC Lnet/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc;
+		FIELD f_vbzpbykb key Ljava/lang/String;
+		FIELD f_whmsayxx VARIANTS Ljava/util/function/IntFunction;
 		FIELD f_zesyrhdp baseBlock Lnet/minecraft/unmapped/C_mmxmpdoq;
 		METHOD <init> (Ljava/lang/String;ILnet/minecraft/unmapped/C_mmxmpdoq;Ljava/lang/String;)V
 			ARG 3 baseBlock
-			ARG 4 name
-		METHOD m_icoyxmnb getName ()Ljava/lang/String;
-		METHOD m_nujjmmjc getBaseBlock ()Lnet/minecraft/unmapped/C_mmxmpdoq;
-		METHOD m_qbsqgvtg getType (Ljava/lang/String;)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
+			ARG 4 key
+		METHOD m_icoyxmnb key ()Ljava/lang/String;
+		METHOD m_nujjmmjc baseBlock ()Lnet/minecraft/unmapped/C_mmxmpdoq;
+		METHOD m_qbsqgvtg get (Ljava/lang/String;)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
 			ARG 0 name
-		METHOD m_vpilhxjx getType (I)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
+		METHOD m_vpilhxjx get (I)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
 			ARG 0 type
 	CLASS C_tdpqooxn Location

--- a/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 	FIELD f_aehqikwc waterLevel D
 	FIELD f_alxmmeec bubbleWobble F
 	FIELD f_brsrwydq location Lnet/minecraft/unmapped/C_mpfuowct$C_tdpqooxn;
-	FIELD f_bvvqhrku BOAT_TYPE Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_bvvqhrku BOAT_VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_caqrdywi lastBubbleWobble F
 	FIELD f_cqovsjfd pressingLeft Z
 	FIELD f_cswmhrlg pressingBack Z
@@ -103,5 +103,5 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 		METHOD m_qbsqgvtg get (Ljava/lang/String;)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
 			ARG 0 name
 		METHOD m_vpilhxjx get (I)Lnet/minecraft/unmapped/C_mpfuowct$C_jyahrrif;
-			ARG 0 type
+			ARG 0 id
 	CLASS C_tdpqooxn Location

--- a/mappings/net/minecraft/registry/BuiltinRegistries.mapping
+++ b/mappings/net/minecraft/registry/BuiltinRegistries.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/unmapped/C_nusqeapl net/minecraft/registry/BuiltinRegistries
 	FIELD f_dzikfapz VILLAGER_PROFESSION Lnet/minecraft/unmapped/C_zogerkic;
 	FIELD f_ecfhfzpk SENSOR_TYPE Lnet/minecraft/unmapped/C_zogerkic;
 	FIELD f_efqqjcay BLOCK Lnet/minecraft/unmapped/C_zogerkic;
-	FIELD f_evwusxvi CAT_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
+	FIELD f_evwusxvi CAT_VARIANT Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_gicfyjuu ENTITY_TYPE Lnet/minecraft/unmapped/C_zogerkic;
 	FIELD f_gmdysfqt ENCHANTMENT Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_gruwefbj HEIGHT_PROVIDER_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
@@ -42,13 +42,13 @@ CLASS net/minecraft/unmapped/C_nusqeapl net/minecraft/registry/BuiltinRegistries
 	FIELD f_oktgdyzx BIOME_SOURCE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_oopkwqqu SCHEDULE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_oszjuuhn REGISTRY Lnet/minecraft/unmapped/C_tqxyjqsk;
-	FIELD f_pnbggpct PAINTING_TYPE Lnet/minecraft/unmapped/C_zogerkic;
+	FIELD f_pnbggpct PAINTING_VARIANT Lnet/minecraft/unmapped/C_zogerkic;
 	FIELD f_ppdhawvx LOOT_POOL_ENTRY_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_pvltkylp LOADERS Ljava/util/Map;
 	FIELD f_qddxgoam CARVER_WORLDGEN Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_qiyhrbuq SOUND_EVENT Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_rfgveamu FLUID Lnet/minecraft/unmapped/C_zogerkic;
-	FIELD f_rgwwkrrw FROG_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
+	FIELD f_rgwwkrrw FROG_VARIANT Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_sjckywau PARTICLE_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_sxlapuzz TREE_DECORATOR_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_titdfptp SCREEN_HANDLER_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;

--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -24,13 +24,13 @@ CLASS net/minecraft/unmapped/C_msgswxvc net/minecraft/registry/Registries
 	FIELD f_iwtrllds BLOCK Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_jjrdwfmf MATERIAL_RULE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_jkejtpbg LOOT_NBT_PROVIDER_TYPE Lnet/minecraft/unmapped/C_xhhleach;
-	FIELD f_jyiseabr FROG_TYPE Lnet/minecraft/unmapped/C_xhhleach;
+	FIELD f_jyiseabr FROG_VARIANT Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_kbqrdovi DENSITY_FUNCTION Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_kghxptnh POS_RULE_TEST_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_khmqfvbz LOOT_FUNCTION_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_kileutlg RULE_TEST_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_kmbjptzz DIMENSION_TYPE Lnet/minecraft/unmapped/C_xhhleach;
-	FIELD f_kmiixefd CAT_TYPE Lnet/minecraft/unmapped/C_xhhleach;
+	FIELD f_kmiixefd CAT_VARIANT Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_lhdmpois FOLIAGE_PLACER_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_lhjabeiq DENSITY_FUNCTION_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_loitxqmx SENSOR_TYPE Lnet/minecraft/unmapped/C_xhhleach;
@@ -63,7 +63,7 @@ CLASS net/minecraft/unmapped/C_msgswxvc net/minecraft/registry/Registries
 	FIELD f_skgskmpg STRUCTURE_FEATURE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_sowxagta RECIPE_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_syizfxro STRUCTURE_SET Lnet/minecraft/unmapped/C_xhhleach;
-	FIELD f_tafonlwq PAINTING_TYPE Lnet/minecraft/unmapped/C_xhhleach;
+	FIELD f_tafonlwq PAINTING_VARIANT Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_trwzeuus DIMENSION Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_ttfybole LOOT_SCORE_PROVIDER_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_vuklbmqc STRUCTURE_PROCESSOR_LIST Lnet/minecraft/unmapped/C_xhhleach;


### PR DESCRIPTION
the sequel to the sadly deceased #279 
this pr gives up on having a convention and simply accepts mojang's `variant` name, since the new interface-based structure makes it impossible to have a clear distinction between variants and types