### PR TITLE
fix toInitialChunkDataNbt() mapping

### DIFF
--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -21,11 +21,11 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 	METHOD m_dfzdncts readNbt (Lnet/minecraft/unmapped/C_hhlwcnih;)V
 		ARG 1 nbt
 	METHOD m_dzrbmfhv toIdentifiedNbt ()Lnet/minecraft/unmapped/C_hhlwcnih;
-	METHOD m_escrnqip toInitialChunkDataNbt ()Lnet/minecraft/unmapped/C_hhlwcnih;
+	METHOD m_escrnqip toSyncedNbt ()Lnet/minecraft/unmapped/C_hhlwcnih;
 		COMMENT Serializes the state of this block entity that is observable by clients.
 		COMMENT It is sent alongside the initial chunk data, as well as when the block
-		COMMENT entity implements {@link #toUpdatePacket} and decides to use the default
-		COMMENT {@link net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket}.
+		COMMENT entity implements {@link #toUpdatePacket} and decides to use the
+		COMMENT shorthand implementation as described in its javadoc.
 	METHOD m_ftinwujz markRemoved ()V
 	METHOD m_ghbzlfof toNbt ()Lnet/minecraft/unmapped/C_hhlwcnih;
 	METHOD m_idcywgkm createFromNbt (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hhlwcnih;)Lnet/minecraft/unmapped/C_kvegafmh;
@@ -47,7 +47,7 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 		COMMENT Implement and return a packet that should be sent to players nearby when the observable state of
 		COMMENT this block entity changes. Return null to not send an update packet.
 		COMMENT <p>
-		COMMENT If the data returned by {@link #toInitialChunkDataNbt initial chunk data} is suitable for updates,
+		COMMENT If the data returned by {@link #toSyncedNbt} is suitable for updates,
 		COMMENT the following shortcut can be used to create an update packet: {@code BlockEntityUpdateS2CPacket.create(this)}.
 		COMMENT <p>
 		COMMENT The NBT will be passed to {@link #readNbt} on the client.


### PR DESCRIPTION
discussed in the discord from https://discord.com/channels/833872081585700874/877319390901706753/1045903651782266920

key points on why we should make this change:
- this is called more often than just sending initial chunk data
- it's used to get block entity data to sync across server and client
- it's only used in networking, so the `toSyncedNbt()` mapping makes sense