### PR TITLE
rename setShader to draw, fixes #238

### DIFF
--- a/mappings/com/mojang/blaze3d/vertex/VertexBuffer.mapping
+++ b/mappings/com/mojang/blaze3d/vertex/VertexBuffer.mapping
@@ -10,9 +10,13 @@ CLASS net/minecraft/unmapped/C_lhjdxjis com/mojang/blaze3d/vertex/VertexBuffer
 	METHOD close close ()V
 	METHOD m_byhiivrh unbind ()V
 	METHOD m_evikmcnb invalid ()Z
-	METHOD m_hhvpgfwa setShader (Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/unmapped/C_alllhitb;)V
+	METHOD m_hhvpgfwa draw (Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/unmapped/C_alllhitb;)V
+		ARG 1 viewMatrix
+		ARG 2 projectionMatrix
 		ARG 3 shader
-	METHOD m_ikpyaonm drawWithShaderInternal (Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/unmapped/C_alllhitb;)V
+	METHOD m_ikpyaonm drawInternal (Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/unmapped/C_alllhitb;)V
+		ARG 1 viewMatrix
+		ARG 2 projectionMatrix
 		ARG 3 shader
 	METHOD m_mefqlhes drawElements ()V
 	METHOD m_nyzeuatd getIndexType ()Lnet/minecraft/unmapped/C_rnldvdpe;


### PR DESCRIPTION
I went with `draw` over `drawWithShader` because the `withShader` is implied through parameters. Also maps parameters.

notes:
fixes #238 