### PR TITLE
Fix #304

### DIFF
--- a/buildSrc/src/main/java/quilt/internal/tasks/build/AbstractTinyMergeTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/AbstractTinyMergeTask.java
@@ -71,7 +71,7 @@ public abstract class AbstractTinyMergeTask extends DefaultMappingsTask {
 
     @Internal
     protected Map<String, String> getNameAlternatives() {
-        return Collections.singletonMap("named", this.fillName); // Fill unnamed classes with hashed; Needed for remapUnpickDefinitions and possibly other things
+        return Collections.emptyMap();
     }
 
     protected MappingVisitor getFirstVisitor(MappingVisitor next) {


### PR DESCRIPTION
The code I removed said "required by unpick". However, I diffed the `definitions.unpick` from this fork and the `definitions.unpick` from `1.19.3+build.2`, and there were no differences, so something may have changed since this code was written two months ago.