### PR TITLE
fix missing netty javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -321,19 +321,19 @@ javadoc {
 
 		addBooleanOption "-allow-script-in-comments", true
 		links(
-				"https://guava.dev/releases/${libs.versions.guava.get()}/api/docs/",
+				"https://javadoc.io/doc/com.google.guava/guava/${libs.versions.guava.get()}/",
 				"https://javadoc.io/doc/com.google.code.gson/gson/${project.gson}/",
-				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
 				"https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.jetbrains.annotations.get()}/",
 				"https://javadoc.io/doc/com.google.code.findbugs/jsr305/${libs.versions.jsr305.get()}/",
+				"https://javadoc.io/doc/org.apache.commons/commons-compress/${project.commons_compress}/",
+				"https://javadoc.io/doc/io.netty/netty-all/${project.netty}/",
 				'https://javadoc.lwjgl.org/',
+				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
 //				'https://fastutil.di.unimi.it/docs/',
-				"https://netty.io/${project.netty}/api/",
 				"https://commons.apache.org/proper/commons-logging/javadocs/api-release/",
 				"https://commons.apache.org/proper/commons-lang/javadocs/api-release/",
 				"https://commons.apache.org/proper/commons-io/apidocs/",
 				"https://commons.apache.org/proper/commons-codec/archives/${project.commons_codec}/apidocs/",
-				"https://javadoc.io/doc/org.apache.commons/commons-compress/${project.commons_compress}/",
 				"https://maven.fabricmc.net/docs/fabric-loader-${libs.versions.fabric.loader.get()}/",
 				"https://docs.oracle.com/en/java/javase/${project.java}/docs/api/"
 		)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ commons_codec=1.15
 commons_compress=1.21
 gson=2.9.1
 java=17
-netty=4.1
+netty=4.1.68.Final


### PR DESCRIPTION
local girl too lazy to write clever snippet, asked to leave qm prs

changes: 
- move netty and guava to javadoc.io