### PR TITLE
update javadoc draftsman to 1.2.2 -- fix "inconsistent generic signature" warnings

### DIFF
--- a/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerDecompiler.java
+++ b/buildSrc/src/main/java/quilt/internal/decompile/quiltflower/QuiltflowerDecompiler.java
@@ -40,7 +40,6 @@ public class QuiltflowerDecompiler extends AbstractDecompiler implements IByteco
 
         // disable "inconsistent inner class" warning due to spam in the logs
         options.put(IFernflowerPreferences.WARN_INCONSISTENT_INNER_CLASSES, "0");
-        // note: "inconsistent generic signature" warnings should also be suppressed, but that isn't currently option in quiltflower
 
         IFabricJavadocProvider javadocProvider = null;
         if (this.javadocProvider != null) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ tiny_remapper = "0.7.2"
 stitch = "0.6.1"
 unpick = "3.0.2"
 mapping_io = "0.3.0"
-javadoc_draftsman = "1.2.1"
+javadoc_draftsman = "1.2.2"
 
 fabric_loader = "0.14.11"
 jetbrains_annotations = "23.0.0"


### PR DESCRIPTION
thanks to some incredible work from @ByMartrixx, the javadoc jar now generates without decompiler warnings!