### PR TITLE
Fix a wrong method reference in BlockEntity

### DIFF
--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -48,7 +48,8 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 		COMMENT this block entity changes. Return null to not send an update packet.
 		COMMENT <p>
 		COMMENT If the data returned by {@link #toSyncedNbt} is suitable for updates,
-		COMMENT the following shortcut can be used to create an update packet: {@code BlockEntityUpdateS2CPacket.create(this)}.
+		COMMENT the following shortcut can be used to create an update packet:
+		COMMENT {@link net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket#of(BlockEntity) BlockEntityUpdateS2CPacket.of(this)}.
 		COMMENT <p>
 		COMMENT The NBT will be passed to {@link #readNbt} on the client.
 	METHOD m_phlhitmt markDirty ()V


### PR DESCRIPTION
The referenced method was renamed, and wasn't properly linked