### PR TITLE
Fix an inconsistent mojmap method name

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -305,7 +305,8 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 1 name
 	METHOD m_fzshfvfl isSprinting ()Z
 	METHOD m_gavkvalj hasWings ()Z
-	METHOD m_ggpcigyk addDeltaMovement (Lnet/minecraft/unmapped/C_vgpupfxx;)V
+	METHOD m_ggpcigyk addVelocity (Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 1 velocity
 	METHOD m_ghqcprlw onPlayerCollision (Lnet/minecraft/unmapped/C_jzrpycqo;)V
 		ARG 1 player
 	METHOD m_glbnrqjr getFirstPassenger ()Lnet/minecraft/unmapped/C_astfners;


### PR DESCRIPTION
All other methods use `velocity` instead of Mojang's `deltaMovement`