### PR TITLE
Issue #346 - Moved MessageRemovalS2CPacket

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/MessageRemovalS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/MessageRemovalS2CPacket.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_dwdiesmw net/minecraft/packet/s2c/play/MessageRemovalS2CPacket
+CLASS net/minecraft/unmapped/C_dwdiesmw net/minecraft/network/packet/s2c/play/MessageRemovalS2CPacket
 	FIELD f_powtxqow signature Lnet/minecraft/unmapped/C_shphkjbi$C_qiadtssi;
 	METHOD <init> (Lnet/minecraft/unmapped/C_idfydwco;)V
 		ARG 1 buf


### PR DESCRIPTION
MessageRemovalS2CPacket is in the wrong package #346
Moved MessageRemovalS2CPacket to net.minecraft.network.packet.s2c.play.MessageRemovalS2CPacket