### PR TITLE
Backport 323 (`Block loot table generators`) for 1.19.3

### DIFF
--- a/mappings/net/minecraft/data/server/loot_table/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loot_table/BlockLootTableGenerator.mapping
@@ -1,0 +1,134 @@
+CLASS net/minecraft/unmapped/C_qvbzxacb net/minecraft/data/server/loot_table/BlockLootTableGenerator
+	FIELD f_icxaaeib enabledFeatures Lnet/minecraft/unmapped/C_czxxrbcp;
+	FIELD f_inyjghhz LEAVES_STICK_DROP_CHANCES [F
+	FIELD f_llapfzxm LEAVES_SAPLING_DROP_CHANCES [F
+	FIELD f_obaulack WITH_SHEARS Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;
+	FIELD f_pbtagkng WITHOUT_SILK_TOUCH Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;
+	FIELD f_qxvtbsum lootTables Ljava/util/Map;
+	FIELD f_scztoibg explosionResistantItems Ljava/util/Set;
+	FIELD f_tdwqluze WITH_SILK_TOUCH Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;
+	FIELD f_uoxfrmri WITH_SHEARS_OR_SILK_TOUCH Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;
+	FIELD f_ustmwfwz WITHOUT_SHEARS_OR_SILK_TOUCH Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;
+	METHOD <init> (Ljava/util/Set;Lnet/minecraft/unmapped/C_czxxrbcp;)V
+		ARG 1 explosionResistantItems
+		ARG 2 enabledFeatures
+	METHOD m_bnzvpgqo addDropWithSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;)V
+	METHOD m_btqwsjay dropsWithShearsOrSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_rhqekity$C_ygespcrj;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+		ARG 1 alternative
+	METHOD m_buprdvjq candleCakeDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_doejxrqc copperOreDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_fcihpktt shulkerBoxDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_hpsfdeye redstoneOreDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_huwptlyk oakLeavesDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_mmxmpdoq;[F)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 leaves
+		ARG 2 drop
+		ARG 3 chance
+	METHOD m_icjzesrx stemDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vorddnax;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 stem
+		ARG 2 drop
+	METHOD m_imzrkxfh oreDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vorddnax;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 dropWithSilkTouch
+		ARG 2 drop
+	METHOD m_ivwzwdoy singleDrop (Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_iajmfyig;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+		ARG 2 count
+	METHOD m_jbysywuh candleDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_jlqaivfs pottedPlantDrops (Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 plant
+	METHOD m_kfomhbnn applySurvivesExplosionCondition (Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_xlpxhrrl;)Lnet/minecraft/unmapped/C_xlpxhrrl;
+		ARG 1 drop
+		ARG 2 builder
+	METHOD m_kurpjrxc multiFaceBlockDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+		ARG 2 condition
+	METHOD m_lfklkvaa dropsWithShears (Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_llfqgnyd dropsWithSilkTouch (Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_lqojiqvk slabDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_lvjwktnr seagrassDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_mdpyjjrq dropsWithPropertyValue (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vzlztuyw;Ljava/lang/Comparable;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+		ARG 2 property
+		ARG 3 value
+	METHOD m_mkxtlejp generate ()V
+	METHOD m_mqmibism singleDrop (Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_mvgsyhrv mushroomBlockDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 dropWithSilkTouch
+		ARG 2 drop
+	METHOD m_nezujawp tallGrassDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 tallGrass
+		ARG 2 drop
+	METHOD m_nhzkwlcr beeHiveDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_njksnwsr bannerDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_npbtbssh dropsWithShears (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_rhqekity$C_ygespcrj;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+		ARG 1 alternative
+	METHOD m_nwsdiuso addDropWithSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_mmxmpdoq;)V
+	METHOD m_ocoglggc lapisLazuliOreDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_pgjzzrvc leavesDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_mmxmpdoq;[F)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 leaves
+		ARG 2 drop
+		ARG 3 chance
+	METHOD m_pjgvtcdj beeNestDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_psgoknhy addDrop (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_gmbqjnle;)V
+		ARG 2 drop
+	METHOD m_ptdrisyl add (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;)V
+		ARG 2 lootTable
+	METHOD m_pzwbwszi doorDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_qxdwxduz add (Lnet/minecraft/unmapped/C_mmxmpdoq;Ljava/util/function/Function;)V
+		ARG 2 lootTableFunction
+	METHOD m_rjtmxkxc grassDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 dropWithShears
+	METHOD m_rpleggpc addNetherVinesDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_mmxmpdoq;)V
+		ARG 1 vines
+		ARG 2 plant
+	METHOD m_seoyeuaw mangroveLeavesDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 leaves
+	METHOD m_sgdbhupd cropDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vorddnax;Lnet/minecraft/unmapped/C_vorddnax;Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 crop
+		ARG 2 product
+		ARG 3 seeds
+		ARG 4 condition
+	METHOD m_tnhhlied dropsConditionally (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vqkczpuv$C_cjvmpogn;Lnet/minecraft/unmapped/C_rhqekity$C_ygespcrj;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+		ARG 1 condition
+		ARG 2 alternative
+	METHOD m_tzqnvsdr caveVineDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+	METHOD m_uciprkeh applyExplosionDecay (Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_uenkggwx;)Lnet/minecraft/unmapped/C_uenkggwx;
+		ARG 1 drop
+		ARG 2 builder
+	METHOD m_uhfrelnt dropsWithSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+		ARG 2 alternative
+	METHOD m_vwoeavmn dropsWithSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_iajmfyig;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+		ARG 2 alternative
+		ARG 3 alternativeCount
+	METHOD m_wddtzajg addDrop (Lnet/minecraft/unmapped/C_mmxmpdoq;)V
+	METHOD m_wgxgtmrm nameableBlockEntityDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 drop
+	METHOD m_xfxbfttg dropsNothing ()Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+	METHOD m_xsbkmpdj dropsWithSilkTouch (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_rhqekity$C_ygespcrj;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 0 drop
+		ARG 1 alternative
+	METHOD m_xtkqbrpf addPottedPlantDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;)V
+		ARG 1 drop
+	METHOD m_ynjolyvi attachedStemDrops (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vorddnax;)Lnet/minecraft/unmapped/C_inwsuliy$C_daaljsfu;
+		ARG 1 stem
+		ARG 2 drop

--- a/mappings/net/minecraft/data/server/loot_table/LootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loot_table/LootTableGenerator.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/unmapped/C_ujnowvgu net/minecraft/data/server/loot_table/LootTableGenerator
-	METHOD generate (Ljava/util/function/BiConsumer;)V
+	METHOD generate generate (Ljava/util/function/BiConsumer;)V
 		ARG 1 consumer

--- a/mappings/net/minecraft/data/server/loot_table/OneTwentyBlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loot_table/OneTwentyBlockLootTableGenerator.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_vbqmpxrd net/minecraft/data/server/loot_table/OneTwentyBlockLootTableGenerator

--- a/mappings/net/minecraft/data/server/loot_table/VanillaBlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loot_table/VanillaBlockLootTableGenerator.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_nmrxwpfa net/minecraft/data/server/loot_table/VanillaBlockLootTableGenerator
+	FIELD f_grkujmer JUNGLE_SAPLING_DROP_CHANCES [F
+	FIELD f_toutzgio EXPLOSION_RESISTANT Ljava/util/Set;


### PR DESCRIPTION
Backport of #323 for 1.19.3 (with some fix of omissions)