### PR TITLE
Fix a Fabricism on the GameTest mappings

### DIFF
--- a/mappings/net/minecraft/test/GameTest.mapping
+++ b/mappings/net/minecraft/test/GameTest.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/unmapped/C_qanvkdqp net/minecraft/test/GameTest
 	METHOD m_hxdvfvrg structureName ()Ljava/lang/String;
 		COMMENT An {@link net.minecraft.util.Identifier} describing the location of the structure file to load for this test
 		COMMENT
-		COMMENT <p>The actual path for the file depends on the current test framework, but usually gets resolved as {@code "<namespace>:gametest/structures/<location>.nbt"}
+		COMMENT <p>The actual path for the file depends on the current test framework, but usually gets resolved as {@code "<namespace>:game_test/structures/<location>.nbt"}
 	METHOD m_mpjcinpl maxAttempts ()I
 		COMMENT The maximum amount of times this test may run
 		COMMENT


### PR DESCRIPTION
This PR fixes the usage of a Fabric-only convention that won't be used by the upcoming Quilt Testing API; This PR must be backported to 1.19.3 as well