### PR TITLE
Map dynamic registry sync utility class

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -78,6 +78,7 @@ stacktrace
 symlinks
 timestamped
 google
+taggable
 
 // word combinations
 backend

--- a/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
+++ b/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/unmapped/C_uhbbwvga net/minecraft/registry/DynamicRegistrySync
-	FIELD f_hmxjhwjb codices Ljava/util/Map;
+	FIELD f_hmxjhwjb CODICES Ljava/util/Map;
 	METHOD m_cakupvxg streamReloadableSyncedRegistries (Lnet/minecraft/unmapped/C_bcpxdrik;)Ljava/util/stream/Stream;
 		ARG 0 registryManager
 	METHOD m_dfuklmpj addSyncedRegistry (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_xhhleach;Lcom/mojang/serialization/Codec;)V

--- a/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
+++ b/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/unmapped/C_uhbbwvga net/minecraft/registry/DynamicRegistrySync
+	FIELD f_hmxjhwjb codices Ljava/util/Map;
+	METHOD m_cakupvxg streamReloadableSyncedRegistries (Lnet/minecraft/unmapped/C_bcpxdrik;)Ljava/util/stream/Stream;
+		ARG 0 registryManager
+	METHOD m_dfuklmpj addSyncedRegistry (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_xhhleach;Lcom/mojang/serialization/Codec;)V
+	METHOD m_gnuhreao streamTaggableRegistries (Lnet/minecraft/unmapped/C_bcpxdrik;)Ljava/util/stream/Stream;
+	METHOD m_jzlceccg buildManagerCodec (Lcom/mojang/serialization/codecs/UnboundedMapCodec;)Lcom/mojang/serialization/Codec;
+	METHOD m_mtppejqi (Lnet/minecraft/unmapped/C_wqxmvzdq$C_rsrqqoeq;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 entry
+	METHOD m_njqgeayc (Lnet/minecraft/unmapped/C_uhbbwvga$C_keyyzmde;)Lcom/mojang/serialization/Codec;
+		ARG 0 entry
+	METHOD m_pldzidcf (Lnet/minecraft/unmapped/C_wqxmvzdq$C_rsrqqoeq;)Lnet/minecraft/unmapped/C_tqxyjqsk;
+		ARG 0 entry
+	METHOD m_vcpumcmq streamSyncedRegistries (Lnet/minecraft/unmapped/C_wqxmvzdq;)Ljava/util/stream/Stream;
+	METHOD m_wuebhqcv buildManagerCodec ()Lcom/mojang/serialization/Codec;
+	METHOD m_zoyrbumq getSyncCodec (Lnet/minecraft/unmapped/C_xhhleach;)Lcom/mojang/serialization/DataResult;
+	CLASS C_keyyzmde SyncEntry

--- a/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
+++ b/mappings/net/minecraft/registry/DynamicRegistrySync.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_uhbbwvga net/minecraft/registry/DynamicRegistrySync
-	FIELD f_hmxjhwjb CODICES Ljava/util/Map;
+	FIELD f_hmxjhwjb SYNCED_CODECS Ljava/util/Map;
+	FIELD f_rmhfhkqs MANAGER_CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_cakupvxg streamReloadableSyncedRegistries (Lnet/minecraft/unmapped/C_bcpxdrik;)Ljava/util/stream/Stream;
 		ARG 0 registryManager
 	METHOD m_dfuklmpj addSyncedRegistry (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_xhhleach;Lcom/mojang/serialization/Codec;)V

--- a/mappings/net/minecraft/test/GameTest.mapping
+++ b/mappings/net/minecraft/test/GameTest.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/unmapped/C_qanvkdqp net/minecraft/test/GameTest
 	METHOD m_mpjcinpl maxAttempts ()I
 		COMMENT The maximum amount of times this test may run
 		COMMENT
-		COMMENT When this number is above one, the annotated test method may be called again once the previous run has completed (successfully or not) if the number of {@link #requiredSuccesses} has not been not reached.
+		COMMENT <p>When this number is above one, the annotated test method may be called again once the previous run has completed (successfully or not), if the number of {@link #requiredSuccesses} has not been not reached.
 	METHOD m_nntnqpde startDelay ()J
 		COMMENT The number of ticks to wait between loading the structure and starting the test
 	METHOD m_rkpcwgbd requiredSuccesses ()I


### PR DESCRIPTION
This PR aims to map the class responsible for dynamic registry serialization in the context of entry synchronization.
Also contains a minor fix for a previous contribution.