### PR TITLE
add getArea() mapping in Widget

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/Widget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/Widget.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_dpukplka net/minecraft/client/gui/widget/Widget
 	METHOD m_alwmixgb setX (I)V
 		ARG 1 x
+	METHOD m_duvbqmml getArea ()Lnet/minecraft/unmapped/C_erwldarl;
 	METHOD m_dynvkhcq visitWidgets (Ljava/util/function/Consumer;)V
 		ARG 1 widget
 	METHOD m_keflvkfy getY ()I


### PR DESCRIPTION
fixes an issue with tiny remapper as described by @TheGlitch76 from [here](https://discord.com/channels/833872081585700874/877319390901706753/1078477525304488017) on in https://quiltmc.org/discord/toolchain