### PR TITLE
A bunch of gui mappings

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -13,6 +13,21 @@ CLASS net/minecraft/unmapped/C_smpzexmx net/minecraft/client/gui/DrawableHelper
 		ARG 3 y0
 		ARG 4 y1
 		ARG 5 z
+		ARG 6 regionWidth
+		ARG 7 regionHeight
+		ARG 8 u
+		ARG 9 v
+		ARG 10 textureWidth
+		ARG 11 textureHeight
+	METHOD m_dlroeoai drawRepeatingTexture (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIIIII)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 u
+		ARG 6 v
+		ARG 7 textureWidth
+		ARG 8 textureHeight
 	METHOD m_ebgtwbqu fillGradient (Lorg/joml/Matrix4f;Lnet/minecraft/unmapped/C_nxnqmnng;IIIIIII)V
 		ARG 0 matrix
 		ARG 2 startX
@@ -109,11 +124,17 @@ CLASS net/minecraft/unmapped/C_smpzexmx net/minecraft/client/gui/DrawableHelper
 		ARG 4 color
 	METHOD m_kpibnkqc changeScissorState (Lnet/minecraft/unmapped/C_erwldarl;)V
 		ARG 0 area
-	METHOD m_ksjujvmg (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIIIIIII)V
+	METHOD m_ksjujvmg drawNineSlicedTexture (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIIIIIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 width
 		ARG 4 height
+		ARG 5 outerSliceWidth
+		ARG 6 outerSliceHeight
+		ARG 7 centerSliceWidth
+		ARG 8 centerSliceHeight
+		ARG 9 u
+		ARG 10 v
 	METHOD m_nmhsgmhu drawSprite (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIILnet/minecraft/unmapped/C_uflrwbwt;)V
 		ARG 0 matrices
 		ARG 1 x
@@ -213,6 +234,16 @@ CLASS net/minecraft/unmapped/C_smpzexmx net/minecraft/client/gui/DrawableHelper
 		ARG 3 x
 		ARG 4 y
 		ARG 5 color
+	METHOD m_teqwkepu drawNineSlicedTexture (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIIIIII)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 outerSliceSize
+		ARG 6 centerSliceWidth
+		ARG 7 centerSliceHeight
+		ARG 8 u
+		ARG 9 v
 	METHOD m_tkjjzcwb drawTexturedQuad (Lorg/joml/Matrix4f;IIIIIFFFF)V
 		ARG 0 matrix
 		ARG 1 x0
@@ -237,6 +268,19 @@ CLASS net/minecraft/unmapped/C_smpzexmx net/minecraft/client/gui/DrawableHelper
 		ARG 3 centerX
 		ARG 4 y
 		ARG 5 color
+	METHOD m_xlsnqlxk drawNineSlicedTexture (Lnet/minecraft/unmapped/C_cnszsxvd;IIIIIIIIIIII)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 leftSliceWidth
+		ARG 6 topSliceHeight
+		ARG 7 rightSliceWidth
+		ARG 8 bottomSliceHeight
+		ARG 9 centerSliceWidth
+		ARG 10 centerSliceHeight
+		ARG 11 u
+		ARG 12 v
 	METHOD m_xywfifzm drawCenteredTextWithShadow (Lnet/minecraft/unmapped/C_cnszsxvd;Lnet/minecraft/unmapped/C_mavozmpp;Lnet/minecraft/unmapped/C_apvkgwyi;III)V
 		ARG 0 matrices
 		ARG 1 textRenderer

--- a/mappings/net/minecraft/client/gui/screen/pack/PackListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/pack/PackListWidget.mapping
@@ -1,8 +1,14 @@
 CLASS net/minecraft/unmapped/C_redlhkpq net/minecraft/client/gui/screen/pack/PackListWidget
+	FIELD f_cjzkiqlr screen Lnet/minecraft/unmapped/C_vndksvfp;
 	FIELD f_epxfgfrh INCOMPATIBLE Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_jwzqijym title Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_lhstvivy INCOMPATIBLE_CONFIRM Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_xlrlgers RESOURCE_PACKS_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	METHOD <init> (Lnet/minecraft/unmapped/C_ayfeobid;Lnet/minecraft/unmapped/C_vndksvfp;IILnet/minecraft/unmapped/C_rdaqiwdt;)V
+		ARG 2 screen
+		ARG 3 width
+		ARG 4 height
+		ARG 5 title
 	CLASS C_yysprobl ResourcePackEntry
 		FIELD f_axzwhrjd pack Lnet/minecraft/unmapped/C_ufhpfkse$C_grqcamjx;
 		FIELD f_bwqzkghu MOVE_DOWN_ICON_OVERLAY_X I
@@ -20,10 +26,18 @@ CLASS net/minecraft/unmapped/C_redlhkpq net/minecraft/client/gui/screen/pack/Pac
 		FIELD f_qkuvwcwf NAME_WIDTH I
 		FIELD f_xyxkarah description Lnet/minecraft/unmapped/C_ogfbkizf;
 		FIELD f_zhwivsmh client Lnet/minecraft/unmapped/C_ayfeobid;
+		METHOD <init> (Lnet/minecraft/unmapped/C_ayfeobid;Lnet/minecraft/unmapped/C_redlhkpq;Lnet/minecraft/unmapped/C_ufhpfkse$C_grqcamjx;)V
+			ARG 2 widget
+			ARG 3 pack
 		METHOD m_bzczxiww createMultilineText (Lnet/minecraft/unmapped/C_ayfeobid;Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_ogfbkizf;
 			ARG 0 client
 			ARG 1 text
+		METHOD m_ewmajpwp keyboardToggle ()V
+		METHOD m_hbzsujuq (Z)V
+			ARG 1 confirmed
+		METHOD m_humjacbf enable ()Z
 		METHOD m_icwzmxei isSelectable ()Z
+		METHOD m_iqgbisnq getPackName ()Ljava/lang/String;
 		METHOD m_nxhmptqm tryMoveTowardStart ()V
 		METHOD m_pfqkpjst trimTextToWidth (Lnet/minecraft/unmapped/C_ayfeobid;Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_apvkgwyi;
 			ARG 0 client

--- a/mappings/net/minecraft/client/gui/screen/pack/PackScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/pack/PackScreen.mapping
@@ -38,7 +38,7 @@ CLASS net/minecraft/unmapped/C_vndksvfp net/minecraft/client/gui/screen/pack/Pac
 	METHOD m_gnvbxkeb closeDirectoryWatcher ()V
 	METHOD m_hzqrsuug updatePackLists ()V
 	METHOD m_ixpydxed deselectAll ()V
-	METHOD m_kdjmhvkp (Lnet/minecraft/unmapped/C_redlhkpq;)V
+	METHOD m_kdjmhvkp updateFocus (Lnet/minecraft/unmapped/C_redlhkpq;)V
 		ARG 1 packList
 	METHOD m_ldgniucd (Lnet/minecraft/unmapped/C_lvnjxuwi;Ljava/lang/String;)Lnet/minecraft/unmapped/C_ncpywfca;
 		ARG 2 profileName

--- a/mappings/net/minecraft/client/gui/screen/pack/ResourcePackOrganizer.mapping
+++ b/mappings/net/minecraft/client/gui/screen/pack/ResourcePackOrganizer.mapping
@@ -42,6 +42,7 @@ CLASS net/minecraft/unmapped/C_ufhpfkse net/minecraft/client/gui/screen/pack/Res
 		METHOD m_tdbfolre moveTowardEnd ()V
 		METHOD m_uocmbkwp canMoveTowardStart ()Z
 		METHOD m_wafpkxgm getCompatibility ()Lnet/minecraft/unmapped/C_pchdyjmm;
+		METHOD m_wvelgyyn getName ()Ljava/lang/String;
 		METHOD m_ykpwzbku getSource ()Lnet/minecraft/unmapped/C_evnnymfu;
 		METHOD m_ymzjihnb canMoveTowardEnd ()Z
 		METHOD m_zemapqrv canBeEnabled ()Z

--- a/mappings/net/minecraft/client/gui/widget/TabWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/TabWidget.mapping
@@ -1,5 +1,14 @@
 CLASS net/minecraft/unmapped/C_ljfeyjcb net/minecraft/client/gui/widget/TabWidget
+	FIELD f_btdmnrlb TEXT_MARGIN I
+	FIELD f_ckbxhlog SELECTED_OFFSET I
+	FIELD f_mlrppjyk UNDERLINE_MARGIN_BOTTOM I
+	FIELD f_nqhwvkvp UNDERLINE_MARGIN_X I
+	FIELD f_qvbogixm UNDERLINE_HEIGHT I
+	FIELD f_ruhxhinp TEXTURE_BORDER I
+	FIELD f_seqesugd TEXTURE_WIDTH I
+	FIELD f_vojebtmj TEXTURE_BORDER_BOTTOM I
 	FIELD f_wowovtch TAB_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_yzviyiuy TEXTURE_HEIGHT I
 	METHOD <init> (Lnet/minecraft/unmapped/C_shidhwhk;Lnet/minecraft/unmapped/C_aojwjkua;II)V
 		ARG 3 width
 		ARG 4 height


### PR DESCRIPTION
Just some mappings I found were missing while updating one of my mods. Some notes:
- The method names in `DrawableHelper` were made from Yarn and MojMap, `blit...` in MM is `draw...Texture` in QM, same for Yarn
- `drawNineSlicedTexture` seems to draw a texture up to nine times around an area, in a 3x3 region, using the different sizes for each slice