### PR TITLE
Redstone related mappings and refactors

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -15,6 +15,11 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 settings
 	METHOD m_bhohbmwk getWeakRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT Returns the weak redstone power this block emits in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT returns power in the <i>opposite</i> direction of the one given.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -44,7 +49,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 2 view
 		ARG 3 pos
 	METHOD m_ewcsdntg asBlock ()Lnet/minecraft/unmapped/C_mmxmpdoq;
-	METHOD m_fjkbizwn emitsRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_fjkbizwn isRedstonePowerSource (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
 	METHOD m_fqngyjtr getOutlineShape (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_pbfjvesm;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 state
@@ -202,6 +207,11 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 4 projectile
 	METHOD m_xfdklwdd getVerticalModelOffsetMultiplier ()F
 	METHOD m_ydisyayk getStrongRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT Returns the strong redstone power this block emits in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT returns power in the <i>opposite</i> direction of the one given.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -470,7 +480,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 2 state
 			ARG 3 hit
 			ARG 4 projectile
-		METHOD m_vlxoaqxh emitsRedstonePower ()Z
+		METHOD m_vlxoaqxh isRedstonePowerSource ()Z
 		METHOD m_vrkuyjxa onSyncedBlockEvent (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;II)Z
 			ARG 1 world
 			ARG 2 pos

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -16,7 +16,6 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 1 settings
 	METHOD m_bhohbmwk getWeakRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
 		COMMENT Returns the weak redstone power this block emits in the given direction.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT returns power in the <i>opposite</i> direction of the one given.
@@ -208,7 +207,6 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	METHOD m_xfdklwdd getVerticalModelOffsetMultiplier ()F
 	METHOD m_ydisyayk getStrongRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
 		COMMENT Returns the strong redstone power this block emits in the given direction.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT returns power in the <i>opposite</i> direction of the one given.

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 settings
 	METHOD m_bhohbmwk getWeakRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
-		COMMENT Returns the weak redstone power this block emits in the given direction.
+		COMMENT {@return the weak redstone power this block emits in the given direction}
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT returns power in the <i>opposite</i> direction of the one given.
@@ -206,7 +206,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 4 projectile
 	METHOD m_xfdklwdd getVerticalModelOffsetMultiplier ()F
 	METHOD m_ydisyayk getStrongRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
-		COMMENT Returns the strong redstone power this block emits in the given direction.
+		COMMENT {@return the strong redstone power this block emits in the given direction}
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT returns power in the <i>opposite</i> direction of the one given.

--- a/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_lgaafbhj net/minecraft/block/AbstractPressurePlat
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;Lnet/minecraft/unmapped/C_hgpogkhy;)V
 		ARG 1 settings
 		ARG 2 blockSetType
-	METHOD m_bbgybojj getRedstoneOutput (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)I
+	METHOD m_bbgybojj calculateRedstoneOutput (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 world
 		ARG 2 pos
 	METHOD m_cyzszxhg updatePlateState (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;I)V

--- a/mappings/net/minecraft/block/ComparatorBlock.mapping
+++ b/mappings/net/minecraft/block/ComparatorBlock.mapping
@@ -4,11 +4,11 @@ CLASS net/minecraft/unmapped/C_qrhvqyam net/minecraft/block/ComparatorBlock
 		ARG 1 world
 		ARG 2 facing
 		ARG 3 pos
-	METHOD m_flfmkilz calculateOutputSignal (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+	METHOD m_flfmkilz calculateOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_gnmmcvoj update (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
+	METHOD m_gnmmcvoj updateOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state

--- a/mappings/net/minecraft/block/RedstoneDiodeBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneDiodeBlock.mapping
@@ -1,7 +1,8 @@
-CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/AbstractRedstoneGateBlock
+CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/RedstoneDiodeBlock
 	FIELD f_kflbgyvb SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zkbuxycf POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD m_awrsqovb getMaxInputLevelSides (Lnet/minecraft/unmapped/C_gpzjbzcw;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 	METHOD m_axktpyln getOutputLevel (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
@@ -12,26 +13,27 @@ CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/AbstractRedstoneGate
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_gxskdeps getPower (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+	METHOD m_gxskdeps getInputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 	METHOD m_ivykfrsh getUpdateDelayInternal (Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 state
-	METHOD m_jsbiqhca isRedstoneGate (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_jsbiqhca isDiode (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_lgirilub isTargetNotAligned (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_ncapgwkk updatePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
+	METHOD m_ncapgwkk checkOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_qmwftzms hasPower (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_qmwftzms shouldBePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+	METHOD m_wrjkascy useStrictSideInput ()Z
 	METHOD m_znbpmztc isLocked (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/world/RedstonePowerView.mapping
+++ b/mappings/net/minecraft/world/RedstonePowerView.mapping
@@ -1,0 +1,48 @@
+CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
+	FIELD f_caqhuckp DIRECTIONS [Lnet/minecraft/unmapped/C_xpuuihxf;
+	METHOD m_dnkvwchb getEmittedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT Returns the redstone power emitted from the given position in the given direction.
+		COMMENT This is the highest value between power emitted by the block itself, and strong redstone power
+		COMMENT received from neighboring blocks if the block is a redstone conductor.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
+		ARG 1 pos
+		ARG 2 dir
+	METHOD m_dsckesgu isEmittingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
+		COMMENT Returns whether redstone power is emitted from the given position in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
+		ARG 1 pos
+		ARG 2 dir
+	METHOD m_fwaivkfo isReceivingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		COMMENT Returns whether the given position receives any redstone power from neighboring blocks.
+		ARG 1 pos
+	METHOD m_hizjdvsd getReceivedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
+		COMMENT Returns the redstone power the given position receives from neighboring blocks.
+		ARG 1 pos
+	METHOD m_rgxdlzfx getReceivedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
+		COMMENT Returns the strong redstone power the given position receives from neighboring blocks.
+		ARG 1 pos
+	METHOD m_uegtusaf getEmittedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT Returns the strong redstone power emitted from the given position in the given direction.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
+		ARG 1 pos
+		ARG 2 dir
+	METHOD m_vjljrkvs getFilteredEmittedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Z)I
+		COMMENT Returns the filtered redstone power emitted from the given position in the given direction.
+		COMMENT In 'strict' mode the filter only allows strong redstone power from redstone diodes (repeaters and comparators),
+		COMMENT while in 'lenient' mode it allows strong redstone power from any block as well as weak redstone power from redstone blocks.
+		COMMENT
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
+		ARG 1 pos
+		ARG 2 dir
+		ARG 3 strict

--- a/mappings/net/minecraft/world/RedstonePowerView.mapping
+++ b/mappings/net/minecraft/world/RedstonePowerView.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 	FIELD f_caqhuckp DIRECTIONS [Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_dnkvwchb getEmittedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
-		COMMENT Returns the redstone power emitted from the given position in the given direction.
+		COMMENT {@return the redstone power emitted from the given position in the given direction}
 		COMMENT This is the highest value between power emitted by the block itself, and strong redstone power
 		COMMENT received from neighboring blocks if the block is a redstone conductor.
 		COMMENT <p>
@@ -10,30 +10,30 @@ CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 		ARG 1 pos
 		ARG 2 dir
 	METHOD m_dsckesgu isEmittingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
-		COMMENT Returns whether redstone power is emitted from the given position in the given direction.
+		COMMENT {@return whether redstone power is emitted from the given position in the given direction}
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 dir
 	METHOD m_fwaivkfo isReceivingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)Z
-		COMMENT Returns whether the given position receives any redstone power from neighboring blocks.
+		COMMENT {@return whether the given position receives any redstone power from neighboring blocks}
 		ARG 1 pos
 	METHOD m_hizjdvsd getReceivedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
-		COMMENT Returns the redstone power the given position receives from neighboring blocks.
+		COMMENT {@return the redstone power the given position receives from neighboring blocks}
 		ARG 1 pos
 	METHOD m_rgxdlzfx getReceivedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
-		COMMENT Returns the strong redstone power the given position receives from neighboring blocks.
+		COMMENT {@return the strong redstone power the given position receives from neighboring blocks}
 		ARG 1 pos
 	METHOD m_uegtusaf getEmittedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
-		COMMENT Returns the strong redstone power emitted from the given position in the given direction.
+		COMMENT {@return the strong redstone power emitted from the given position in the given direction}
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
 		ARG 2 dir
 	METHOD m_vjljrkvs getFilteredEmittedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Z)I
-		COMMENT Returns the filtered redstone power emitted from the given position in the given direction.
+		COMMENT {@return the filtered redstone power emitted from the given position in the given direction}
 		COMMENT In 'strict' mode the filter only allows strong redstone power from redstone diodes (repeaters and comparators),
 		COMMENT while in 'lenient' mode it allows strong redstone power from any block as well as weak redstone power from redstone blocks.
 		COMMENT <p>

--- a/mappings/net/minecraft/world/RedstonePowerView.mapping
+++ b/mappings/net/minecraft/world/RedstonePowerView.mapping
@@ -4,7 +4,6 @@ CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 		COMMENT Returns the redstone power emitted from the given position in the given direction.
 		COMMENT This is the highest value between power emitted by the block itself, and strong redstone power
 		COMMENT received from neighboring blocks if the block is a redstone conductor.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.
@@ -12,7 +11,6 @@ CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 		ARG 2 dir
 	METHOD m_dsckesgu isEmittingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		COMMENT Returns whether redstone power is emitted from the given position in the given direction.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.
@@ -29,7 +27,6 @@ CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 		ARG 1 pos
 	METHOD m_uegtusaf getEmittedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
 		COMMENT Returns the strong redstone power emitted from the given position in the given direction.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.
@@ -39,7 +36,6 @@ CLASS net/minecraft/unmapped/C_gpzjbzcw net/minecraft/world/RedstonePowerView
 		COMMENT Returns the filtered redstone power emitted from the given position in the given direction.
 		COMMENT In 'strict' mode the filter only allows strong redstone power from redstone diodes (repeaters and comparators),
 		COMMENT while in 'lenient' mode it allows strong redstone power from any block as well as weak redstone power from redstone blocks.
-		COMMENT
 		COMMENT <p>
 		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
 		COMMENT checks for power in the <i>opposite</i> direction of the one given.


### PR DESCRIPTION
In terms of new mappings:
- `RedstonePowerView ` is an interface that extends `BlockView` and contains only methods for querying emitted and received redstone power. I went with the Yarn convention for names of these methods, even though they're a bit bulky, they're more consistent with all the redstone related names used elsewhere.

In terms of refactors:
- `AbstractRedstoneGateBlock` has been renamed to `RedstoneDiodeBlock` for a more accurate and concise name. Several methods in this class, as well as its subclasses `RepeaterBlock` and `ComparatorBlock`, have been renamed to better reflect whether they deal with input or output.
- `AbstractBlock#emitsRedstonePower` has been renamed to `isRedstonePowerSource` to make it less confusing.