### PR TITLE
BrainStorm: Behaviour, SetEntityLookTargetRandomly

### DIFF
--- a/mappings/net/minecraft/entity/ai/brain/Behaviour.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/Behaviour.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/unmapped/C_rcqaryar net/minecraft/entity/ai/brain/Behaviour
+	METHOD m_elxiakeb of (Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_yfpegcpm;
+	CLASS C_loqvwuht
+		METHOD m_gcuzwcid get (Lnet/minecraft/unmapped/C_ujlmiamh;)Ljava/lang/Object;
+		METHOD m_owejzxbp isAbsent (Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_rcqaryar;
+		METHOD m_qgrmwbxe isPresent (Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_rcqaryar;

--- a/mappings/net/minecraft/entity/ai/brain/MemoryAccess.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/MemoryAccess.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/unmapped/C_ujlmiamh net/minecraft/entity/ai/brain/MemoryAccess
+	FIELD f_nnqvfqwh memoryModule Lnet/minecraft/unmapped/C_vbbyoqyw;
+	FIELD f_powfpjln value Lcom/mojang/datafixers/kinds/App;
+	METHOD <init> (Lnet/minecraft/unmapped/C_rjqjaxef;Lnet/minecraft/unmapped/C_vbbyoqyw;Lcom/mojang/datafixers/kinds/App;)V
+		ARG 2 memoryModule
+		ARG 3 value
+	METHOD m_bczdgokz setOrElse (Ljava/util/Optional;)V
+		ARG 1 optionalValue
+	METHOD m_gfsxfard discard ()V
+	METHOD m_klbizcog set (Ljava/lang/Object;)V
+		ARG 1 value
+	METHOD m_nrhekywp getValue ()Lcom/mojang/datafixers/kinds/App;
+	METHOD m_zjdztcmb set (Ljava/lang/Object;J)V
+		ARG 1 value

--- a/mappings/net/minecraft/entity/ai/brain/VisibleLivingEntitiesCache.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/VisibleLivingEntitiesCache.mapping
@@ -22,5 +22,6 @@ CLASS net/minecraft/unmapped/C_bfzvfpbw net/minecraft/entity/ai/brain/VisibleLiv
 		ARG 1 predicate
 	METHOD m_yfuatkqw contains (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
+	METHOD m_yzezovsk getClosest (Ljava/util/function/Predicate;)Ljava/util/Optional;
 	METHOD m_zzqpycmq iterate (Ljava/util/function/Predicate;)Ljava/lang/Iterable;
 		ARG 1 predicate

--- a/mappings/net/minecraft/entity/ai/brain/task/SetEntityLookTargetRandomly.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/SetEntityLookTargetRandomly.mapping
@@ -1,0 +1,31 @@
+CLASS net/minecraft/unmapped/C_lygsomtd net/minecraft/entity/ai/brain/task/SetEntityLookTargetRandomly
+	METHOD m_aecmvuxy of (Lnet/minecraft/unmapped/C_ogavsvbr;FLnet/minecraft/unmapped/C_hvilmtvi;)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 0 entityType
+		ARG 1 chance
+		ARG 2 range
+	METHOD m_ipziivps (Lnet/minecraft/unmapped/C_usxaxydn;FLnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 targetLivingEntity
+	METHOD m_nozcjkxz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 7 livingEntiity
+	METHOD m_nteqkjjv (Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 0 predicate
+	METHOD m_ouvkkubu of (FLnet/minecraft/unmapped/C_hvilmtvi;)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 0 chance
+		ARG 1 range
+	METHOD m_shrczqhx (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 entity
+	METHOD m_swcvkveo (Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
+		ARG 3 behaviour
+	METHOD m_uabosmqw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 memory
+		ARG 5 memeory2
+	METHOD m_xpopbuma of (FLnet/minecraft/unmapped/C_hvilmtvi;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 0 distance
+		ARG 1 range
+		ARG 2 predicate
+	CLASS C_gvxfhlod Ticker
+		FIELD f_efesnins countdownToStart I
+		FIELD f_rdvkztgg intProvider Lnet/minecraft/unmapped/C_hvilmtvi;
+		METHOD <init> (Lnet/minecraft/unmapped/C_hvilmtvi;)V
+			ARG 1 intProvider
+		METHOD m_haxoxxhw tick (Lnet/minecraft/unmapped/C_rlomrsco;)Z

--- a/mappings/net/minecraft/entity/ai/brain/task/SetEntityLookTargetRandomly.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/SetEntityLookTargetRandomly.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/unmapped/C_lygsomtd net/minecraft/entity/ai/brain/task/SetEn
 		ARG 3 behaviour
 	METHOD m_uabosmqw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
 		ARG 4 memory
-		ARG 5 memeory2
+		ARG 5 memory2
 	METHOD m_xpopbuma of (FLnet/minecraft/unmapped/C_hvilmtvi;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 distance
 		ARG 1 range


### PR DESCRIPTION
I added some basic mappings for when an entity is selecting a look target at a chance.
This is for a Task in the Brain part of minecraft AI