### PR TITLE
Refactor ScreenTexts into CommonTexts

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
@@ -39,8 +39,8 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/CyclingB
 	METHOD m_jsgmqbgj onOffBuilder (Z)Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 		COMMENT Creates a builder for a cycling button widget that only has {@linkplain Boolean#TRUE}
 		COMMENT and {@linkplain Boolean#FALSE} values.
-		COMMENT It displays {@link net.minecraft.text.ScreenTexts#ON} for {@code true},
-		COMMENT and {@link net.minecraft.text.ScreenTexts#OFF} for {@code false}.
+		COMMENT It displays {@link net.minecraft.text.CommonTexts#ON} for {@code true},
+		COMMENT and {@link net.minecraft.text.CommonTexts#OFF} for {@code false}.
 		COMMENT <p>
 		COMMENT Its current initial value is {@code initialValue}.
 		ARG 0 initialValue
@@ -68,8 +68,8 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/CyclingB
 	METHOD m_wymfsxew onOffBuilder ()Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 		COMMENT Creates a builder for a cycling button widget that only has {@linkplain Boolean#TRUE}
 		COMMENT and {@linkplain Boolean#FALSE} values.
-		COMMENT It displays {@link net.minecraft.text.ScreenTexts#ON} for {@code true},
-		COMMENT and {@link net.minecraft.text.ScreenTexts#OFF} for {@code false}.
+		COMMENT It displays {@link net.minecraft.text.CommonTexts#ON} for {@code true},
+		COMMENT and {@link net.minecraft.text.CommonTexts#OFF} for {@code false}.
 		COMMENT <p>
 		COMMENT Its current initial value is {@code true}.
 	METHOD m_zbsldwum (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;Ljava/lang/Boolean;)Lnet/minecraft/unmapped/C_rdaqiwdt;

--- a/mappings/net/minecraft/text/CommonTexts.mapping
+++ b/mappings/net/minecraft/text/CommonTexts.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_qveejgrk net/minecraft/text/ScreenTexts
+CLASS net/minecraft/unmapped/C_qveejgrk net/minecraft/text/CommonTexts
 	FIELD f_afmmtaio ON Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_bfovsbpw TO_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_bvltkwzp NO Lnet/minecraft/unmapped/C_rdaqiwdt;
@@ -16,24 +16,27 @@ CLASS net/minecraft/unmapped/C_qveejgrk net/minecraft/text/ScreenTexts
 	FIELD f_xswapbgg CANCEL Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_zhzkryyg TRAILING_OFF Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_zwbddpio EMPTY Lnet/minecraft/unmapped/C_rdaqiwdt;
-	METHOD m_cuokxsst composeTimeTextDays (J)Lnet/minecraft/unmapped/C_npqneive;
-		ARG 0 value
+	METHOD m_cuokxsst days (J)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 days
 	METHOD m_dnoultco joinSentences ([Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 0 texts
-	METHOD m_jspdcopa composeGenericOptionText (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_npqneive;
-		ARG 0 text
+	METHOD m_jspdcopa genericOption (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 optionText
 		ARG 1 value
 	METHOD m_mgxxtgko joinLines (Ljava/util/Collection;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 0 texts
-	METHOD m_nsfurkhx composeTimeTextHours (J)Lnet/minecraft/unmapped/C_npqneive;
-		ARG 0 value
-	METHOD m_qsvbgaen composeToggleText (Lnet/minecraft/unmapped/C_rdaqiwdt;Z)Lnet/minecraft/unmapped/C_npqneive;
-		ARG 0 text
+	METHOD m_nsfurkhx hours (J)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 hours
+	METHOD m_qsvbgaen toggleOption (Lnet/minecraft/unmapped/C_rdaqiwdt;Z)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 optionText
 		ARG 1 value
 	METHOD m_sarnrcsh space ()Lnet/minecraft/unmapped/C_npqneive;
-	METHOD m_spljgefr composeTimeTextMinutes (J)Lnet/minecraft/unmapped/C_npqneive;
-		ARG 0 value
+		COMMENT Creates a new literal text containing a space.
+		COMMENT
+		COMMENT @return a literal text containing a space.
+	METHOD m_spljgefr minutes (J)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 minutes
 	METHOD m_yawyozdh joinLines ([Lnet/minecraft/unmapped/C_rdaqiwdt;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 0 texts
-	METHOD m_ybmisxyh onOrOff (Z)Lnet/minecraft/unmapped/C_rdaqiwdt;
-		ARG 0 on
+	METHOD m_ybmisxyh toggleOptionValue (Z)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 value

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -63,7 +63,7 @@ CLASS net/minecraft/unmapped/C_rdaqiwdt net/minecraft/text/Text
 		COMMENT Creates a new mutable empty text.
 		COMMENT
 		COMMENT @return the new mutable empty text
-		COMMENT @see net.minecraft.text.ScreenTexts#EMPTY for a constant equivalent
+		COMMENT @see net.minecraft.text.CommonTexts#EMPTY for a constant equivalent
 	METHOD m_oyjmhrxe getStyle ()Lnet/minecraft/unmapped/C_cpwnhism;
 		COMMENT {@return the style of this text}
 	METHOD m_pgfflmov contains (Lnet/minecraft/unmapped/C_rdaqiwdt;)Z


### PR DESCRIPTION
This resembles the approach done with `Text` and friends, with Mojmap's `CommonComponents` being a heavy inspiration; `ScreenTexts` is a terrible name and it needs to be burnt!