### PR TITLE
map the light engine

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/LightUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/LightUpdateS2CPacket.mapping
@@ -4,6 +4,11 @@ CLASS net/minecraft/unmapped/C_egijoeyc net/minecraft/network/packet/s2c/play/Li
 	FIELD f_rzedanzl chunkZ I
 	METHOD <init> (Lnet/minecraft/unmapped/C_idfydwco;)V
 		ARG 1 buf
+	METHOD <init> (Lnet/minecraft/unmapped/C_ynrszrtu;Lnet/minecraft/unmapped/C_ksposksb;Ljava/util/BitSet;Ljava/util/BitSet;)V
+		ARG 1 pos
+		ARG 2 provider
+		ARG 3 skyLightData
+		ARG 4 blockLightData
 	METHOD m_aiknmzsd getChunkX ()I
 	METHOD m_nimlismw getChunkZ ()I
 	METHOD m_woqldqyp lightUpdateData ()Lnet/minecraft/unmapped/C_qeldjmur;

--- a/mappings/net/minecraft/network/packet/s2c/play/data/LightData.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/data/LightData.mapping
@@ -9,6 +9,11 @@ CLASS net/minecraft/unmapped/C_qeldjmur net/minecraft/network/packet/s2c/play/da
 		ARG 1 buf
 		ARG 2 chunkX
 		ARG 3 chunkZ
+	METHOD <init> (Lnet/minecraft/unmapped/C_ynrszrtu;Lnet/minecraft/unmapped/C_ksposksb;Ljava/util/BitSet;Ljava/util/BitSet;)V
+		ARG 1 pos
+		ARG 2 provider
+		ARG 3 skyLightData
+		ARG 4 blockLightData
 	METHOD m_avpndylk (Lnet/minecraft/unmapped/C_idfydwco;)[B
 		ARG 0 buf
 	METHOD m_gppfxnuq (Lnet/minecraft/unmapped/C_idfydwco;)[B

--- a/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
+++ b/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
@@ -115,6 +115,10 @@ CLASS net/minecraft/unmapped/C_zubvmeye net/minecraft/util/math/ChunkSectionPos
 		COMMENT Creates a chunk section position from its packed representation.
 		COMMENT @see #asLong
 		ARG 0 packed
+	METHOD m_qxyypyrl asLong (II)J
+		COMMENT Creates a packed coordinate with a y value of zero.
+		ARG 0 x
+		ARG 1 z
 	METHOD m_ramiwwjc from (Lnet/minecraft/unmapped/C_ogbhoqwb;)Lnet/minecraft/unmapped/C_zubvmeye;
 		ARG 0 pos
 	METHOD m_rfzysagn unpackY (J)I
@@ -149,6 +153,8 @@ CLASS net/minecraft/unmapped/C_zubvmeye net/minecraft/util/math/ChunkSectionPos
 		COMMENT @see #packLocal
 		ARG 1 packedLocalPos
 	METHOD m_wgttobnw getMinY ()I
+	METHOD m_xidugqcq withZeroY (J)J
+		ARG 0 blockPos
 	METHOD m_xmrsyyyw forEachSectionAround (IIILit/unimi/dsi/fastutil/longs/LongConsumer;)V
 		ARG 0 x
 		ARG 1 y

--- a/mappings/net/minecraft/world/ChunkLightBlockView.mapping
+++ b/mappings/net/minecraft/world/ChunkLightBlockView.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_rtgnnfoz net/minecraft/world/ChunkLightBlockView
+	METHOD m_efhugczn getSkyLightSources ()Lnet/minecraft/unmapped/C_molcobnw;

--- a/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
@@ -2,15 +2,18 @@ CLASS net/minecraft/unmapped/C_cneaxdxg net/minecraft/world/chunk/ChunkNibbleArr
 	FIELD f_cuohkndn BYTES_LENGTH I
 	FIELD f_jwpnluen NIBBLE_SIZE I
 	FIELD f_mjfatltk COPY_BLOCK_SIZE I
+	FIELD f_wmwesnny defaultValue I
 	FIELD f_ywctwepz bytes [B
 	FIELD f_zhqwkcks COPY_TIMES I
 	METHOD <init> (I)V
-		ARG 1 size
+		ARG 1 defaultValue
 	METHOD <init> ([B)V
 		ARG 1 bytes
 	METHOD m_bcnfnyad get (I)I
 		ARG 1 index
-	METHOD m_ckjjmpve divideByTwo (I)I
+	METHOD m_cjxvqmzg isFilledWith (I)Z
+		ARG 1 value
+	METHOD m_ckjjmpve getByteArrayIndex (I)I
 		ARG 0 i
 		ARG 1 n
 	METHOD m_gweyudot get (III)I
@@ -18,6 +21,8 @@ CLASS net/minecraft/unmapped/C_cneaxdxg net/minecraft/world/chunk/ChunkNibbleArr
 		ARG 2 y
 		ARG 3 z
 	METHOD m_hewyaqyb layerToString (I)Ljava/lang/String;
+		ARG 1 unused
+	METHOD m_ksacqlrl isArrayUninitialised ()Z
 	METHOD m_kyccnvzo set (II)V
 		ARG 1 index
 		ARG 2 value
@@ -25,13 +30,17 @@ CLASS net/minecraft/unmapped/C_cneaxdxg net/minecraft/world/chunk/ChunkNibbleArr
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD m_mmkouqgj isUninitialized ()Z
+	METHOD m_mmkouqgj isEmpty ()Z
 	METHOD m_mnhainhj set (IIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 		ARG 4 value
-	METHOD m_mtyszfml isOdd (I)I
+	METHOD m_mtyszfml getNibbleIndex (I)I
 		ARG 0 i
 	METHOD m_ncjbkvsh asByteArray ()[B
 	METHOD m_ozmlvfey copy ()Lnet/minecraft/unmapped/C_cneaxdxg;
+	METHOD m_phygyqqk pack (I)B
+		ARG 0 value
+	METHOD m_zkjiyjin fill (I)V
+		ARG 1 defaultValue

--- a/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/unmapped/C_cneaxdxg net/minecraft/world/chunk/ChunkNibbleArr
 		ARG 3 z
 	METHOD m_hewyaqyb layerToString (I)Ljava/lang/String;
 		ARG 1 unused
-	METHOD m_ksacqlrl isArrayUninitialised ()Z
+	METHOD m_ksacqlrl isArrayUninitialized ()Z
 	METHOD m_kyccnvzo set (II)V
 		ARG 1 index
 		ARG 2 value

--- a/mappings/net/minecraft/world/chunk/light/ChunkBlockLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkBlockLightProvider.mapping
@@ -1,3 +1,9 @@
 CLASS net/minecraft/unmapped/C_uclonkyp net/minecraft/world/chunk/light/ChunkBlockLightProvider
 	METHOD <init> (Lnet/minecraft/unmapped/C_jhssvvvy;)V
 		ARG 1 chunkProvider
+	METHOD <init> (Lnet/minecraft/unmapped/C_jhssvvvy;Lnet/minecraft/unmapped/C_bjhznhnk;)V
+		ARG 1 chunkProvider
+		ARG 2 storage
+	METHOD m_nmkvjyre getEmission (JLnet/minecraft/unmapped/C_txtbiemp;)I
+		ARG 1 blockPos
+		ARG 3 blockState

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -1,0 +1,136 @@
+CLASS net/minecraft/unmapped/C_upkweuif net/minecraft/world/chunk/light/ChunkLightProvider
+	FIELD f_afxeukbh CACHE_SIZE I
+	FIELD f_arfcwfgy DIRECTIONS [Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_cvbmvasy increaseQueue Lit/unimi/dsi/fastutil/longs/LongArrayFIFOQueue;
+	FIELD f_dsknzrus cachedChunks [Lnet/minecraft/unmapped/C_rtgnnfoz;
+	FIELD f_edtaifbh MIN_QUEUE_SIZE I
+	FIELD f_lguzwiso MAX_LEVEL I
+	FIELD f_lrychktf cachedChunkPositions [J
+	FIELD f_lvwsjqtw MIN_OPACITY I
+	FIELD f_mnzbramm decreaseQueue Lit/unimi/dsi/fastutil/longs/LongArrayFIFOQueue;
+	FIELD f_oietxybg chunkProvider Lnet/minecraft/unmapped/C_jhssvvvy;
+	FIELD f_pthtxwge lightStorage Lnet/minecraft/unmapped/C_jbeocnxo;
+	FIELD f_ruzjxnps mutablePos Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;
+	FIELD f_vueaucjh blockNodesToCheck Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD f_xjlhmzmi PULL_LIGHT_IN_ENTRY J
+	METHOD <init> (Lnet/minecraft/unmapped/C_jhssvvvy;Lnet/minecraft/unmapped/C_jbeocnxo;)V
+		ARG 1 chunkProvider
+		ARG 2 lightStorage
+	METHOD m_acljlcls setRetainColumn (Lnet/minecraft/unmapped/C_ynrszrtu;Z)V
+		ARG 1 pos
+		ARG 2 retain
+	METHOD m_ayxicyia propagateIncrease (JJI)V
+		ARG 1 blockPos
+		ARG 3 state
+		ARG 5 lightData
+	METHOD m_dpvvjcdf shapeOccludes (JLnet/minecraft/unmapped/C_txtbiemp;JLnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
+		ARG 1 sourceId
+		ARG 3 sourceState
+		ARG 4 targetId
+		ARG 6 targetState
+		ARG 7 direction
+	METHOD m_etktdote enqueueIncrease (JJ)V
+		ARG 1 blockPos
+		ARG 3 state
+	METHOD m_fyornymb getOpacity (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;)I
+		ARG 1 state
+		ARG 2 pos
+	METHOD m_gvoflnzj checkNode (J)V
+		ARG 1 blockPos
+	METHOD m_iaxlkdhu clearChunkCache ()V
+	METHOD m_ivirmkin enqueueDecrease (JJ)V
+		ARG 1 blockPos
+		ARG 3 state
+	METHOD m_mjqcyboe markSectionAsChecked (J)V
+		ARG 1 sectionPos
+	METHOD m_nqytrssw getType (J)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
+		ARG 1 sectionPos
+	METHOD m_pezdxydv getChunk (II)Lnet/minecraft/unmapped/C_rtgnnfoz;
+		ARG 1 chunkX
+		ARG 2 chunkZ
+	METHOD m_phxaiaai getOcclusionShape (Lnet/minecraft/unmapped/C_txtbiemp;JLnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 1 state
+		ARG 2 pos
+		ARG 4 direction
+	METHOD m_plzsbbaz (JJ)Z
+		ARG 2 pos
+	METHOD m_quncefjf propagateDecreases ()I
+	METHOD m_qvdxwyuy isEmptyShape (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+		ARG 0 state
+	METHOD m_ryzxffeg getLightBlockInto (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;I)I
+		ARG 0 world
+		ARG 1 sourceState
+		ARG 2 sourcePos
+		ARG 3 targetState
+		ARG 4 targetPos
+		ARG 6 defaultValue
+	METHOD m_ucugtqkd getOcclusionShape (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 direction
+	METHOD m_vffsnuwj propagateIncreases ()I
+	METHOD m_vfxjjknv enqueueSectionData (JLnet/minecraft/unmapped/C_cneaxdxg;)V
+		ARG 1 sectionPos
+		ARG 3 lightArray
+	METHOD m_vxkkvyil getState (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 1 pos
+	METHOD m_vxlgbudj getTypeId (J)Ljava/lang/String;
+		ARG 1 sectionPos
+	METHOD m_wcjydhhg propagateDecrease (JJ)V
+		ARG 1 blockPos
+		ARG 3 state
+	METHOD m_yinhjcxa needsLightUpdate (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 oldState
+		ARG 3 newState
+	CLASS C_bbshbbpk QueueEntry
+		FIELD f_gjefnxsn FLAG_INCREASE_FROM_EMISSION J
+		FIELD f_qvkrglrm FLAG_FROM_EMPTY_SHAPE J
+		FIELD f_qwctgdgy FROM_LEVEL_BITS I
+		FIELD f_udjopaao DIRECTIONS_MASK J
+		FIELD f_ugqcqlyi DIRECTION_BITS I
+		FIELD f_wbxmfsvk LEVEL_MASK J
+		METHOD m_avilvcpm increaseSingleDirection (IZLnet/minecraft/unmapped/C_xpuuihxf;)J
+			ARG 0 lightLevel
+			ARG 1 emptyShape
+			ARG 2 direction
+		METHOD m_bafmnwqp isFromEmptyShape (J)Z
+			ARG 0 packed
+		METHOD m_bszvuvrj withLightLevel (JI)J
+			ARG 0 packed
+			ARG 2 lightLevel
+		METHOD m_gpguxllf isIncreaseFromEmission (J)Z
+			ARG 0 packed
+		METHOD m_lvfxqrjl decreaseWithSkippedDirection (ILnet/minecraft/unmapped/C_xpuuihxf;)J
+			ARG 0 lightLevel
+			ARG 1 skipped
+		METHOD m_pbiefprb clearDirection (JLnet/minecraft/unmapped/C_xpuuihxf;)J
+			ARG 0 packed
+			ARG 2 direction
+		METHOD m_ptlbimvx increaseSkySourceForDirections (ZZZZZ)J
+			ARG 0 down
+			ARG 1 north
+			ARG 2 south
+			ARG 3 west
+			ARG 4 east
+		METHOD m_qbtvhgjz decreaseAllDirections (I)J
+			ARG 0 lightLevel
+		METHOD m_qgnnqzhk increaseWithSkippedDirection (IZLnet/minecraft/unmapped/C_xpuuihxf;)J
+			ARG 0 lightLevel
+			ARG 1 emptyShape
+			ARG 2 skipped
+		METHOD m_qrxhmfxp getLightLevel (J)I
+			ARG 0 packed
+		METHOD m_rozbpmfo increaseLightFromEmission (IZ)J
+			ARG 0 lightLevel
+			ARG 1 emptyShape
+		METHOD m_svuqgven withDirection (JLnet/minecraft/unmapped/C_xpuuihxf;)J
+			ARG 0 packed
+			ARG 2 direction
+		METHOD m_xdwnbkte shouldPropagateInDirection (JLnet/minecraft/unmapped/C_xpuuihxf;)Z
+			ARG 0 packed
+	CLASS C_ftiejceo
+		METHOD rehash rehash (I)V
+			ARG 1 i

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/unmapped/C_upkweuif net/minecraft/world/chunk/light/ChunkLig
 		ARG 3 state
 	METHOD m_mjqcyboe markSectionAsChecked (J)V
 		ARG 1 sectionPos
-	METHOD m_nqytrssw getType (J)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
+	METHOD m_nqytrssw getSectionType (J)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
 		ARG 1 sectionPos
 	METHOD m_pezdxydv getChunk (II)Lnet/minecraft/unmapped/C_rtgnnfoz;
 		ARG 1 chunkX
@@ -75,7 +75,7 @@ CLASS net/minecraft/unmapped/C_upkweuif net/minecraft/world/chunk/light/ChunkLig
 		ARG 3 lightArray
 	METHOD m_vxkkvyil getState (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 1 pos
-	METHOD m_vxlgbudj getTypeId (J)Ljava/lang/String;
+	METHOD m_vxlgbudj getSectionTypeId (J)Ljava/lang/String;
 		ARG 1 sectionPos
 	METHOD m_wcjydhhg propagateDecrease (JJ)V
 		ARG 1 blockPos

--- a/mappings/net/minecraft/world/chunk/light/ChunkSkyLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkSkyLightProvider.mapping
@@ -1,3 +1,45 @@
 CLASS net/minecraft/unmapped/C_fqoxlcti net/minecraft/world/chunk/light/ChunkSkyLightProvider
+	FIELD f_dwdezbvz mutablePos Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;
+	FIELD f_mvchqxqp REMOVE_SKY_SOURCE_ENTRY J
+	FIELD f_nbkotqzz ADD_SKY_SOURCE_ENTRY J
+	FIELD f_odjczdqr REMOVE_TOP_SKY_SOURCE_ENTRY J
+	FIELD f_ssjyfvhw emptyChunkSources Lnet/minecraft/unmapped/C_molcobnw;
 	METHOD <init> (Lnet/minecraft/unmapped/C_jhssvvvy;)V
 		ARG 1 chunkProvider
+	METHOD <init> (Lnet/minecraft/unmapped/C_jhssvvvy;Lnet/minecraft/unmapped/C_rlaljihp;)V
+		ARG 1 chunkProvider
+		ARG 2 lightStorage
+	METHOD m_kauqwoam addSourcesAbove (IIII)V
+		ARG 1 chunkX
+		ARG 2 chunkZ
+		ARG 3 maxY
+		ARG 4 minSectionY
+	METHOD m_ocqkwawa crossesSectionEdge (Lnet/minecraft/unmapped/C_xpuuihxf;II)Z
+		ARG 0 direction
+		ARG 1 localX
+		ARG 2 localY
+	METHOD m_pprdzkex updateSourcesInColumn (III)V
+		ARG 1 x
+		ARG 2 z
+		ARG 3 lowestSourceY
+	METHOD m_qbmvznwm isSourceLevel (I)Z
+		ARG 0 level
+	METHOD m_rjiyhqoj getLowestSourceY (III)I
+		ARG 1 chunkX
+		ARG 2 chunkZ
+		ARG 3 defaultValue
+	METHOD m_rnknusgh removeSourcesBelow (IIII)V
+		ARG 1 chunkX
+		ARG 2 chunkZ
+		ARG 3 lowestSourceY
+		ARG 4 minSectionY
+	METHOD m_tiiuiqob getChunkSources (II)Lnet/minecraft/unmapped/C_molcobnw;
+		ARG 1 chunkX
+		ARG 2 chunkZ
+	METHOD m_tpvwupzl countEmptySectionsBelow (J)I
+		ARG 1 blockPos
+	METHOD m_ubeesytw propagateFromEmptySections (JLnet/minecraft/unmapped/C_xpuuihxf;IZI)V
+		ARG 1 blockPos
+		ARG 4 lightLevel
+		ARG 5 increase
+		ARG 6 yNegativeOffset

--- a/mappings/net/minecraft/world/chunk/light/ChunkSkyLightSources.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkSkyLightSources.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/unmapped/C_molcobnw net/minecraft/world/chunk/light/ChunkSkyLightSources
-	FIELD f_lpddgleu mutablePos Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;
 	FIELD f_ovjbsvnn minY I
 	FIELD f_uueodcpu NEGATIVE_INFINITY I
 	FIELD f_vvmrhqbr heightmap Lnet/minecraft/unmapped/C_nwtdaytc;

--- a/mappings/net/minecraft/world/chunk/light/ChunkSkyLightSources.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkSkyLightSources.mapping
@@ -1,0 +1,47 @@
+CLASS net/minecraft/unmapped/C_molcobnw net/minecraft/world/chunk/light/ChunkSkyLightSources
+	FIELD f_lpddgleu mutablePos Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;
+	FIELD f_ovjbsvnn minY I
+	FIELD f_uueodcpu NEGATIVE_INFINITY I
+	FIELD f_vvmrhqbr heightmap Lnet/minecraft/unmapped/C_nwtdaytc;
+	FIELD f_wcgylhyp SIZE I
+	METHOD m_andvgujm findLowestSourceY (Lnet/minecraft/unmapped/C_lwzmmmqr;III)I
+		ARG 1 chunk
+		ARG 2 topSectionIndex
+		ARG 3 localX
+		ARG 4 localZ
+	METHOD m_clukdkhz isEdgeOccluded (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+		ARG 0 world
+		ARG 1 upperPos
+		ARG 2 upperState
+		ARG 3 lowerPos
+		ARG 4 lowerState
+	METHOD m_cqubmixx getLowestSourceY (II)I
+		ARG 1 localX
+		ARG 2 localZ
+	METHOD m_dhqgdede findLowestSourceBelow (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+	METHOD m_fypykufr getMaxSurfaceY ()I
+	METHOD m_gyexyxvn fillFrom (Lnet/minecraft/unmapped/C_lwzmmmqr;)V
+		ARG 1 chunk
+	METHOD m_houyjuxt get (I)I
+		ARG 1 index
+	METHOD m_jcofmsai getPackedIndex (II)I
+		ARG 0 localX
+		ARG 1 localZ
+	METHOD m_poqqebym convertMinY (I)I
+		ARG 1 y
+	METHOD m_wfqjzysz updateEdge (Lnet/minecraft/unmapped/C_peaveboq;IILnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+		ARG 2 index
+		ARG 3 value
+		ARG 4 upperPos
+		ARG 5 upperState
+		ARG 6 lowerPos
+		ARG 7 lowerState
+	METHOD m_xwudgstm set (II)V
+		ARG 1 index
+		ARG 2 y
+	METHOD m_xxpidknn update (Lnet/minecraft/unmapped/C_peaveboq;III)Z
+		ARG 2 localX
+		ARG 3 y
+		ARG 4 localZ
+	METHOD m_zfufeuoh fill (I)V
+		ARG 1 y

--- a/mappings/net/minecraft/world/chunk/light/LevelPriorityQueue.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LevelPriorityQueue.mapping
@@ -1,0 +1,21 @@
+CLASS net/minecraft/unmapped/C_phdbftjf net/minecraft/world/chunk/light/LevelPriorityQueue
+	FIELD f_cwekqynq firstQueuedLevel I
+	FIELD f_htmmymnw levelCount I
+	FIELD f_yfmcijcz queues [Lit/unimi/dsi/fastutil/longs/LongLinkedOpenHashSet;
+	METHOD <init> (II)V
+		ARG 1 levelCount
+		ARG 2 expectedLevelSize
+	METHOD m_cjvytoia checkFirstQueuedLevel (I)V
+		ARG 1 maxLevel
+	METHOD m_juquperx enqueue (JI)V
+		ARG 1 id
+		ARG 3 level
+	METHOD m_mzaqjths removeFirstLong ()J
+	METHOD m_uuyythrm dequeue (JII)V
+		ARG 1 id
+		ARG 3 level
+		ARG 4 maxLevel
+	METHOD m_vzrywweg isEmpty ()Z
+	CLASS C_qryfoxpv
+		METHOD rehash rehash (I)V
+			ARG 1 i

--- a/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_psydzvcq net/minecraft/world/chunk/light/LevelPropagator
+	FIELD f_fsxcmtae pendingUpdateQueue Lnet/minecraft/unmapped/C_phdbftjf;
 	FIELD f_gzihvuvd levelCount I
+	FIELD f_jzlyqmhk SOURCE J
 	FIELD f_nfunmrxz pendingUpdates Lit/unimi/dsi/fastutil/longs/Long2ByteMap;
 	FIELD f_ucijpoih hasPendingUpdates Z
 	FIELD f_xrtgeqfq MAX_LEVEL I
@@ -16,6 +18,9 @@ CLASS net/minecraft/unmapped/C_psydzvcq net/minecraft/world/chunk/light/LevelPro
 		ARG 3 id
 		ARG 5 level
 		ARG 6 decrease
+	METHOD m_iuzvpwxo calculateLevel (II)I
+		ARG 1 a
+		ARG 2 b
 	METHOD m_lpjrhbxi getPropagatedLevel (JJI)I
 		ARG 1 sourceId
 		ARG 3 targetId
@@ -31,6 +36,8 @@ CLASS net/minecraft/unmapped/C_psydzvcq net/minecraft/world/chunk/light/LevelPro
 		ARG 1 id
 		ARG 3 excludedId
 		ARG 5 maxLevel
+	METHOD m_pzufxuen (Ljava/util/function/LongPredicate;Lit/unimi/dsi/fastutil/longs/LongList;J)V
+		ARG 2 level
 	METHOD m_rcktpimf isMarker (J)Z
 		ARG 1 id
 	METHOD m_rfsxllfk removePendingUpdateIf (Ljava/util/function/LongPredicate;)V

--- a/mappings/net/minecraft/world/chunk/light/LightEventListener.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightEventListener.mapping
@@ -1,10 +1,16 @@
-CLASS net/minecraft/unmapped/C_uwjwgxhc net/minecraft/world/chunk/light/LightingView
+CLASS net/minecraft/unmapped/C_uwjwgxhc net/minecraft/world/chunk/light/LightEventListener
+	METHOD m_cmfibydp runLightUpdates ()I
 	METHOD m_gyneyqlr setSectionStatus (Lnet/minecraft/unmapped/C_hynzadkk;Z)V
 		ARG 1 pos
 		ARG 2 notReady
 	METHOD m_idxlrtdh checkBlock (Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 pos
+	METHOD m_kjgxwinj setLightEnabled (Lnet/minecraft/unmapped/C_ynrszrtu;Z)V
+		ARG 1 pos
+		ARG 2 enabled
 	METHOD m_mlkcmlsw hasUpdates ()Z
 	METHOD m_myforzem setSectionStatus (Lnet/minecraft/unmapped/C_zubvmeye;Z)V
 		ARG 1 pos
 		ARG 2 notReady
+	METHOD m_nhbjqcvk propagateLightSources (Lnet/minecraft/unmapped/C_ynrszrtu;)V
+		ARG 1 pos

--- a/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
@@ -14,40 +14,62 @@ CLASS net/minecraft/unmapped/C_jbeocnxo net/minecraft/world/chunk/light/LightSto
 	FIELD f_mesdifhs lightType Lnet/minecraft/unmapped/C_fhvlmqtw;
 	FIELD f_msjxleyd dirtySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD f_nuubbbls columnsToRetain Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD f_oogambyi enabledColumns Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD f_pvwqdcuu notifySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD f_qwkkrrne queuedSections Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
+	FIELD f_scqciszr hasLightUpdates Z
 	FIELD f_sklbmqyv uncachedStorage Lnet/minecraft/unmapped/C_jdzznmbv;
 	FIELD f_trtxwtss sectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD f_voaewlib sectionStates Lit/unimi/dsi/fastutil/longs/Long2ByteMap;
 	FIELD f_zrurunvu chunkProvider Lnet/minecraft/unmapped/C_jhssvvvy;
 	METHOD <init> (Lnet/minecraft/unmapped/C_fhvlmqtw;Lnet/minecraft/unmapped/C_jhssvvvy;Lnet/minecraft/unmapped/C_jdzznmbv;)V
 		ARG 1 lightType
 		ARG 2 chunkProvider
 		ARG 3 lightData
+	METHOD m_briaekcb putSectionState (JB)V
+		ARG 1 sectionPos
+		ARG 3 state
 	METHOD m_dqsmfxmr setRetainColumn (JZ)V
 		ARG 1 sectionPos
 		ARG 3 retain
+	METHOD m_egnbnfxl getType (J)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
+		ARG 1 sectionPos
 	METHOD m_eiakvigx hasSection (J)Z
 		ARG 1 sectionPos
 	METHOD m_fqmrtdms updateLight (Lnet/minecraft/unmapped/C_upkweuif;)V
+		ARG 1 lightProvider
 	METHOD m_hjzphppe onLoadSection (J)V
 		ARG 1 sectionPos
 	METHOD m_hqhiqhhi set (JI)V
 		ARG 1 blockPos
 		ARG 3 value
+	METHOD m_hwfejwis setColumEnabled (JZ)V
+		ARG 1 columnPos
+		ARG 3 enabled
 	METHOD m_kddiegam enqueueSectionData (JLnet/minecraft/unmapped/C_cneaxdxg;)V
 		ARG 1 sectionPos
 		ARG 3 array
 	METHOD m_mhvcjheb get (J)I
 		ARG 1 blockPos
+	METHOD m_npchrzjp addNotifySections (J)V
+		ARG 1 sectionPos
+	METHOD m_nsozzdfz getLightSectionToWrite (J)Lnet/minecraft/unmapped/C_cneaxdxg;
+		ARG 1 sectionPos
 	METHOD m_ofuazfca notifyChanges ()V
 	METHOD m_pvecduvn getLightSection (Lnet/minecraft/unmapped/C_jdzznmbv;J)Lnet/minecraft/unmapped/C_cneaxdxg;
 		ARG 1 storage
 		ARG 2 sectionPos
+	METHOD m_pxhvbkpf isSectionColumnEnabled (J)Z
+		ARG 1 sectionPos
 	METHOD m_rxafiwiu getLight (J)I
 		ARG 1 blockPos
+	METHOD m_tyyxpbbk queueForUpdate (J)V
+		ARG 1 sectionPos
 	METHOD m_vhvnvicu getLightSection (JZ)Lnet/minecraft/unmapped/C_cneaxdxg;
 		ARG 1 sectionPos
 		ARG 3 cached
+	METHOD m_wzssrukw queueSectionRemoval (J)V
+		ARG 1 sectionPos
 	METHOD m_xfsbvnmn getLightSection (J)Lnet/minecraft/unmapped/C_cneaxdxg;
 		ARG 1 sectionPos
 	METHOD m_xjzllulu createSection (J)Lnet/minecraft/unmapped/C_cneaxdxg;
@@ -58,3 +80,26 @@ CLASS net/minecraft/unmapped/C_jbeocnxo net/minecraft/world/chunk/light/LightSto
 		ARG 1 sectionPos
 		ARG 3 notReady
 	METHOD m_zxaouzke hasLightUpdates ()Z
+	CLASS C_ljdoldct SectionType
+		FIELD f_apcsdihh id Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 id
+		METHOD m_hdcpudxb getId ()Ljava/lang/String;
+	CLASS C_qcjrtiqw SectionState
+		FIELD f_bgcypcpf EMPTY B
+		FIELD f_lmbdqkcm MAX_NEIGHBOR_COUNT I
+		FIELD f_sybxyakg MIN_NEIGHBOR_COUNT I
+		FIELD f_vhxlknkj HAS_DATA_BIT B
+		FIELD f_ybdnfcqo NEIGHBOR_COUNT_BITS B
+		METHOD m_kggxezfj getNeighborCount (B)I
+			ARG 0 packed
+		METHOD m_omwbasiq setHasData (BZ)B
+			ARG 0 packed
+			ARG 1 hasData
+		METHOD m_pwllrsuj getType (B)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
+			ARG 0 packed
+		METHOD m_svkahyyl withNeighborCount (BI)B
+			ARG 0 packed
+			ARG 1 neighborCount
+		METHOD m_yvatgcgo hasData (B)Z
+			ARG 0 packed

--- a/mappings/net/minecraft/world/chunk/light/LightingProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightingProvider.mapping
@@ -10,6 +10,9 @@ CLASS net/minecraft/unmapped/C_ksposksb net/minecraft/world/chunk/light/Lighting
 	METHOD m_dyemchbd displaySectionLevel (Lnet/minecraft/unmapped/C_fhvlmqtw;Lnet/minecraft/unmapped/C_zubvmeye;)Ljava/lang/String;
 		ARG 1 lightType
 		ARG 2 sectionPos
+	METHOD m_hkuaoqwh getSectionType (Lnet/minecraft/unmapped/C_fhvlmqtw;Lnet/minecraft/unmapped/C_zubvmeye;)Lnet/minecraft/unmapped/C_jbeocnxo$C_ljdoldct;
+		ARG 1 lightType
+		ARG 2 pos
 	METHOD m_krxqidxo get (Lnet/minecraft/unmapped/C_fhvlmqtw;)Lnet/minecraft/unmapped/C_blhynqen;
 		ARG 1 lightType
 	METHOD m_nprthdzi getLight (Lnet/minecraft/unmapped/C_hynzadkk;I)I
@@ -25,3 +28,5 @@ CLASS net/minecraft/unmapped/C_ksposksb net/minecraft/world/chunk/light/Lighting
 		ARG 1 pos
 		ARG 2 retainData
 	METHOD m_wxfuiila getHeight ()I
+	METHOD m_yyhojihj isLightingEnabled (Lnet/minecraft/unmapped/C_zubvmeye;)Z
+		ARG 1 pos

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -8,6 +8,11 @@ CLASS net/minecraft/unmapped/C_rlaljihp net/minecraft/world/chunk/light/SkyLight
 		ARG 3 cached
 	METHOD m_hlkejitm isAtOrAboveTopmostSection (J)Z
 		ARG 1 sectionPos
+	METHOD m_ltheuegr getTopSectionForColumn (J)I
+		ARG 1 columnPos
+	METHOD m_ogdqasif isAboveMinSectionY (I)Z
+		ARG 1 sectionY
+	METHOD m_vwwbggyq getMinSectionY ()I
 	CLASS C_ruqcmsku Data
 		FIELD f_dixjawif columnToTopSection Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;
 		FIELD f_dvidliyi minSectionY I


### PR DESCRIPTION
DEFINITELY not my best work and very mojmapped. 100%s everything in `net/minecraft/world/chunk/light`.

notes:
- does a couple renames to clear out some questionable old yarn
- refactors ChunkNibbleArray to just be more in line with mojang's intention