### PR TITLE
[1.19.4] Fix name collision in `DisplayEntity` with methods on `Entity`

### DIFF
--- a/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	METHOD m_mfdnbnif getBillboardRenderConstraints ()Lnet/minecraft/unmapped/C_zdeutotk$C_cozbiatm;
 	METHOD m_mhzmmfsl getTransformation (Lnet/minecraft/unmapped/C_pyoaoolj;)Lnet/minecraft/unmapped/C_qvfggwhk;
 		ARG 0 tracker
-	METHOD m_mkgxqfrt getWidth ()F
+	METHOD m_mkgxqfrt getDisplayWidth ()F
 	METHOD m_nbotmszd setTransformation (Lnet/minecraft/unmapped/C_qvfggwhk;)V
 		ARG 1 transformation
 	METHOD m_ogmsufqg getInterpolationProgress (F)F
@@ -77,7 +77,7 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 		ARG 1 brightness
 	METHOD m_wmplpzcr interpolate (F)Lnet/minecraft/unmapped/C_qvfggwhk;
 		ARG 1 delta
-	METHOD m_xnqmzrtk getHeight ()F
+	METHOD m_xnqmzrtk getDisplayHeight ()F
 	METHOD m_xqfovtgz (Lcom/mojang/datafixers/util/Pair;)V
 		ARG 1 pair
 	METHOD m_xytfwvza getShadowRadius ()F


### PR DESCRIPTION
Fixes #418 