### PR TITLE
[1.20-pre1] Fix name collision in `DisplayEntity` with methods on `Entity`

### DIFF
--- a/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	METHOD m_mfdnbnif getBillboardRenderConstraints ()Lnet/minecraft/unmapped/C_zdeutotk$C_cozbiatm;
 	METHOD m_mhzmmfsl getTransformation (Lnet/minecraft/unmapped/C_pyoaoolj;)Lnet/minecraft/unmapped/C_qvfggwhk;
 		ARG 0 tracker
-	METHOD m_mkgxqfrt getWidth ()F
+	METHOD m_mkgxqfrt getDisplayWidth ()F
 	METHOD m_mrtvrlhy getStartInterpolation ()I
 	METHOD m_nbotmszd setTransformation (Lnet/minecraft/unmapped/C_qvfggwhk;)V
 		ARG 1 transformation
@@ -65,7 +65,7 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 		ARG 1 duration
 	METHOD m_vifcnxkl setBrightnessOverride (Lnet/minecraft/unmapped/C_wzagqsft;)V
 		ARG 1 brightness
-	METHOD m_xnqmzrtk getHeight ()F
+	METHOD m_xnqmzrtk getDisplayHeight ()F
 	METHOD m_xqfovtgz (Lcom/mojang/datafixers/util/Pair;)V
 		ARG 1 pair
 	METHOD m_ykgoueyp setShadowRadius (F)V


### PR DESCRIPTION
Fixes #418 