### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/actions/diff-uploader/action.yml
+++ b/.github/actions/diff-uploader/action.yml
@@ -11,5 +11,5 @@ outputs:
   result:
     description: 'Result of the action'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/.github/actions/diff-uploader/index.js
+++ b/.github/actions/diff-uploader/index.js
@@ -1,6 +1,73 @@
 const core = require('@actions/core');
+const { summary } = require('@actions/core/lib/summary');
 const {context, getOctokit} = require('@actions/github');
 const fs = require("fs");
+
+const maxDiffCommentLength = 64000;
+const maxDiffComments = 3;
+
+function splitDiff(diff, depth) {
+    if (diff.length <= maxDiffCommentLength) {
+        return [diff];
+    }
+
+    let lastDiffLiteralIndex = diff.lastIndexOf("\ndiff", maxDiffCommentLength) + 1;
+
+    let resultDiff;
+    let remainingDiff;
+    if (lastDiffLiteralIndex == 0) {
+        let index = diff.lastIndexOf("\n", maxDiffCommentLength) + 1;
+        resultDiff = diff.substring(0, index) + "\nThe diff for this file is not complete!";
+        remainingDiff = "Continuation of the last diff...\n" + diff.substring(index);
+    } else {
+        resultDiff = diff.substring(0, lastDiffLiteralIndex);
+        remainingDiff = diff.substring(lastDiffLiteralIndex);
+    }
+
+
+    if (depth < maxDiffComments - 1) {
+        return [resultDiff].concat(splitDiff(remainingDiff, depth + 1));
+    } else {
+        return [resultDiff + "\n\nThe remaining diff is too long!"];
+    }
+}
+
+async function commentDiff(summary, diff, doComment) {
+    if (diff.length > maxDiffCommentLength) {
+        let diffs = splitDiff(diff, 0);
+        let l = diffs.length;
+        for (let i = 0; i < l; i++) {
+            let iDiff = diffs[i];
+            let pref = i == 0 ? summary + "\n\n" : "";
+
+            // Formatting :pain:
+            await doComment(
+`${pref}\<details\>
+\<summary\>View the diff here (${i + 1}/${l}):\</summary\>
+\<br\>
+
+\`\`\`diff
+${iDiff}
+\`\`\`
+\</details\>`
+);
+        }
+    } else {
+
+        await doComment(
+`${summary}
+
+\<details\>
+\<summary\>View the diff here:\</summary\>
+\<br\>
+
+\`\`\`diff
+${diff}
+\`\`\`
+\</details\>`
+);
+    }
+}
 
 async function main() {
     const token = core.getInput('github-token', {required: true});
@@ -53,7 +120,7 @@ async function main() {
             let modified_files = (diff.match(new RegExp("^\\+\\+\\+", "gm")) || []).length;
 
             core.setOutput("result", "success");
-            await comment(`With commit ${context.sha}, ${modified_files} file(s) were updated with ${added_lines} line(s) added and ${removed_lines} removed compared to the latest Quilt Mappings version. \n\n\<details\>\n\<summary\>View the diff here:\</summary\> \n\<br\>\n\n\`\`\`diff\n${diff}\`\`\`\n\</details\>`)
+            await commentDiff(`With commit ${context.sha}, ${modified_files} file(s) were updated with ${added_lines} line(s) added and ${removed_lines} removed compared to the latest Quilt Mappings version.`, diff, comment);
         }
     } catch (err) {
         console.error(err);

--- a/.github/actions/diff-uploader/package-lock.json
+++ b/.github/actions/diff-uploader/package-lock.json
@@ -5,12 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "diff-uploader",
       "version": "1.0.0",
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/github": "^5.0.0",
         "@extra-fs/promises": "^3.1.4",
-        "@vercel/ncc": "^0.32.0"
+        "@vercel/ncc": "^0.36.0"
       }
     },
     "node_modules/@actions/core": {
@@ -148,9 +149,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.32.0.tgz",
-      "integrity": "sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
@@ -376,9 +377,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.32.0.tgz",
-      "integrity": "sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA=="
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw=="
     },
     "before-after-hook": {
       "version": "2.2.3",

--- a/.github/actions/diff-uploader/package.json
+++ b/.github/actions/diff-uploader/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/github": "^5.0.0",
-    "@vercel/ncc": "^0.32.0",
+    "@vercel/ncc": "^0.36.0",
     "@extra-fs/promises": "^3.1.4"
   }
 }

--- a/.github/actions/update-base/action.yml
+++ b/.github/actions/update-base/action.yml
@@ -11,5 +11,5 @@ outputs:
   result:
     description: 'Result of the action'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/.github/actions/update-base/package-lock.json
+++ b/.github/actions/update-base/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/github": "^5.0.0",
-        "@vercel/ncc": "^0.32.0"
+        "@vercel/ncc": "^0.36.0"
       }
     },
     "node_modules/@actions/core": {
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.32.0.tgz",
-      "integrity": "sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
@@ -384,9 +384,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.32.0.tgz",
-      "integrity": "sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA=="
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw=="
     },
     "before-after-hook": {
       "version": "2.2.2",

--- a/.github/actions/update-base/package.json
+++ b/.github/actions/update-base/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/github": "^5.0.0",
-    "@vercel/ncc": "^0.32.0"
+    "@vercel/ncc": "^0.36.0"
   }
 }


### PR DESCRIPTION
Also fixes the `body is too long (maximum is 65536 characters)` error when the diff is too long, by splitting it into smaller comments