### PR TITLE
Redstone related refactors - 1.19.4 edition

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -15,6 +15,10 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 settings
 	METHOD m_bhohbmwk getWeakRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT {@return the weak redstone power this block emits in the given direction}
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT returns power in the <i>opposite</i> direction of the one given.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -44,7 +48,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 2 view
 		ARG 3 pos
 	METHOD m_ewcsdntg asBlock ()Lnet/minecraft/unmapped/C_mmxmpdoq;
-	METHOD m_fjkbizwn emitsRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_fjkbizwn isRedstonePowerSource (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
 	METHOD m_fqngyjtr getOutlineShape (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_pbfjvesm;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 state
@@ -204,6 +208,10 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 4 projectile
 	METHOD m_xfdklwdd getVerticalModelOffsetMultiplier ()F
 	METHOD m_ydisyayk getStrongRedstonePower (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT {@return the strong redstone power this block emits in the given direction}
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT returns power in the <i>opposite</i> direction of the one given.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -472,7 +480,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 2 state
 			ARG 3 hit
 			ARG 4 projectile
-		METHOD m_vlxoaqxh emitsRedstonePower ()Z
+		METHOD m_vlxoaqxh isRedstonePowerSource ()Z
 		METHOD m_vrkuyjxa onSyncedBlockEvent (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;II)Z
 			ARG 1 world
 			ARG 2 pos

--- a/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_lgaafbhj net/minecraft/block/AbstractPressurePlat
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;Lnet/minecraft/unmapped/C_hgpogkhy;)V
 		ARG 1 settings
 		ARG 2 blockSetType
-	METHOD m_bbgybojj getRedstoneOutput (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)I
+	METHOD m_bbgybojj calculateRedstoneOutput (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 world
 		ARG 2 pos
 	METHOD m_cyzszxhg updatePlateState (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;I)V

--- a/mappings/net/minecraft/block/ComparatorBlock.mapping
+++ b/mappings/net/minecraft/block/ComparatorBlock.mapping
@@ -4,11 +4,11 @@ CLASS net/minecraft/unmapped/C_qrhvqyam net/minecraft/block/ComparatorBlock
 		ARG 1 world
 		ARG 2 facing
 		ARG 3 pos
-	METHOD m_flfmkilz calculateOutputSignal (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+	METHOD m_flfmkilz calculateOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_gnmmcvoj update (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
+	METHOD m_gnmmcvoj updateOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state

--- a/mappings/net/minecraft/block/RedstoneDiodeBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneDiodeBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/AbstractRedstoneGateBlock
+CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/RedstoneDiodeBlock
 	FIELD f_kflbgyvb SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zkbuxycf POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD m_awrsqovb getMaxInputLevelSides (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
@@ -13,29 +13,29 @@ CLASS net/minecraft/unmapped/C_ivhjpfio net/minecraft/block/AbstractRedstoneGate
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_gxskdeps getPower (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
+	METHOD m_gxskdeps getInputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 	METHOD m_ivykfrsh getUpdateDelayInternal (Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 state
-	METHOD m_jsbiqhca isRedstoneGate (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_jsbiqhca isDiode (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
-	METHOD m_knkofhxw isValidInput (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_knkofhxw isSideInputValid (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
 	METHOD m_lgirilub isTargetNotAligned (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_ncapgwkk updatePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
+	METHOD m_ncapgwkk checkOutputLevel (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_qmwftzms hasPower (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_qmwftzms shouldBePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD m_vrqcwder getInputLevel (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+	METHOD m_vrqcwder getInputLevelSide (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 dir

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -68,6 +68,7 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 3 fromPos
 	METHOD m_bbirufyx disconnect ()V
 	METHOD m_bwleesdb getReceivedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
+		COMMENT {@return the strong redstone power the given position receives from neighboring blocks}
 		ARG 1 pos
 	METHOD m_cftbxfln isDirectionSolid (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 pos
@@ -82,8 +83,12 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 	METHOD m_cnpexxbj setLightningTicksLeft (I)V
 		ARG 1 lightningTicksLeft
 	METHOD m_cosjeaoq isEmittingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
+		COMMENT {@return whether redstone power is emitted from the given position in the given direction}
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
-		ARG 2 direction
+		ARG 2 dir
 	METHOD m_cpgionsz getRegistryKey ()Lnet/minecraft/unmapped/C_xhhleach;
 	METHOD m_cqotfzpd playSound (Lnet/minecraft/unmapped/C_jzrpycqo;DDDLnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_pqzizukq;FFJ)V
 		ARG 1 except
@@ -105,6 +110,7 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 2 pos
 		ARG 3 data
 	METHOD m_dhgnxris getReceivedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)I
+		COMMENT {@return the redstone power the given position receives from neighboring blocks}
 		ARG 1 pos
 	METHOD m_dmpgcjnl updateListeners (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;I)V
 		ARG 1 pos
@@ -263,8 +269,14 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 2 block
 	METHOD m_qziyykad getDamageSources ()Lnet/minecraft/unmapped/C_lddxcbik;
 	METHOD m_rbciwyji getEmittedRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT {@return the redstone power emitted from the given position in the given direction}
+		COMMENT This is the highest value between power emitted by the block itself, and strong redstone power
+		COMMENT received from neighboring blocks if the block is a redstone conductor.
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
-		ARG 2 direction
+		ARG 2 dir
 	METHOD m_rlsuyrel createExplosion (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;Lnet/minecraft/unmapped/C_dmexlawk;DDDFZLnet/minecraft/unmapped/C_cdctfzbn$C_dlzvrbnu;Z)Lnet/minecraft/unmapped/C_aahhrzpf;
 		ARG 1 entity
 		ARG 2 source
@@ -287,6 +299,7 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 11 velocityY
 		ARG 13 velocityZ
 	METHOD m_rorehhll isReceivingRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		COMMENT {@return whether the given position receives any redstone power from neighboring blocks}
 		ARG 1 pos
 	METHOD m_rsnbcuug getWorldChunk (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hrdsvlkq;
 		ARG 1 pos

--- a/mappings/net/minecraft/world/WorldView.mapping
+++ b/mappings/net/minecraft/world/WorldView.mapping
@@ -1,8 +1,12 @@
 CLASS net/minecraft/unmapped/C_eemzphbi net/minecraft/world/WorldView
 	COMMENT Represents a scoped, read-only view of a world like structure that contains biomes, chunks and is bound to a dimension.
-	METHOD m_anifzqoe getStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+	METHOD m_anifzqoe getEmittedStrongRedstonePower (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)I
+		COMMENT {@return the strong redstone power emitted from the given position in the given direction}
+		COMMENT <p>
+		COMMENT NOTE: directions in redstone power related methods are backwards, so this method
+		COMMENT checks for power in the <i>opposite</i> direction of the one given.
 		ARG 1 pos
-		ARG 2 direction
+		ARG 2 dir
 	METHOD m_biizoxac getBiome (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 1 pos
 	METHOD m_btlyapdt getChunk (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_lwzmmmqr;


### PR DESCRIPTION
backports #402 to 1.19.4 - also fixes #434 

- `AbstractRedstoneGateBlock` has been renamed to `RedstoneDiodeBlock` for a more accurate and concise name. Several methods in this class, as well as its subclasses `RepeaterBlock` and `ComparatorBlock`, have been renamed to better reflect whether they deal with input or output.
- `AbstractBlock#emitsRedstonePower` has been renamed to `isRedstonePowerSource` to make it less confusing.
- Methods for querying redstone power in `World` have been updated to match those in the new `RedstonePowerView` interface in 1.20.