### PR TITLE
specify that some `Text.translatable` methods take a fallback

### DIFF
--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/unmapped/C_rdaqiwdt net/minecraft/text/Text
 	COMMENT @see Text#nbt(String, boolean, Optional, TextData)
 	COMMENT @see Text#score(String, String)
 	COMMENT @see Text#selector(String, Optional)
-	METHOD m_dbsuxeye translatable (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_npqneive;
+	METHOD m_dbsuxeye translatableWithFallback (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 0 translationKey
 		ARG 1 fallback
 	METHOD m_dmavlphp asOrderedText ()Lnet/minecraft/unmapped/C_apvkgwyi;
@@ -108,7 +108,7 @@ CLASS net/minecraft/unmapped/C_rdaqiwdt net/minecraft/text/Text
 		COMMENT @return the new mutable score text
 		ARG 0 name
 		ARG 1 objective
-	METHOD m_ywwehcem translatable (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Lnet/minecraft/unmapped/C_npqneive;
+	METHOD m_ywwehcem translatableWithFallback (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 0 translationKey
 		ARG 1 fallback
 		ARG 2 args


### PR DESCRIPTION
I'm personally neutral on this change, but it was suggested by @patbox. discuss!