### PR TITLE
Add javadoc publishing code

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.github_token }}
           prefix: "build/${{ github.ref }}"
 
-      - run: ./gradlew build javadocJar publish --stacktrace
+      - run: ./gradlew build javadoc javadocJar publish --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
@@ -38,7 +38,21 @@ jobs:
           SNAPSHOTS_USERNAME: ${{ secrets.SNAPSHOTS_USERNAME }}
           SNAPSHOTS_PASSWORD: ${{ secrets.SNAPSHOTS_PASSWORD }}
           BRANCH_NAME: ${{ github.ref }}
-
+      # Javadoc publishing
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: 'gh-pages'
+          path: 'gh-pages'
+      - run: |
+        rm -rf ./gh-pages/${GITHUB_REF##*/}/
+        mv ./build/docs/javadoc ./gh-pages/${GITHUB_REF##*/}/
+        cd gh-pages
+        git add .
+        git config user.name "Github Actions"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git commit --allow-empty -m "Publish javadoc from actions"
+        git push
       - name: Update Quilt Meta
         uses: quiltmc/update-quilt-meta@main
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -392,6 +392,7 @@ javadoc {
 		addBooleanOption 'Xdoclint:syntax', true
 		addBooleanOption 'Xdoclint:reference', true
 		addBooleanOption 'Xdoclint:accessibility', true
+		addStringOption '-notimestamp'
 	}
 	source fileTree(fakeSourceDir) + sourceSets.constants.allJava + sourceSets.packageDocs.allJava
 	classpath = configurations.javadocClasspath + downloadMinecraftLibraries.outputs.files.asFileTree + mapNamedJar.outputs.files.asFileTree

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This publishes javadoc for the latest QM version at `quiltmc.github.io/quilt-mappings/<BRANCH_NAME>` (domain can be changed by an admin if they desire, i'd recommend `javadoc.quiltmc.org`)

Before merge someone needs to run the following code to set up the `gh-pages` branch:
`git switch --orphan gh-pages`
`git commit --allow-empty -m "root commit for javadoc"`
`git push`

(Also, yes this code is awful i'm not an infra person)