### PR TITLE
mostly client mappings

### DIFF
--- a/mappings/net/minecraft/block/BlockSetType.mapping
+++ b/mappings/net/minecraft/block/BlockSetType.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/unmapped/C_hgpogkhy net/minecraft/block/BlockSetType
 	FIELD f_zicdgceu TYPES Ljava/util/Set;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 id
+	METHOD <init> (Ljava/lang/String;ZLnet/minecraft/unmapped/C_aevintex;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_avavozay;)V
+		ARG 1 name
 	METHOD m_qhxbzkuh create (Lnet/minecraft/unmapped/C_hgpogkhy;)Lnet/minecraft/unmapped/C_hgpogkhy;
 		ARG 0 type
 	METHOD m_tcwtnxpb getTypes ()Ljava/util/stream/Stream;

--- a/mappings/net/minecraft/block/LavaCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/LavaCauldronBlock.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/unmapped/C_rkbdhhnb net/minecraft/block/LavaCauldronBlock

--- a/mappings/net/minecraft/block/PowderSnowCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/PowderSnowCauldronBlock.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/unmapped/C_gxepsuup net/minecraft/block/PowderSnowCauldronBlock

--- a/mappings/net/minecraft/block/SignBlock.mapping
+++ b/mappings/net/minecraft/block/SignBlock.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_kkhuxlco net/minecraft/block/SignBlock
-	FIELD f_vgyqsszu ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;

--- a/mappings/net/minecraft/block/cauldron/AbstractCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/AbstractCauldronBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_ukinmebz net/minecraft/block/AbstractCauldronBlock
+CLASS net/minecraft/unmapped/C_ukinmebz net/minecraft/block/cauldron/AbstractCauldronBlock
 	FIELD f_cytxtxxd OUTLINE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ewvwrjxo LEG_WIDTH I
 	FIELD f_oamzdawa SIDE_THICKNESS I

--- a/mappings/net/minecraft/block/cauldron/CauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/CauldronBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_vlqpfmkq net/minecraft/block/CauldronBlock
+CLASS net/minecraft/unmapped/C_vlqpfmkq net/minecraft/block/cauldron/CauldronBlock
 	FIELD f_mhftrnlc FILL_WITH_SNOW_CHANCE F
 	FIELD f_rkkxqgtp FILL_WITH_RAIN_CHANCE F
 	METHOD m_mvzwzigt canFillWithPrecipitation (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_orlkpefs$C_xwlyzxea;)Z

--- a/mappings/net/minecraft/block/cauldron/LavaCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/LavaCauldronBlock.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_rkbdhhnb net/minecraft/block/cauldron/LavaCauldronBlock

--- a/mappings/net/minecraft/block/cauldron/LeveledCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/LeveledCauldronBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_lfbgqelt net/minecraft/block/LeveledCauldronBlock
+CLASS net/minecraft/unmapped/C_lfbgqelt net/minecraft/block/cauldron/LeveledCauldronBlock
 	FIELD f_erckkndb RAIN_PREDICATE Ljava/util/function/Predicate;
 	FIELD f_gerxtvdv LEVEL Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_gnqvlsoc SNOW_PREDICATE Ljava/util/function/Predicate;

--- a/mappings/net/minecraft/block/cauldron/PowderSnowCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/PowderSnowCauldronBlock.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_gxepsuup net/minecraft/block/cauldron/PowderSnowCauldronBlock

--- a/mappings/net/minecraft/block/dispenser/DispenserBlock.mapping
+++ b/mappings/net/minecraft/block/dispenser/DispenserBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_sridforj net/minecraft/block/DispenserBlock
+CLASS net/minecraft/unmapped/C_sridforj net/minecraft/block/dispenser/DispenserBlock
 	FIELD f_bkwqoovv BEHAVIORS Ljava/util/Map;
 	FIELD f_etrjkrot SCHEDULED_TICK_DELAY I
 	FIELD f_kigvivjn FACING Lnet/minecraft/unmapped/C_tcujuvjb;

--- a/mappings/net/minecraft/block/piston/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/piston/PistonBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/PistonBlock
+CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/piston/PistonBlock
 	FIELD f_ajnebgtk TRIGGER_DROP I
 	FIELD f_dtwjvhds TRIGGER_RETRACT I
 	FIELD f_fwvupsif EXTENDED_WEST_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/piston/PistonExtensionBlock.mapping
+++ b/mappings/net/minecraft/block/piston/PistonExtensionBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_yqbibfrg net/minecraft/block/PistonExtensionBlock
+CLASS net/minecraft/unmapped/C_yqbibfrg net/minecraft/block/piston/PistonExtensionBlock
 	FIELD f_ffpotnhz TYPE Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_xcreetym FACING Lnet/minecraft/unmapped/C_tcujuvjb;
 	METHOD m_llleflen getPistonBlockEntity (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_wpearmnv;

--- a/mappings/net/minecraft/block/piston/PistonHeadBlock.mapping
+++ b/mappings/net/minecraft/block/piston/PistonHeadBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_kovydcjx net/minecraft/block/PistonHeadBlock
+CLASS net/minecraft/unmapped/C_kovydcjx net/minecraft/block/piston/PistonHeadBlock
 	FIELD f_acanyiod SHORT_DOWN_ARM_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_exikhpdp WEST_HEAD_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_fbtweryx NORTH_ARM_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/sapling/SaplingBlock.mapping
+++ b/mappings/net/minecraft/block/sapling/SaplingBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_zzbhjpvq net/minecraft/block/SaplingBlock
+CLASS net/minecraft/unmapped/C_zzbhjpvq net/minecraft/block/sapling/SaplingBlock
 	FIELD f_cewxtiqp SHAPE_OFFSET F
 	FIELD f_tbvcakjw generator Lnet/minecraft/unmapped/C_zmhytkpk;
 	FIELD f_tqtogbrh SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/sculk/SculkBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_jfiifxec net/minecraft/block/SculkBlock
+CLASS net/minecraft/unmapped/C_jfiifxec net/minecraft/block/sculk/SculkBlock
 	METHOD m_cndtctvo canSpreadTo (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/block/sculk/SculkCatalystBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkCatalystBlock.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/unmapped/C_qqcyyscl net/minecraft/block/SculkCatalystBlock
+CLASS net/minecraft/unmapped/C_qqcyyscl net/minecraft/block/sculk/SculkCatalystBlock
 	FIELD f_kqttjvnj BLOOM Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_wlgjopre experienceProvider Lnet/minecraft/unmapped/C_macfejbg;

--- a/mappings/net/minecraft/block/sculk/SculkSensorBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkSensorBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_ecaydczd net/minecraft/block/SculkSensorBlock
+CLASS net/minecraft/unmapped/C_ecaydczd net/minecraft/block/sculk/SculkSensorBlock
 	FIELD f_ctnilncr OUTLINE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_cvdnduhl RESONATION_NOTE_PITCHES [F
 	FIELD f_mdopchsr SCULK_SENSOR_PHASE Lnet/minecraft/unmapped/C_cgckxfsw;

--- a/mappings/net/minecraft/block/sculk/SculkShriekerBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkShriekerBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_wxvelcrz net/minecraft/block/SculkShriekerBlock
+CLASS net/minecraft/unmapped/C_wxvelcrz net/minecraft/block/sculk/SculkShriekerBlock
 	FIELD f_iaexdaun SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_lfdezzzn WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_reudzzme CAN_SUMMON Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/block/sculk/SculkVeinBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkVeinBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_bjvwjobf net/minecraft/block/SculkVeinBlock
+CLASS net/minecraft/unmapped/C_bjvwjobf net/minecraft/block/sculk/SculkVeinBlock
 	FIELD f_lhdhlpuz samePosLichenSpreadBehavior Lnet/minecraft/unmapped/C_twpgwpwn;
 	FIELD f_pwsdtjjz lichenSpreadBehavior Lnet/minecraft/unmapped/C_twpgwpwn;
 	FIELD f_xpzepffk WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/block/sign/AbstractSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/AbstractSignBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_siepybep net/minecraft/block/AbstractSignBlock
+CLASS net/minecraft/unmapped/C_siepybep net/minecraft/block/sign/AbstractSignBlock
 	FIELD f_csmgbvyd SHAPE_OFFSET F
 	FIELD f_jhuobgwm SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_mryvqsio type Lnet/minecraft/unmapped/C_xlaykyai;

--- a/mappings/net/minecraft/block/sign/CeilingHangingSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/CeilingHangingSignBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_vsqrirpz net/minecraft/block/CeilingHangingSignBlock
+CLASS net/minecraft/unmapped/C_vsqrirpz net/minecraft/block/sign/CeilingHangingSignBlock
 	FIELD f_ddmznrkm SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_mofkwlez SHAPES Ljava/util/Map;
 	FIELD f_nvyebogo ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;

--- a/mappings/net/minecraft/block/sign/SignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/SignBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_kkhuxlco net/minecraft/block/sign/SignBlock
+	FIELD f_vgyqsszu ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;

--- a/mappings/net/minecraft/block/sign/SignType.mapping
+++ b/mappings/net/minecraft/block/sign/SignType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_xlaykyai net/minecraft/util/SignType
+CLASS net/minecraft/unmapped/C_xlaykyai net/minecraft/block/sign/SignType
 	FIELD f_bklshwff SPRUCE Lnet/minecraft/unmapped/C_xlaykyai;
 	FIELD f_ceylskkb CHERRY Lnet/minecraft/unmapped/C_xlaykyai;
 	FIELD f_irhjmyrf OAK Lnet/minecraft/unmapped/C_xlaykyai;

--- a/mappings/net/minecraft/block/sign/WallHangingSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/WallHangingSignBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_hzvmpvoj net/minecraft/block/WallHangingSignBlock
+CLASS net/minecraft/unmapped/C_hzvmpvoj net/minecraft/block/sign/WallHangingSignBlock
 	FIELD f_ajgnnuad SIGN_NORTH_SOUTH Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_joxgcayp SIGN_EAST_WEST Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_lwnocpar SHAPES Ljava/util/Map;

--- a/mappings/net/minecraft/block/sign/WallSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/WallSignBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_rgitojot net/minecraft/block/WallSignBlock
+CLASS net/minecraft/unmapped/C_rgitojot net/minecraft/block/sign/WallSignBlock
 	FIELD f_jlirgbrx FACING Lnet/minecraft/unmapped/C_tcujuvjb;
 	FIELD f_jsiraebb SHAPE_BOTTOM F
 	FIELD f_jwankqwl SHAPE_THICKNESS F

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -321,6 +321,7 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 		COMMENT
 		COMMENT <p>The integrated server is only present when a local single player world is open.
 	METHOD m_jtfycguy getVersionType ()Ljava/lang/String;
+	METHOD m_jvlajuse onGameLoaded ()V
 	METHOD m_jytpvdsa countryEqualsISO3 (Ljava/lang/Object;)Z
 		ARG 0 o
 	METHOD m_kclqbfew cleanUpAfterCrash ()V
@@ -500,6 +501,7 @@ CLASS net/minecraft/unmapped/C_ayfeobid net/minecraft/client/MinecraftClient
 	METHOD m_xthkfemp isConnectedToServer ()Z
 	METHOD m_xutfzscx initializeSearchableContainers ()V
 	METHOD m_yadnzivw isDemo ()Z
+	METHOD m_yknnrfie createSignatureValidator ()Lnet/minecraft/unmapped/C_yvuwcvkm;
 	METHOD m_ymfxsgvs getChatNarratorManager ()Lnet/minecraft/unmapped/C_qwmxzagq;
 	METHOD m_yxvsqbme hasReducedDebugInfo ()Z
 	METHOD m_yyiisqrp isWindowFocused ()Z

--- a/mappings/net/minecraft/client/multiplayer/prediction/BlockStatePredictionManager.mapping
+++ b/mappings/net/minecraft/client/multiplayer/prediction/BlockStatePredictionManager.mapping
@@ -1,0 +1,22 @@
+CLASS net/minecraft/unmapped/C_czisrdmd net/minecraft/client/multiplayer/prediction/BlockStatePredictionManager
+	FIELD f_bmpbngyn predicting Z
+	FIELD f_hcvpxtyt sequence I
+	FIELD f_irkdwisi serverVerifiedStates Lit/unimi/dsi/fastutil/longs/Long2ObjectOpenHashMap;
+	METHOD m_bguakajn (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_jlopmfei;Ljava/lang/Long;Lnet/minecraft/unmapped/C_czisrdmd$C_ivvmpfib;)Lnet/minecraft/unmapped/C_czisrdmd$C_ivvmpfib;
+		ARG 3 pos
+		ARG 4 verifiedState
+	METHOD m_gqtwgmpw getSequence ()I
+	METHOD m_mmtdqsga updateKnownServerState (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_nssimvch isPredicting ()Z
+	METHOD m_plwiurco retainKnownServerState (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_jlopmfei;)V
+		ARG 3 player
+	METHOD m_rhbdpkkw startPredicting ()Lnet/minecraft/unmapped/C_czisrdmd;
+	METHOD m_vfahppjl endPredictionsUntil (ILnet/minecraft/unmapped/C_ghdnlrrw;)V
+		ARG 1 maxSequence
+	CLASS C_ivvmpfib VerifiedState
+		FIELD f_bfinrexc playerPos Lnet/minecraft/unmapped/C_vgpupfxx;
+		FIELD f_ovpelcnt sequence I
+		FIELD f_vvwiefxl blockState Lnet/minecraft/unmapped/C_txtbiemp;
+		METHOD m_fxchmlnj setBlockState (Lnet/minecraft/unmapped/C_txtbiemp;)V
+		METHOD m_twfpffxt withSequence (I)Lnet/minecraft/unmapped/C_czisrdmd$C_ivvmpfib;
+			ARG 1 sequence

--- a/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_nqcidrhe net/minecraft/client/network/ClientLoginNetworkHandler
+	FIELD f_cprgzlsx minigameName Ljava/lang/String;
 	FIELD f_doornbdf profile Lcom/mojang/authlib/GameProfile;
 	FIELD f_eqdlvwgp worldLoadTime Ljava/time/Duration;
 	FIELD f_fbredsfl info Lnet/minecraft/unmapped/C_xotldzgg;
@@ -22,3 +23,5 @@ CLASS net/minecraft/unmapped/C_nqcidrhe net/minecraft/client/network/ClientLogin
 		ARG 4 encryptionCipher
 	METHOD m_ihxrsrrp joinServerSession (Ljava/lang/String;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 1 serverId
+	METHOD m_omrzsyoi setMinigameName (Ljava/lang/String;)V
+		ARG 1 name

--- a/mappings/net/minecraft/client/util/ChatNarratorManager.mapping
+++ b/mappings/net/minecraft/client/util/ChatNarratorManager.mapping
@@ -21,6 +21,8 @@ CLASS net/minecraft/unmapped/C_qwmxzagq net/minecraft/client/util/ChatNarratorMa
 			COMMENT the message to narrate
 	METHOD m_sfsvmehj narrateSystemMessage (Lnet/minecraft/unmapped/C_rdaqiwdt;)V
 		ARG 1 message
+	METHOD m_sunuzqut checkLibraryStatus (Z)V
+		ARG 1 narratorEnabled
 	METHOD m_wnnchpxz narrate (Lnet/minecraft/unmapped/C_rdaqiwdt;)V
 		COMMENT Narrates the given system message.
 		COMMENT <p>
@@ -35,3 +37,4 @@ CLASS net/minecraft/unmapped/C_qwmxzagq net/minecraft/client/util/ChatNarratorMa
 		COMMENT Called when the narration mode is changed.
 		ARG 1 newMode
 			COMMENT the new narration mode
+	CLASS C_jwlsjyea NarratorInitException

--- a/mappings/net/minecraft/client/util/NetworkUtils.mapping
+++ b/mappings/net/minecraft/client/util/NetworkUtils.mapping
@@ -14,3 +14,5 @@ CLASS net/minecraft/unmapped/C_vposufsj net/minecraft/client/util/NetworkUtils
 		ARG 3 maxFileSize
 		ARG 4 progressListener
 		ARG 5 proxy
+	METHOD m_wsltejex isPortAvailable (I)Z
+		ARG 0 port

--- a/mappings/net/minecraft/client/util/ParticleUtil.mapping
+++ b/mappings/net/minecraft/client/util/ParticleUtil.mapping
@@ -8,13 +8,17 @@ CLASS net/minecraft/unmapped/C_hkabwoqt net/minecraft/client/util/ParticleUtil
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 effect
+		ARG 3 variance
 	METHOD m_ilwncwtt getRandomOffset (Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 0 random
 	METHOD m_jjtyixcy spawnParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_nqucohct;Lnet/minecraft/unmapped/C_macfejbg;Lnet/minecraft/unmapped/C_xpuuihxf;Ljava/util/function/Supplier;D)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 effect
+		ARG 3 repeatCount
 		ARG 4 direction
+		ARG 5 velocity
+		ARG 6 offsetMultiplier
 	METHOD m_odtveaxh spawnParticle (Lnet/minecraft/unmapped/C_xpuuihxf$C_rmpfouoz;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;DLnet/minecraft/unmapped/C_nqucohct;Lnet/minecraft/unmapped/C_hvilmtvi;)V
 		ARG 0 axis
 		ARG 1 world
@@ -28,3 +32,4 @@ CLASS net/minecraft/unmapped/C_hkabwoqt net/minecraft/client/util/ParticleUtil
 		ARG 2 direction
 		ARG 3 effect
 		ARG 4 velocity
+		ARG 5 offsetMultiplier

--- a/mappings/net/minecraft/client/util/PlayerKeyPairManager.mapping
+++ b/mappings/net/minecraft/client/util/PlayerKeyPairManager.mapping
@@ -3,5 +3,6 @@ CLASS net/minecraft/unmapped/C_huqpbmju net/minecraft/client/util/PlayerKeyPairM
 	METHOD m_fgoaidjm create (Lcom/mojang/authlib/minecraft/UserApiService;Lnet/minecraft/unmapped/C_cwfizcnb;Ljava/nio/file/Path;)Lnet/minecraft/unmapped/C_huqpbmju;
 		ARG 0 service
 		ARG 1 session
+		ARG 2 path
 	METHOD m_mynredww fetchKeyPair ()Ljava/util/concurrent/CompletableFuture;
 	METHOD m_qlupaddp isExpired ()Z

--- a/mappings/net/minecraft/client/util/ScreenshotRecorder.mapping
+++ b/mappings/net/minecraft/client/util/ScreenshotRecorder.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/unmapped/C_craqpqxw net/minecraft/client/util/ScreenshotReco
 	FIELD f_odhezoam buffer [B
 	FIELD f_qbsyukhj file Ljava/io/File;
 	FIELD f_thmnivov LOGGER Lorg/slf4j/Logger;
+	FIELD f_ymjndgta SCREENSHOTS_DIRECTORY Ljava/lang/String;
 	FIELD f_zsbdrwes width I
 	METHOD <init> (Ljava/io/File;III)V
 		COMMENT Creates a screenshot recorder for huge screenshots.
@@ -16,6 +17,8 @@ CLASS net/minecraft/unmapped/C_craqpqxw net/minecraft/client/util/ScreenshotReco
 		ARG 2 width
 		ARG 3 height
 		ARG 4 unitHeight
+	METHOD m_bsqujatp (Ljava/io/File;Lnet/minecraft/unmapped/C_cpwnhism;)Lnet/minecraft/unmapped/C_cpwnhism;
+		ARG 1 style
 	METHOD m_cyvkwkpf saveScreenshot (Ljava/io/File;Lnet/minecraft/unmapped/C_xxwgvelc;Ljava/util/function/Consumer;)V
 		ARG 0 gameDirectory
 		ARG 1 framebuffer

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryManager.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryManager.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_cgkxybww net/minecraft/client/util/telemetry/Tele
 	FIELD f_bvwetahy TELEMETRY_SENDER_EXECUTOR Ljava/util/concurrent/Executor;
 	FIELD f_duxfibma propertyMap Lnet/minecraft/unmapped/C_tupaamrk;
 	FIELD f_dzalcfzr telemetrySenderThreads Ljava/util/concurrent/atomic/AtomicInteger;
+	FIELD f_heodzugs sender Ljava/util/function/Supplier;
 	FIELD f_jgobxttp logManager Ljava/util/concurrent/CompletableFuture;
 	FIELD f_qsuuyhhu userApi Lcom/mojang/authlib/minecraft/UserApiService;
 	FIELD f_xkinpwcy logDirectory Ljava/nio/file/Path;
@@ -14,6 +15,11 @@ CLASS net/minecraft/unmapped/C_cgkxybww net/minecraft/client/util/telemetry/Tele
 	METHOD m_lsdtaxjn createWorldTelemetryManager (ZLjava/time/Duration;Ljava/lang/String;)Lnet/minecraft/unmapped/C_bfepxqwf;
 		ARG 1 isNewWorld
 		ARG 2 worldLoadTime
+		ARG 3 minigameName
+	METHOD m_muaatcpb getSender ()Lnet/minecraft/unmapped/C_wzhvxvch;
+	METHOD m_qsixfwvb createEventSender ()Lnet/minecraft/unmapped/C_wzhvxvch;
+	METHOD m_ukhcejff (Ljava/util/Optional;)V
+		ARG 0 manager
 	METHOD m_vpkwibmh (Ljava/lang/Runnable;)Ljava/lang/Thread;
 		ARG 0 action
 	METHOD m_xdytqxrm (Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryProperty.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryProperty.mapping
@@ -13,21 +13,50 @@ CLASS net/minecraft/unmapped/C_vykgtyww net/minecraft/client/util/telemetry/Tele
 	METHOD m_agomzdpf createLongList (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
 		ARG 0 id
 		ARG 1 exportKey
+	METHOD m_bujpgsvl (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lnet/minecraft/unmapped/C_vykgtyww$C_dwgrnklg;)V
+		ARG 0 container
+		ARG 1 name
+		ARG 2 gameMode
+	METHOD m_bvmbvvst createMeasurement (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD m_fzzhpgdi (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lnet/minecraft/unmapped/C_znpzgoww$C_wtksiulk;)V
+		ARG 0 container
+		ARG 1 name
+		ARG 2 measurement
 	METHOD m_gbrbzzts createInteger (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
 		ARG 0 id
 		ARG 1 exportKey
 	METHOD m_hpowlaaz export (Lnet/minecraft/unmapped/C_tupaamrk;Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;)V
 		ARG 1 propertyMap
 		ARG 2 container
+	METHOD m_ixbdsyys (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Ljava/util/UUID;)V
+		ARG 0 container
+		ARG 1 name
 	METHOD m_jadmvviu createUuid (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
 		ARG 0 id
 		ARG 1 exportKey
 	METHOD m_jvqgfioi createString (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
 		ARG 0 id
 		ARG 1 exportKey
+	METHOD m_kfnpisdi createLong (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD m_kstaylix (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Ljava/time/Instant;)V
+		ARG 0 container
+		ARG 1 name
+		ARG 2 instant
 	METHOD m_maatndmi createBoolean (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_vykgtyww;
 		ARG 0 id
 		ARG 1 exportKey
+	METHOD m_nhjyqfst (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lit/unimi/dsi/fastutil/longs/LongList;)V
+		ARG 0 container
+		ARG 1 name
+		ARG 2 list
+	METHOD m_oroqsyms (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lnet/minecraft/unmapped/C_vykgtyww$C_afeghidc;)V
+		ARG 0 container
+		ARG 1 name
+		ARG 2 serverType
 	METHOD m_pmddrquw codec ()Lcom/mojang/serialization/Codec;
 	METHOD m_tkjnpann exportKey ()Ljava/lang/String;
 	METHOD m_ulasainp create (Ljava/lang/String;Ljava/lang/String;Lcom/mojang/serialization/Codec;Lnet/minecraft/unmapped/C_vykgtyww$C_bqxexqea;)Lnet/minecraft/unmapped/C_vykgtyww;

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryPropertyMap.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryPropertyMap.mapping
@@ -22,11 +22,17 @@ CLASS net/minecraft/unmapped/C_tupaamrk net/minecraft/client/util/telemetry/Tele
 			ARG 1 result
 			ARG 3 data
 			ARG 4 property
+		METHOD m_tcklxxiq (Lnet/minecraft/unmapped/C_vykgtyww;Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;
+			ARG 1 map
+			ARG 2 value
 	CLASS C_ivdfigoc Builder
 		FIELD f_rqsepvfy propertyMap Ljava/util/Map;
 		METHOD m_bsmfklmd appendMap (Lnet/minecraft/unmapped/C_tupaamrk;)Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;
 			ARG 1 properties
 		METHOD m_fchnzwzq build ()Lnet/minecraft/unmapped/C_tupaamrk;
+		METHOD m_mfccenqo addNullableEntry (Lnet/minecraft/unmapped/C_vykgtyww;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;
+			ARG 1 property
+			ARG 2 value
 		METHOD m_tjrttbyb addEntry (Lnet/minecraft/unmapped/C_vykgtyww;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;
 			ARG 1 property
 			ARG 2 value

--- a/mappings/net/minecraft/client/util/telemetry/WorldTelemetryManager.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/WorldTelemetryManager.mapping
@@ -5,15 +5,24 @@ CLASS net/minecraft/unmapped/C_bfepxqwf net/minecraft/client/util/telemetry/Worl
 	FIELD f_hpfayblq performanceMetrics Lnet/minecraft/unmapped/C_royaphdp;
 	FIELD f_vgyxthkm worldUnload Lnet/minecraft/unmapped/C_aslkqmjb;
 	FIELD f_xyydpqwk worldLoadTimes Lnet/minecraft/unmapped/C_kpajfktr;
+	METHOD <init> (Lnet/minecraft/unmapped/C_wzhvxvch;ZLjava/time/Duration;Ljava/lang/String;)V
+		ARG 1 sender
+		ARG 2 newWorld
+		ARG 3 loadDuration
+		ARG 4 minigameName
 	METHOD m_fxtpqbcv onPlayerInfoReceived (Lnet/minecraft/unmapped/C_lghcpyvl;Z)V
 		ARG 1 gameMode
 		ARG 2 isNewWorld
+	METHOD m_ksbcmwmh onAdvancementMade (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_kdwyuhdb;)V
+		ARG 2 advancement
 	METHOD m_nprsgzws (Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;)V
 		ARG 1 propertyMapBuilder
 	METHOD m_sicilrwq setWorldUnloadTime (J)V
 		ARG 1 gameTime
 	METHOD m_vsbdpsuq onServerBrandReceived (Ljava/lang/String;)V
 		ARG 1 serverBrand
+	METHOD m_wppayvsg (Lnet/minecraft/unmapped/C_ncpywfca;JLnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;)V
+		ARG 3 map
 	METHOD m_ytkimvpi onWorldSessionStart ()V
 	METHOD m_ywhdxtta onDisconnect ()V
 	METHOD m_zfefjgvk tickPerformanceMetrics ()V

--- a/mappings/net/minecraft/client/util/telemetry/event/GameLoadTimesEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/event/GameLoadTimesEvent.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/unmapped/C_znpzgoww net/minecraft/client/util/telemetry/even
 		ARG 1 time
 	METHOD m_yddbcfgf beginStep (Lnet/minecraft/unmapped/C_vykgtyww;Ljava/util/function/Function;)V
 		ARG 1 measurement
-		ARG 2 timerCreator
+		ARG 2 timerFactory
 	CLASS C_wtksiulk Measurement
 		METHOD m_gfnzktqb (Lnet/minecraft/unmapped/C_znpzgoww$C_wtksiulk;)Ljava/lang/Integer;
 			ARG 0 i

--- a/mappings/net/minecraft/client/util/telemetry/event/GameLoadTimesEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/event/GameLoadTimesEvent.mapping
@@ -1,0 +1,33 @@
+CLASS net/minecraft/unmapped/C_znpzgoww net/minecraft/client/util/telemetry/event/GameLoadTimesEvent
+	FIELD f_ctaskvum ticker Lcom/google/common/base/Ticker;
+	FIELD f_hnwidwus bootstrapTime Ljava/util/OptionalLong;
+	FIELD f_iwmkvmik INSTANCE Lnet/minecraft/unmapped/C_znpzgoww;
+	FIELD f_zxvfnvqn measurements Ljava/util/Map;
+	METHOD m_azilswbo setBootstrapTime (J)V
+		ARG 1 time
+	METHOD m_cpwgnkoe send (Lnet/minecraft/unmapped/C_wzhvxvch;)V
+		ARG 1 sender
+	METHOD m_fnyuvggd (Lnet/minecraft/unmapped/C_vykgtyww;)Lcom/google/common/base/Stopwatch;
+		ARG 1 property
+	METHOD m_micqzfkw startTimer (Lnet/minecraft/unmapped/C_vykgtyww;)V
+		ARG 1 measurement
+	METHOD m_mjmctrta addTimer (Lnet/minecraft/unmapped/C_vykgtyww;Lcom/google/common/base/Stopwatch;)V
+		ARG 1 measurement
+		ARG 2 timer
+	METHOD m_pynrxyat endStep (Lnet/minecraft/unmapped/C_vykgtyww;)V
+		ARG 1 measurement
+	METHOD m_smcoufop (Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;)V
+		ARG 1 map
+	METHOD m_szrrcpry (Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;Lnet/minecraft/unmapped/C_vykgtyww;Lcom/google/common/base/Stopwatch;)V
+		ARG 1 measurement
+		ARG 2 timer
+	METHOD m_wagporif (Lcom/google/common/base/Stopwatch;Lnet/minecraft/unmapped/C_vykgtyww;)Lcom/google/common/base/Stopwatch;
+		ARG 1 property
+	METHOD m_xjunibsk (Lnet/minecraft/unmapped/C_tupaamrk$C_ivdfigoc;J)V
+		ARG 1 time
+	METHOD m_yddbcfgf beginStep (Lnet/minecraft/unmapped/C_vykgtyww;Ljava/util/function/Function;)V
+		ARG 1 measurement
+		ARG 2 timerCreator
+	CLASS C_wtksiulk Measurement
+		METHOD m_gfnzktqb (Lnet/minecraft/unmapped/C_znpzgoww$C_wtksiulk;)Ljava/lang/Integer;
+			ARG 0 i

--- a/mappings/net/minecraft/client/util/telemetry/event/TelemetryEventType.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/event/TelemetryEventType.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_tmmyxvlq net/minecraft/client/util/telemetry/even
 	FIELD f_bytszwsi properties Ljava/util/List;
 	FIELD f_cvwcldeg isOptional Z
 	FIELD f_ddpimmqp exportKey Ljava/lang/String;
+	FIELD f_ehllagxi GAME_LOAD_TIMES Lnet/minecraft/unmapped/C_tmmyxvlq;
 	FIELD f_elopsxlk WORLD_SESSION_PROPERTIES Ljava/util/List;
 	FIELD f_epconzfz TYPES Ljava/util/Map;
 	FIELD f_epufzqkg GAME_PROPERTIES Ljava/util/List;
@@ -11,6 +12,7 @@ CLASS net/minecraft/unmapped/C_tmmyxvlq net/minecraft/client/util/telemetry/even
 	FIELD f_lltydytr PERFORMANCE_METRICS Lnet/minecraft/unmapped/C_tmmyxvlq;
 	FIELD f_nlyrngye CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_nugxruyq WORLD_LOAD_TIMES Lnet/minecraft/unmapped/C_tmmyxvlq;
+	FIELD f_qrtfgfgv ADVANCEMENT_MADE Lnet/minecraft/unmapped/C_tmmyxvlq;
 	FIELD f_rqgiytav WORLD_UNLOADED Lnet/minecraft/unmapped/C_tmmyxvlq;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)V
 		ARG 1 id
@@ -21,6 +23,8 @@ CLASS net/minecraft/unmapped/C_tmmyxvlq net/minecraft/client/util/telemetry/even
 	METHOD m_askujhkg (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 key
 	METHOD m_caqjrxmm codec ()Lcom/mojang/serialization/Codec;
+	METHOD m_chemwvwk (Lnet/minecraft/unmapped/C_tupaamrk;)Lnet/minecraft/unmapped/C_faiydnha;
+		ARG 1 map
 	METHOD m_dttxkwhf text (Ljava/lang/String;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 1 textType
 	METHOD m_fejwfwdm createBuilder (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/unmapped/C_tmmyxvlq$C_znootsfj;
@@ -29,6 +33,8 @@ CLASS net/minecraft/unmapped/C_tmmyxvlq net/minecraft/client/util/telemetry/even
 	METHOD m_hjozgtul hasProperty (Lnet/minecraft/unmapped/C_vykgtyww;)Z
 		ARG 1 property
 	METHOD m_hqysqizp properties ()Ljava/util/List;
+	METHOD m_knmfqskm (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
 	METHOD m_mafkgwpl title ()Lnet/minecraft/unmapped/C_npqneive;
 	METHOD m_okysctud id ()Ljava/lang/String;
 	METHOD m_pwkotkuo copyTypes ()Ljava/util/List;

--- a/mappings/net/minecraft/client/util/telemetry/event/WorldLoadEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/event/WorldLoadEvent.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_adyqesdt net/minecraft/client/util/telemetry/event/WorldLoadEvent
 	FIELD f_bpektmrv serverBrand Ljava/lang/String;
 	FIELD f_maecwshu gameMode Lnet/minecraft/unmapped/C_vykgtyww$C_dwgrnklg;
+	FIELD f_nggemfls minigameName Ljava/lang/String;
 	FIELD f_rpddrdgf sent Z
 	METHOD m_ftyviais setServerBrand (Ljava/lang/String;)V
 		ARG 1 serverBrand

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -20,6 +20,7 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 	FIELD f_vwrlovng entityManager Lnet/minecraft/unmapped/C_xuynuyjo;
 	FIELD f_wzsnmiyr entityList Lnet/minecraft/unmapped/C_rtdymhtu;
 	FIELD f_xsrdqdyy worldRenderer Lnet/minecraft/unmapped/C_sfkkabhx;
+	FIELD f_ycswtnpc blockPredictionManager Lnet/minecraft/unmapped/C_czisrdmd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_nuofrxvi;Lnet/minecraft/unmapped/C_ghdnlrrw$C_nwouoiiq;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_cjzoxshv;IILjava/util/function/Supplier;Lnet/minecraft/unmapped/C_sfkkabhx;ZJ)V
 		ARG 1 netHandler
 		ARG 2 clientWorldProperties
@@ -36,6 +37,8 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 	METHOD m_alvumyoa getSkyColor (Lnet/minecraft/unmapped/C_vgpupfxx;F)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 cameraPosition
 		ARG 2 tickDelta
+	METHOD m_blplldfx syncBlockState (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 3 playerPos
 	METHOD m_bmqpmbrd (Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 pos
 	METHOD m_btpmymzu getSkyProperties ()Lnet/minecraft/unmapped/C_bxlqmlyr;
@@ -57,10 +60,13 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 		ARG 10 pitch
 		ARG 11 delay
 		ARG 12 seed
+	METHOD m_emdmfdsn overrideMapState (Ljava/lang/String;Lnet/minecraft/unmapped/C_nvpllgmg;)V
+		ARG 1 id
+		ARG 2 state
 	METHOD m_fbbmqzbb tickEntities ()V
 	METHOD m_fsnivgsu (Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 pos
-	METHOD m_ftefeyzd (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;I)V
+	METHOD m_ftefeyzd setVerifiedBlockState (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;I)V
 		ARG 3 flags
 	METHOD m_futjdoxn getStarBrightness (F)F
 		ARG 1 tickDelta
@@ -78,6 +84,7 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 		ARG 1 chunk
 	METHOD m_iesewwfc calculateColor (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_qodopjcw;)I
 		ARG 1 pos
+		ARG 2 provider
 	METHOD m_jijellmt setSpawnPos (Lnet/minecraft/unmapped/C_hynzadkk;F)V
 		ARG 1 pos
 		ARG 2 angle
@@ -95,7 +102,9 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 	METHOD m_kokxxpdc setSimulationDistance (I)V
 		ARG 1 simulationDistance
 	METHOD m_kutvaluc tickTime ()V
+	METHOD m_lvsrwztn getBlockPredictionManager ()Lnet/minecraft/unmapped/C_czisrdmd;
 	METHOD m_nsvkfxjo onBlockChangeAcknowledgement (I)V
+		ARG 1 sequence
 	METHOD m_ofmlapxi (Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;)V
 		ARG 1 map
 	METHOD m_ondfgyqt getMapStates ()Ljava/util/Map;
@@ -106,6 +115,7 @@ CLASS net/minecraft/unmapped/C_ghdnlrrw net/minecraft/client/world/ClientWorld
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 parameters
+		ARG 4 solidBelow
 	METHOD m_rfjxxibf setTimeOfDay (J)V
 		ARG 1 timeOfDay
 	METHOD m_rplgnmem tickPassenger (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_astfners;)V

--- a/mappings/net/minecraft/client/world/FlatWorldGeneratorPresets.mapping
+++ b/mappings/net/minecraft/client/world/FlatWorldGeneratorPresets.mapping
@@ -2,7 +2,9 @@ CLASS net/minecraft/unmapped/C_brlntonw net/minecraft/client/world/FlatWorldGene
 	METHOD m_qyjelmkr register (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
 		ARG 0 id
 	METHOD m_sybrxjpq getHolder (Lnet/minecraft/unmapped/C_wlftclvz;)V
+		ARG 0 context
 	CLASS C_gyvjwgmv Bootstrap
+		FIELD f_nevetevc context Lnet/minecraft/unmapped/C_wlftclvz;
 		METHOD m_brclgowj run ()V
 		METHOD m_ndfjmmec add (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/Set;ZZ[Lnet/minecraft/unmapped/C_mbigakvk;)V
 			ARG 1 key

--- a/mappings/net/minecraft/client/world/GeneratorType.mapping
+++ b/mappings/net/minecraft/client/world/GeneratorType.mapping
@@ -9,6 +9,9 @@ CLASS net/minecraft/unmapped/C_uejfhynd net/minecraft/client/world/GeneratorType
 		ARG 0 type
 	METHOD m_euxgcixf (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
+	METHOD m_lnppwtff requireOverworld (Lnet/minecraft/unmapped/C_uejfhynd;)Lcom/mojang/serialization/DataResult;
+		ARG 0 type
 	METHOD m_pwxqzcjv createDimensionOptionsRegistry ()Lnet/minecraft/unmapped/C_tqxyjqsk;
 	METHOD m_sfbrvsgk (Lnet/minecraft/unmapped/C_eexxncvi;Lnet/minecraft/unmapped/C_xhhleach;)V
 		ARG 2 dimension
+	METHOD m_tpfjotrl getWorldDimensions ()Lnet/minecraft/unmapped/C_oiwekzxo;

--- a/mappings/net/minecraft/client/world/GeneratorTypes.mapping
+++ b/mappings/net/minecraft/client/world/GeneratorTypes.mapping
@@ -1,22 +1,34 @@
 CLASS net/minecraft/unmapped/C_ogomnjoy net/minecraft/client/world/GeneratorTypes
+	METHOD m_grmkvtyw getWorldDimensions (Lnet/minecraft/unmapped/C_wqxmvzdq;)Lnet/minecraft/unmapped/C_oiwekzxo;
 	METHOD m_nqtsxyfa getOverworld (Lnet/minecraft/unmapped/C_wqxmvzdq;)Lnet/minecraft/unmapped/C_alziuayn;
 		ARG 0 registryManager
 	METHOD m_odjnqceb getKey (Lnet/minecraft/unmapped/C_tqxyjqsk;)Ljava/util/Optional;
 	METHOD m_tacmrwaf registerKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
 		ARG 0 id
 	METHOD m_vtlthqfd getHolder (Lnet/minecraft/unmapped/C_wlftclvz;)V
+		ARG 0 context
+	METHOD m_zpcohllh (Lnet/minecraft/unmapped/C_alziuayn;)Ljava/util/Optional;
+		ARG 0 options
 	CLASS C_fhucecjz Bootstrap
+		FIELD f_feuzwykz context Lnet/minecraft/unmapped/C_wlftclvz;
+		FIELD f_hnemzeja multiNoiseBiomeSourceParameterList Lnet/minecraft/unmapped/C_pzdchrcy;
 		FIELD f_hrjdepgm biome Lnet/minecraft/unmapped/C_pzdchrcy;
 		FIELD f_ijmchwaw endDimension Lnet/minecraft/unmapped/C_alziuayn;
 		FIELD f_lczxbtbb chunkGeneratorSettings Lnet/minecraft/unmapped/C_pzdchrcy;
 		FIELD f_mtmgbsxo netherDimension Lnet/minecraft/unmapped/C_alziuayn;
+		FIELD f_osxonyab placedFeature Lnet/minecraft/unmapped/C_pzdchrcy;
 		FIELD f_sgqhsdyg overworld Lnet/minecraft/unmapped/C_cjzoxshv;
 		FIELD f_wlrmhbdd structureSets Lnet/minecraft/unmapped/C_pzdchrcy;
+		METHOD <init> (Lnet/minecraft/unmapped/C_wlftclvz;)V
+			ARG 1 context
+		METHOD m_bmunbwen registerOverworlds (Lnet/minecraft/unmapped/C_ajguowya;)V
+			ARG 1 biomeSource
 		METHOD m_elmuhiwj overworld (Lnet/minecraft/unmapped/C_ajguowya;Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_alziuayn;
 			ARG 1 source
 			ARG 2 settings
 		METHOD m_fcxvrgsk createType (Lnet/minecraft/unmapped/C_alziuayn;)Lnet/minecraft/unmapped/C_uejfhynd;
 			ARG 1 dimension
+		METHOD m_gfaqqwev bootstrap ()V
 		METHOD m_hitteira addDimensionGenerator (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_alziuayn;)V
 			ARG 1 generator
 			ARG 2 dimension

--- a/mappings/net/minecraft/client/world/WorldCreationContext.mapping
+++ b/mappings/net/minecraft/client/world/WorldCreationContext.mapping
@@ -1,7 +1,22 @@
 CLASS net/minecraft/unmapped/C_njsjipmy net/minecraft/client/world/WorldCreationContext
 	FIELD f_sabuzwmd resources Lnet/minecraft/unmapped/C_migzkpst;
+	METHOD <init> (Lnet/minecraft/unmapped/C_naismckd;Lnet/minecraft/unmapped/C_oiwekzxo;Lnet/minecraft/unmapped/C_bcpxdrik;Lnet/minecraft/unmapped/C_migzkpst;Lnet/minecraft/unmapped/C_yknpgzdr;)V
+		ARG 1 options
+		ARG 2 worldDimensions
+		ARG 3 registryManager
+		ARG 5 featureAndDataSettings
 	METHOD <init> (Lnet/minecraft/unmapped/C_oxnufhsj;Lnet/minecraft/unmapped/C_bcpxdrik;Lnet/minecraft/unmapped/C_migzkpst;Lnet/minecraft/unmapped/C_yknpgzdr;)V
 		ARG 1 generatorOptions
+		ARG 2 registryManager
 		ARG 4 featureAndDataSettings
 	METHOD m_pqzxpkce resources ()Lnet/minecraft/unmapped/C_migzkpst;
+	METHOD m_ptgdwbnf create (Lnet/minecraft/unmapped/C_naismckd;Lnet/minecraft/unmapped/C_oiwekzxo;)Lnet/minecraft/unmapped/C_njsjipmy;
+		ARG 1 options
+		ARG 2 worldDimensions
+	METHOD m_wtltvvtl create (Lnet/minecraft/unmapped/C_njsjipmy$C_ixwvvclr;)Lnet/minecraft/unmapped/C_njsjipmy;
+		ARG 1 modifier
 	METHOD m_yhokwcqr getWorldgenRegistryManager ()Lnet/minecraft/unmapped/C_wqxmvzdq$C_ggmzysrd;
+	METHOD m_zvxwfsao create (Lnet/minecraft/unmapped/C_njsjipmy$C_iucotkie;)Lnet/minecraft/unmapped/C_njsjipmy;
+		ARG 1 updater
+	CLASS C_iucotkie DimensionsUpdater
+	CLASS C_ixwvvclr OptionsModifier

--- a/mappings/net/minecraft/client/world/WorldCreator.mapping
+++ b/mappings/net/minecraft/client/world/WorldCreator.mapping
@@ -1,24 +1,96 @@
 CLASS net/minecraft/unmapped/C_hypraqfe net/minecraft/client/world/WorldCreator
+	FIELD f_doyaxhqe normalWorldTypes Ljava/util/List;
+	FIELD f_dqjclmla saveFolderName Ljava/lang/String;
 	FIELD f_einkjnrv context Lnet/minecraft/unmapped/C_njsjipmy;
+	FIELD f_giiezriy hasBonusChest Z
+	FIELD f_gjinmbjb seed Ljava/lang/String;
 	FIELD f_gwbrsste worldSavesPath Ljava/nio/file/Path;
 	FIELD f_hrqmvgvi worldName Ljava/lang/String;
-	FIELD f_nwmnwule consumers Ljava/util/List;
+	FIELD f_jmyxcove cheatsEnabled Ljava/lang/Boolean;
+	FIELD f_lakfutsq generateStructures Z
+	FIELD f_mlubojta gameRules Lnet/minecraft/unmapped/C_xmldumst;
+	FIELD f_mxgdqqgs worldType Lnet/minecraft/unmapped/C_hypraqfe$C_jbuehfan;
+	FIELD f_nwmnwule listeners Ljava/util/List;
 	FIELD f_ogdjdkbj gameMode Lnet/minecraft/unmapped/C_hypraqfe$C_ohbtvxdv;
+	FIELD f_sleyatvc extendedWorldTypes Ljava/util/List;
 	FIELD f_tyljjtrt difficulty Lnet/minecraft/unmapped/C_mpbjgxic;
 	FIELD f_xaojvoii DEFAULT_WORLD_NAME Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD <init> (Ljava/nio/file/Path;Lnet/minecraft/unmapped/C_njsjipmy;Ljava/util/Optional;Ljava/util/OptionalLong;)V
 		ARG 2 context
+		ARG 3 defaultWorldType
+		ARG 4 seed
+	METHOD m_cavqkcak getNormalWorldTypes ()Ljava/util/List;
 	METHOD m_choiiayp isHardcore ()Z
+	METHOD m_csetaxjh (Lnet/minecraft/unmapped/C_naismckd;)Lnet/minecraft/unmapped/C_naismckd;
+		ARG 1 options
+	METHOD m_cwibfpjj shouldGenerateStructures ()Z
+	METHOD m_detzuxbw updateContext (Lnet/minecraft/unmapped/C_yknpgzdr;)Z
+		ARG 1 featureAndDataSettings
+	METHOD m_dmnnomne getWorldType ()Lnet/minecraft/unmapped/C_hypraqfe$C_jbuehfan;
+	METHOD m_dvqxcggy getWorldPreset (Lnet/minecraft/unmapped/C_njsjipmy;Ljava/util/Optional;)Ljava/util/Optional;
+		ARG 0 context
+		ARG 1 generatorType
 	METHOD m_elkvzcwc getOrCreateSaveFolder (Ljava/lang/String;)Ljava/lang/String;
 		ARG 1 worldName
+	METHOD m_foaxpdkg getDifficulty ()Lnet/minecraft/unmapped/C_mpbjgxic;
+	METHOD m_gshlcejd addListener (Ljava/util/function/Consumer;)V
+		ARG 1 listener
+	METHOD m_gythbeko setWorldType (Lnet/minecraft/unmapped/C_hypraqfe$C_jbuehfan;)V
+		ARG 1 worldType
+	METHOD m_havqvtan (ZLnet/minecraft/unmapped/C_naismckd;)Lnet/minecraft/unmapped/C_naismckd;
+		ARG 1 options
+	METHOD m_hfdhfufg setSeed (Ljava/lang/String;)V
+		ARG 1 seed
+	METHOD m_ijqpixye setWorldName (Ljava/lang/String;)V
+		ARG 1 worldName
 	METHOD m_jlsmcfmz getScreenProvider ()Lnet/minecraft/unmapped/C_qfnmnrio;
+	METHOD m_jmqeorwf isBonusChestEnabled ()Z
 	METHOD m_jodswaac generate ()V
 	METHOD m_kaigmflw setGameMode (Lnet/minecraft/unmapped/C_hypraqfe$C_ohbtvxdv;)V
+		ARG 1 mode
+	METHOD m_kunocypt getWorldPresetList (Lnet/minecraft/unmapped/C_tqxyjqsk;Lnet/minecraft/unmapped/C_ednuhnnn;)Ljava/util/Optional;
+		ARG 1 tag
+	METHOD m_kyfglcjs (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_wqxmvzdq$C_ggmzysrd;Lnet/minecraft/unmapped/C_oiwekzxo;)Lnet/minecraft/unmapped/C_oiwekzxo;
+		ARG 1 registryManager
+		ARG 2 worldDimensions
+	METHOD m_lxkbugsk isDebug ()Z
+	METHOD m_mswhmzta getGameMode ()Lnet/minecraft/unmapped/C_hypraqfe$C_ohbtvxdv;
+	METHOD m_qsmcxzzu areCheatsEnabled ()Z
+	METHOD m_qwzkvgzg updateWorldTypeLists ()V
 	METHOD m_rakbmgei getWorldName ()Ljava/lang/String;
+	METHOD m_rltchgia setDifficulty (Lnet/minecraft/unmapped/C_mpbjgxic;)V
+		ARG 1 difficulty
 	METHOD m_scoilblb getGameRules ()Lnet/minecraft/unmapped/C_xmldumst;
+	METHOD m_thbryyxk (Ljava/util/List;)Z
+		ARG 0 list
+	METHOD m_tiihqnsf (ZLnet/minecraft/unmapped/C_naismckd;)Lnet/minecraft/unmapped/C_naismckd;
+		ARG 1 options
+	METHOD m_ujmxtpie setContext (Lnet/minecraft/unmapped/C_njsjipmy;)V
+		ARG 1 context
+	METHOD m_uuveagan setCheatsEnabled (Z)V
+		ARG 1 enabled
+	METHOD m_vgkmaenv setGameRules (Lnet/minecraft/unmapped/C_xmldumst;)V
+		ARG 1 rules
+	METHOD m_wlqrbnzo (Lnet/minecraft/unmapped/C_odfnijdo$C_orinjhqu;)Ljava/util/List;
+		ARG 0 set
+	METHOD m_wzhatoky setBonusChestEnabled (Z)V
+		ARG 1 enabled
+	METHOD m_xgnefpuy setGenerateStructures (Z)V
+		ARG 1 generateStructures
+	METHOD m_xirteeuv getSaveFolderName ()Ljava/lang/String;
 	METHOD m_xkfzagsg getContext ()Lnet/minecraft/unmapped/C_njsjipmy;
+	METHOD m_xzgmbgqy getExtendedWorldTypes ()Ljava/util/List;
+	METHOD m_yuhyzqip getSeed ()Ljava/lang/String;
+	METHOD m_zbhcqcxd updateContext (Lnet/minecraft/unmapped/C_njsjipmy$C_iucotkie;)V
+		ARG 1 dimensionsUpdater
+	CLASS C_jbuehfan WorldTypeEntry
+		FIELD f_yohsehtx CUSTOM Lnet/minecraft/unmapped/C_rdaqiwdt;
+		METHOD m_aylbuvaw getName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
+		METHOD m_ttszxefp isAmplified ()Z
 	CLASS C_ohbtvxdv GameMode
 		FIELD f_cvowpidu mode Lnet/minecraft/unmapped/C_lghcpyvl;
+		FIELD f_gteudrds info Lnet/minecraft/unmapped/C_rdaqiwdt;
+		FIELD f_imjydtow name Lnet/minecraft/unmapped/C_rdaqiwdt;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/unmapped/C_lghcpyvl;)V
 			ARG 3 name
 			ARG 4 mode

--- a/mappings/net/minecraft/unmapped/C_czisrdmd.mapping
+++ b/mappings/net/minecraft/unmapped/C_czisrdmd.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_czisrdmd
-	METHOD m_vfahppjl (ILnet/minecraft/unmapped/C_ghdnlrrw;)V

--- a/mappings/net/minecraft/util/Graph.mapping
+++ b/mappings/net/minecraft/util/Graph.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/unmapped/C_yrmbvdfi net/minecraft/util/Graph
 	METHOD m_wjyvsern depthFirstSearch (Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;Ljava/util/function/Consumer;Ljava/lang/Object;)Z
+		ARG 0 successors
+		ARG 1 visited
+		ARG 2 visiting
+		ARG 3 reversedOrderConsumer
+		ARG 4 now

--- a/mappings/net/minecraft/util/SegmentedAnglePrecision.mapping
+++ b/mappings/net/minecraft/util/SegmentedAnglePrecision.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_bhznmlir net/minecraft/util/SegmentedAnglePrecision
 	FIELD f_errgtmjh precision I
-	FIELD f_mqmrqvqi degreeToAngle F
-	FIELD f_ponlgpot angleToDegree F
+	FIELD f_mqmrqvqi degreesToAngle F
+	FIELD f_ponlgpot angleToDegrees F
 	FIELD f_uoqhffkh mask I
 	METHOD <init> (I)V
 		ARG 1 bits

--- a/mappings/net/minecraft/util/SegmentedAnglePrecision.mapping
+++ b/mappings/net/minecraft/util/SegmentedAnglePrecision.mapping
@@ -1,3 +1,22 @@
 CLASS net/minecraft/unmapped/C_bhznmlir net/minecraft/util/SegmentedAnglePrecision
+	FIELD f_errgtmjh precision I
+	FIELD f_mqmrqvqi degreeToAngle F
+	FIELD f_ponlgpot angleToDegree F
+	FIELD f_uoqhffkh mask I
 	METHOD <init> (I)V
 		ARG 1 bits
+	METHOD m_cvwweghh getMask ()I
+	METHOD m_mafvibbu toClampedRotation (F)I
+		ARG 1 degrees
+	METHOD m_rbcwuwpc toDegrees (I)F
+		ARG 1 rotation
+	METHOD m_wqkzvolk axesMatch (II)Z
+		ARG 1 alpha
+		ARG 2 beta
+	METHOD m_wuuhudnn toRotation (Lnet/minecraft/unmapped/C_xpuuihxf;)I
+	METHOD m_ygkkqmpu normalise (I)I
+		ARG 1 rotationBits
+	METHOD m_zaxckokn toRotation (F)I
+		ARG 1 degrees
+	METHOD m_zlufpqdr toWrappedDegrees (I)F
+		ARG 1 rotation

--- a/mappings/net/minecraft/world/WorldEvents.mapping
+++ b/mappings/net/minecraft/world/WorldEvents.mapping
@@ -33,7 +33,7 @@ CLASS net/minecraft/unmapped/C_kkbhcwdu net/minecraft/world/WorldEvents
 	FIELD f_cmdwanmo DISPENSER_FAILS I
 		COMMENT A Dispenser fails to dispense an item.
 		COMMENT <br>Plays the dispenser fail sound event.
-		COMMENT <p>Called by {@link net.minecraft.block.DispenserBlock#dispense(net.minecraft.server.world.ServerWorld, net.minecraft.util.math.BlockPos) DispenserBlock#dispense},
+		COMMENT <p>Called by {@link net.minecraft.block.dispenser.DispenserBlock#dispense(net.minecraft.server.world.ServerWorld, net.minecraft.util.math.BlockPos) DispenserBlock#dispense},
 		COMMENT {@link net.minecraft.block.DropperBlock#dispense(net.minecraft.server.world.ServerWorld, net.minecraft.util.math.BlockPos) DropperBlock#dispense},
 		COMMENT and {@link net.minecraft.block.dispenser.FallibleItemDispenserBehavior#playSound(net.minecraft.util.math.BlockPointer) FallibleItemDispenserBehavior#playSound}
 	FIELD f_dxpbmduz HUSK_CONVERTS_TO_ZOMBIE I
@@ -138,7 +138,7 @@ CLASS net/minecraft/unmapped/C_kkbhcwdu net/minecraft/world/WorldEvents
 	FIELD f_mjgzspkf POINTED_DRIPSTONE_DRIPS_LAVA_INTO_CAULDRON I
 		COMMENT Pointed Dripstone drips Lava into a Cauldron.
 		COMMENT <br>Plays the pointed dripstone dripping lava into cauldron sound event.
-		COMMENT <p>Called by {@link net.minecraft.block.CauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) CauldronBlock#fillFromDripstone}
+		COMMENT <p>Called by {@link net.minecraft.block.cauldron.CauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) CauldronBlock#fillFromDripstone}
 	FIELD f_mqdhxafm BONE_MEAL_USED I
 		COMMENT Bone meal is used.
 		COMMENT <br>Plays the bone meal item used sound event and spawns happy villager particles.
@@ -263,8 +263,8 @@ CLASS net/minecraft/unmapped/C_kkbhcwdu net/minecraft/world/WorldEvents
 	FIELD f_vxlruagb POINTED_DRIPSTONE_DRIPS_WATER_INTO_CAULDRON I
 		COMMENT Pointed Dripstone drips Water into a Cauldron.
 		COMMENT <br>Plays the pointed dripstone dripping water into cauldron sound event.
-		COMMENT <p>Called by {@link net.minecraft.block.CauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) CauldronBlock#fillFromDripstone},
-		COMMENT and {@link net.minecraft.block.LeveledCauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) LeveledCauldronBlock#fillFromDripstone}
+		COMMENT <p>Called by {@link net.minecraft.block.cauldron.CauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) CauldronBlock#fillFromDripstone},
+		COMMENT and {@link net.minecraft.block.cauldron.LeveledCauldronBlock#fillFromDripstone(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.fluid.Fluid) LeveledCauldronBlock#fillFromDripstone}
 	FIELD f_wrcxqnhh LAVA_EXTINGUISHED I
 		COMMENT Lava is extinguished.
 		COMMENT <br>Plays the lava extinguish sound event and spawns large smoke particles.


### PR DESCRIPTION
new mappings? in this economy?

discussion question: should we consider breaking up the "every block is in `net.minecraft.block`" convention for absolutely wild stuff like putting sign blocks in `net.minecraft.block.sign`?