### PR TITLE
Use new Javadoc publishing, link to Quilt Loader.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           token: ${{ secrets.github_token }}
           prefix: "build/${{ github.ref }}"
-
       - run: ./gradlew build javadoc javadocJar publish --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
@@ -38,27 +37,16 @@ jobs:
           SNAPSHOTS_USERNAME: ${{ secrets.SNAPSHOTS_USERNAME }}
           SNAPSHOTS_PASSWORD: ${{ secrets.SNAPSHOTS_PASSWORD }}
           BRANCH_NAME: ${{ github.ref }}
-      # Javadoc publishing
-      - name: Install Git
-        run: |
-          apt-get update && apt-get install -y git
-          git --version
-      - name: Clone gh-pages branch
-        uses: actions/checkout@v3
+      - name: Publish javadoc to javadoc.quiltmc.org
+        uses: shallwefootball/upload-s3-action@v1.3.3
         with:
-          fetch-depth: 0
-          ref: 'gh-pages'
-          path: 'gh-pages'
-      - name: Push javadocs to gh-pages
-        run: |
-          rm -rf ./gh-pages/${GITHUB_REF##*/}/
-          mv ./build/docs/javadoc ./gh-pages/${GITHUB_REF##*/}/
-          cd gh-pages
-          git add .
-          git config user.name "Github Actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit --allow-empty -m "Publish javadoc from actions"
-          git push
+          aws_key_id: ${{ secrets.JAVADOC_USERNAME }}
+          aws_secret_access_key: ${{ secrets.JAVADOC_PASSWORD }}
+          aws_bucket: ${{ secrets.JAVADOC_BUCKET }}
+          endpoint: ${{ secrets.JAVADOC_URL }}
+          source_dir: ./build/docs/
+          destination_dir: "quilt-mappings"
+      # Javadoc publishing
       - name: Update Quilt Meta
         uses: quiltmc/update-quilt-meta@main
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configurations {
 dependencies {
 	enigmaRuntime(libs.enigma.swing)
 	enigmaRuntime(libs.enigma.plugin)
-	javadocClasspath(libs.fabric.loader)
+	javadocClasspath(libs.quilt.loader)
 	javadocClasspath(libs.jetbrains.annotations)
 	javadocClasspath(libs.jsr305) // for some other jsr annotations
 	decompileClasspath(libs.cfr)
@@ -350,7 +350,7 @@ javadoc {
 	dependsOn docletClasses // Needed for javadoc to find the doclet classes.
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
-
+	destinationDir = file("${buildDir}/docs/${project.version}")
 	def docletResources = sourceSets.doclet.resources.asFileTree
 
 	failOnError = true // Failing on error is important to ensure that a Javadoc jar is available.
@@ -388,7 +388,7 @@ javadoc {
 				"https://commons.apache.org/proper/commons-lang/javadocs/api-release/",
 				"https://commons.apache.org/proper/commons-io/apidocs/",
 				"https://commons.apache.org/proper/commons-codec/archives/${project.commons_codec}/apidocs/",
-				"https://maven.fabricmc.net/docs/fabric-loader-${libs.versions.fabric.loader.get()}/",
+				"https://javadoc.quiltmc.org/quilt-loader/${libs.versions.quilt.loader.get()}/",
 				"https://docs.oracle.com/en/java/javase/${project.java}/docs/api/"
 		)
 		// https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ unpick = "3.0.6"
 mapping_io = "0.3.0"
 javadoc_draftsman = "1.2.2"
 
-fabric_loader = "0.14.11"
+quilt_loader = "0.20.0-beta.9"
 jetbrains_annotations = "23.0.0"
 jsr305 = "3.0.2"
 gson = "2.9.1"
@@ -43,7 +43,7 @@ unpick_format_utils = { module = "org.quiltmc.unpick:unpick-format-utils", versi
 mapping_io = { module = "net.fabricmc:mapping-io", version.ref = "mapping_io" }
 javadoc_draftsman = { module = "org.quiltmc:javadoc-draftsman", version.ref = "javadoc_draftsman" }
 
-fabric_loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric_loader" }
+quilt_loader = { module = "org.quiltmc:quilt-loader", version.ref = "quilt_loader" }
 jetbrains_annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains_annotations" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 


### PR DESCRIPTION
The `gh-pages` branch can be deleted now.

The resulting javadoc will be available at `javadoc.quiltmc.org/quilt-mappings/<QM_VERSION>/` (e.g. 1.20.1+build.1)