### PR TITLE
Resource mappings

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
@@ -22,6 +22,7 @@ CLASS net/minecraft/unmapped/C_ibkofvzc net/minecraft/client/gui/screen/world/Cr
 	FIELD f_woybhigv dataPackTempDir Ljava/nio/file/Path;
 	FIELD f_wuyzkrbd GAME_MODE Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_xabhnhby grid Lnet/minecraft/unmapped/C_qykucwmu;
+	FIELD f_yednpqse linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;
 	FIELD f_ztgjtcrr tabManager Lnet/minecraft/unmapped/C_shidhwhk;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ayfeobid;Lnet/minecraft/unmapped/C_wrmtlwqx;Lnet/minecraft/unmapped/C_njsjipmy;Ljava/util/Optional;Ljava/util/OptionalLong;)V
 		ARG 2 parent

--- a/mappings/net/minecraft/resource/ResourceMetadata.mapping
+++ b/mappings/net/minecraft/resource/ResourceMetadata.mapping
@@ -1,13 +1,16 @@
 CLASS net/minecraft/unmapped/C_bzrwskbr net/minecraft/resource/ResourceMetadata
-	COMMENT Represents resource metadata.
+	COMMENT Represents resource metadata, composed of multiple sections.
 	FIELD f_uvkerkbr EMPTY_SUPPLIER Lnet/minecraft/unmapped/C_zccdhhqk;
 		COMMENT Represents a resource supplier of an empty {@code ResourceMetadata}.
 	FIELD f_wzwwuuoh EMPTY Lnet/minecraft/unmapped/C_bzrwskbr;
 		COMMENT Represents empty resource metadata.
-	METHOD m_ihurncqu readMetadata (Lnet/minecraft/unmapped/C_azwofart;)Ljava/util/Optional;
-		COMMENT Reads the resource metadata using the given reader.
+	METHOD m_huhzqhjh copySection (Lnet/minecraft/unmapped/C_bzrwskbr$C_vwlkgaob;Lnet/minecraft/unmapped/C_azwofart;)V
+		ARG 1 builder
+		ARG 2 reader
+	METHOD m_ihurncqu readSection (Lnet/minecraft/unmapped/C_azwofart;)Ljava/util/Optional;
+		COMMENT Reads the resource metadata section using the given reader.
 		COMMENT
-		COMMENT @return the read metadata
+		COMMENT @return the read metadata section
 		ARG 1 metadataReader
 			COMMENT the resource metadata reader
 	METHOD m_jievslte fromInputStream (Ljava/io/InputStream;)Lnet/minecraft/unmapped/C_bzrwskbr;
@@ -16,6 +19,8 @@ CLASS net/minecraft/unmapped/C_bzrwskbr net/minecraft/resource/ResourceMetadata
 		COMMENT @throws IOException if reading the input stream failed
 		ARG 0 stream
 			COMMENT the input stream to read into resource metadata
+	METHOD m_qeireofz copySections (Ljava/util/Collection;)Lnet/minecraft/unmapped/C_bzrwskbr;
+		ARG 1 sections
 	CLASS C_vwlkgaob Builder
 		FIELD f_bjovqcum values Lcom/google/common/collect/ImmutableMap$Builder;
 		METHOD m_dtqfsgix put (Lnet/minecraft/unmapped/C_azwofart;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_bzrwskbr$C_vwlkgaob;

--- a/mappings/net/minecraft/resource/pack/BuiltinResourcePackProvider.mapping
+++ b/mappings/net/minecraft/resource/pack/BuiltinResourcePackProvider.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_lqaxxobw net/minecraft/resource/pack/BuiltinResourcePackProvider
 	FIELD f_hvmbjtwe packDir Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_jxgkyphu type Lnet/minecraft/unmapped/C_abwutbbk;
+	FIELD f_ruizawsx linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;
 	FIELD f_ujknbcsx vanillaResourcePack Lnet/minecraft/unmapped/C_qauewsos;
 	FIELD f_xpkcknrw VANILLA_ID Ljava/lang/String;
 	METHOD m_ateussnw populatePackList (Ljava/util/function/BiConsumer;)V

--- a/mappings/net/minecraft/resource/pack/BuiltinResourcePackProvider.mapping
+++ b/mappings/net/minecraft/resource/pack/BuiltinResourcePackProvider.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/unmapped/C_lqaxxobw net/minecraft/resource/pack/BuiltinResou
 		ARG 1 name
 		ARG 2 factory
 		ARG 3 displayName
+	METHOD m_nklharuz wrapToFactory (Lnet/minecraft/unmapped/C_tguinuvn;)Lnet/minecraft/unmapped/C_lvnjxuwi$C_dwhnbqlk;
 	METHOD m_nptsmwiv (Lnet/minecraft/unmapped/C_lvnjxuwi$C_dwhnbqlk;Ljava/lang/String;)Lnet/minecraft/unmapped/C_lvnjxuwi;
 		ARG 2 name
 	METHOD m_pgtmuvzo getPackDisplayName (Ljava/lang/String;)Lnet/minecraft/unmapped/C_rdaqiwdt;

--- a/mappings/net/minecraft/resource/pack/CompositeResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/CompositeResourcePack.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_hdtifwml net/minecraft/resource/pack/CompositeResourcePack
 	COMMENT A {@link ResourcePack} consisting of a primary resource pack and one or more overlays.
 	FIELD f_gyptkxaa primary Lnet/minecraft/unmapped/C_tguinuvn;
-	FIELD f_uchhhtst packStack Ljava/util/List;
+	FIELD f_uchhhtst packs Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/unmapped/C_tguinuvn;Ljava/util/List;)V
 		ARG 1 primary
 		ARG 2 overlays

--- a/mappings/net/minecraft/resource/pack/CompositeResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/CompositeResourcePack.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_hdtifwml net/minecraft/resource/pack/CompositeResourcePack
+	COMMENT A {@link ResourcePack} consisting of a primary resource pack and one or more overlays.
+	FIELD f_gyptkxaa primary Lnet/minecraft/unmapped/C_tguinuvn;
+	FIELD f_uchhhtst packStack Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/unmapped/C_tguinuvn;Ljava/util/List;)V
+		ARG 1 primary
+		ARG 2 overlays

--- a/mappings/net/minecraft/resource/pack/FileResourcePackProvider.mapping
+++ b/mappings/net/minecraft/resource/pack/FileResourcePackProvider.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_sxnlbpmz net/minecraft/resource/pack/FileResourcePackProvider
 	FIELD f_ctlvxjmk packsFolder Ljava/nio/file/Path;
+	FIELD f_fbuwalab linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;
 	FIELD f_rvvxkazi type Lnet/minecraft/unmapped/C_abwutbbk;
 	FIELD f_rzlwntbb source Lnet/minecraft/unmapped/C_evnnymfu;
 	METHOD m_rdcoaisk searchResourcePacks (Ljava/nio/file/Path;Lnet/minecraft/unmapped/C_jgxjjhjn;ZLjava/util/function/BiConsumer;)V

--- a/mappings/net/minecraft/resource/pack/FileResourcePackProvider.mapping
+++ b/mappings/net/minecraft/resource/pack/FileResourcePackProvider.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_sxnlbpmz net/minecraft/resource/pack/FileResource
 	FIELD f_rzlwntbb source Lnet/minecraft/unmapped/C_evnnymfu;
 	METHOD m_rdcoaisk searchResourcePacks (Ljava/nio/file/Path;Lnet/minecraft/unmapped/C_jgxjjhjn;ZLjava/util/function/BiConsumer;)V
 		ARG 0 packsFolder
+		ARG 1 linkValidator
 		ARG 2 builtin
 		ARG 3 packConsumer
 	METHOD m_vdlrrjjc getResourcePackNameFromFile (Ljava/nio/file/Path;)Ljava/lang/String;
@@ -12,3 +13,7 @@ CLASS net/minecraft/unmapped/C_sxnlbpmz net/minecraft/resource/pack/FileResource
 	METHOD m_wzwvsvdv (Ljava/util/function/Consumer;Ljava/nio/file/Path;Lnet/minecraft/unmapped/C_lvnjxuwi$C_dwhnbqlk;)V
 		ARG 2 packPath
 		ARG 3 packFactory
+	CLASS C_pahuorni Detector
+		FIELD f_ihfafmbx builtin Z
+		METHOD <init> (Lnet/minecraft/unmapped/C_jgxjjhjn;Z)V
+			ARG 1 linkValidator

--- a/mappings/net/minecraft/resource/pack/NioResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/NioResourcePack.mapping
@@ -30,3 +30,6 @@ CLASS net/minecraft/unmapped/C_gvpdzhsk net/minecraft/resource/pack/NioResourceP
 		ARG 1 result
 	METHOD m_zowiccef (Ljava/nio/file/Path;Ljava/util/List;)Lnet/minecraft/unmapped/C_zccdhhqk;
 		ARG 1 pathSegments
+	CLASS C_rmznvduz Factory
+		FIELD f_kjstkldx root Ljava/nio/file/Path;
+		FIELD f_nmvheram builtin Z

--- a/mappings/net/minecraft/resource/pack/PackDetector.mapping
+++ b/mappings/net/minecraft/resource/pack/PackDetector.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/unmapped/C_dwkmbiso net/minecraft/resource/pack/PackDetector
+	FIELD f_rtyclybi linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;
+	METHOD m_jdqwsamm createFromZip (Ljava/nio/file/Path;)Ljava/lang/Object;
+		ARG 1 path
+	METHOD m_kiilwusn detectPack (Ljava/nio/file/Path;Ljava/util/List;)Ljava/lang/Object;
+		ARG 1 candidate
+		ARG 2 foundForbiddenLinks
+	METHOD m_zlvguvti createFromDirectory (Ljava/nio/file/Path;)Ljava/lang/Object;
+		ARG 1 path

--- a/mappings/net/minecraft/resource/pack/ResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/ResourcePack.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_tguinuvn net/minecraft/resource/pack/ResourcePack
 	COMMENT A resource pack, providing resources to resource managers.
 	COMMENT <p>
-	COMMENT They are single-use in each reload cycle of a reloadable resource manager.
+	COMMENT ResourcePacks are single-use in each reload cycle of a reloadable resource manager.
 	COMMENT {@link ResourcePackProfile} is a persistent version of the resource packs.
 	FIELD f_rogaspnc METADATA_PATH_SUFFIX Ljava/lang/String;
 	FIELD f_yjwyajkr PACK_METADATA_NAME Ljava/lang/String;

--- a/mappings/net/minecraft/resource/pack/ResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/ResourcePack.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_tguinuvn net/minecraft/resource/pack/ResourcePack
 	COMMENT A resource pack, providing resources to resource managers.
 	COMMENT <p>
-	COMMENT ResourcePacks are single-use in each reload cycle of a reloadable resource manager.
+	COMMENT {@code ResourcePack}s are single-use in each reload cycle of a reloadable resource manager.
 	COMMENT {@link ResourcePackProfile} is a persistent version of the resource packs.
 	FIELD f_rogaspnc METADATA_PATH_SUFFIX Ljava/lang/String;
 	FIELD f_yjwyajkr PACK_METADATA_NAME Ljava/lang/String;

--- a/mappings/net/minecraft/resource/pack/ResourcePackCompatibility.mapping
+++ b/mappings/net/minecraft/resource/pack/ResourcePackCompatibility.mapping
@@ -3,6 +3,9 @@ CLASS net/minecraft/unmapped/C_pchdyjmm net/minecraft/resource/pack/ResourcePack
 	FIELD f_ojtdjnjb notification Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 		ARG 3 translationSuffix
+	METHOD m_cgssmnwl forVersion (Lnet/minecraft/unmapped/C_uydqwobg;I)Lnet/minecraft/unmapped/C_pchdyjmm;
+		ARG 0 supported
+		ARG 1 version
 	METHOD m_dfdkggaw getNotification ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_eyynnvyp getConfirmMessage ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_mxgwctxl isCompatible ()Z

--- a/mappings/net/minecraft/resource/pack/ResourcePackProfile.mapping
+++ b/mappings/net/minecraft/resource/pack/ResourcePackProfile.mapping
@@ -74,13 +74,13 @@ CLASS net/minecraft/unmapped/C_lvnjxuwi net/minecraft/resource/pack/ResourcePack
 		ARG 7 source
 	CLASS C_dwhnbqlk ResourcePackFactory
 		METHOD m_juxacvht open (Ljava/lang/String;Lnet/minecraft/unmapped/C_lvnjxuwi$C_mowpzosc;)Lnet/minecraft/unmapped/C_tguinuvn;
-			COMMENT Open the primary resource pack and apply its overlays that support the current resource version.
+			COMMENT Opens the primary resource pack and apply its overlays that support the current resource version.
 			COMMENT <p>
 			COMMENT In practice, this usually means wrapping the resource pack and its overlays in a {@link CompositeResourcePack}.
 			ARG 1 name
 			ARG 2 info
 		METHOD m_kokszcyq openPrimary (Ljava/lang/String;)Lnet/minecraft/unmapped/C_tguinuvn;
-			COMMENT Open the primary resource pack only, without any overlays applied.
+			COMMENT Opens the primary resource pack only, without any overlays applied.
 			ARG 1 name
 	CLASS C_mowpzosc Info
 		METHOD m_scojbpqu getCompatibility ()Lnet/minecraft/unmapped/C_pchdyjmm;

--- a/mappings/net/minecraft/resource/pack/ResourcePackProfile.mapping
+++ b/mappings/net/minecraft/resource/pack/ResourcePackProfile.mapping
@@ -48,11 +48,13 @@ CLASS net/minecraft/unmapped/C_lvnjxuwi net/minecraft/resource/pack/ResourcePack
 	METHOD m_npymznkv readInfoFromPack (Ljava/lang/String;Lnet/minecraft/unmapped/C_lvnjxuwi$C_dwhnbqlk;I)Lnet/minecraft/unmapped/C_lvnjxuwi$C_mowpzosc;
 		ARG 0 name
 		ARG 1 factory
+		ARG 2 resourceVersion
 	METHOD m_pvddgias getDescription ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_rrlmzqhj getName ()Ljava/lang/String;
 	METHOD m_tjsvikza getInformationText (Z)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 1 enabled
-	METHOD m_txtppdtr (Ljava/lang/String;Lnet/minecraft/unmapped/C_jyhxjfdl;)Lnet/minecraft/unmapped/C_uydqwobg;
+	METHOD m_txtppdtr getSupportedFormats (Ljava/lang/String;Lnet/minecraft/unmapped/C_jyhxjfdl;)Lnet/minecraft/unmapped/C_uydqwobg;
+		ARG 0 name
 		ARG 1 metadata
 	METHOD m_udfnquim getDisplayName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_vmckdhaa isAlwaysEnabled ()Z
@@ -71,6 +73,15 @@ CLASS net/minecraft/unmapped/C_lvnjxuwi net/minecraft/resource/pack/ResourcePack
 		ARG 6 pinned
 		ARG 7 source
 	CLASS C_dwhnbqlk ResourcePackFactory
+		METHOD m_juxacvht open (Ljava/lang/String;Lnet/minecraft/unmapped/C_lvnjxuwi$C_mowpzosc;)Lnet/minecraft/unmapped/C_tguinuvn;
+			COMMENT Open the primary resource pack and apply its overlays that support the current resource version.
+			COMMENT <p>
+			COMMENT In practice, this usually means wrapping the resource pack and its overlays in a {@link CompositeResourcePack}.
+			ARG 1 name
+			ARG 2 info
+		METHOD m_kokszcyq openPrimary (Ljava/lang/String;)Lnet/minecraft/unmapped/C_tguinuvn;
+			COMMENT Open the primary resource pack only, without any overlays applied.
+			ARG 1 name
 	CLASS C_mowpzosc Info
 		METHOD m_scojbpqu getCompatibility ()Lnet/minecraft/unmapped/C_pchdyjmm;
 	CLASS C_vcyazcku InsertionPosition

--- a/mappings/net/minecraft/resource/pack/ZipResourcePack.mapping
+++ b/mappings/net/minecraft/resource/pack/ZipResourcePack.mapping
@@ -1,6 +1,25 @@
 CLASS net/minecraft/unmapped/C_icnizhru net/minecraft/resource/pack/ZipResourcePack
+	FIELD f_malujtcr prefix Ljava/lang/String;
+	FIELD f_zwrcpvrs zipFile Lnet/minecraft/unmapped/C_icnizhru$C_xudwvgom;
+	METHOD <init> (Ljava/lang/String;Lnet/minecraft/unmapped/C_icnizhru$C_xudwvgom;ZLjava/lang/String;)V
+		ARG 1 name
+		ARG 3 builtin
 	METHOD m_chobegff open (Ljava/lang/String;)Lnet/minecraft/unmapped/C_zccdhhqk;
 		ARG 1 path
+	METHOD m_fcsqqbet addPrefix (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 subPath
 	METHOD m_gagzfjxh getPath (Lnet/minecraft/unmapped/C_abwutbbk;Lnet/minecraft/unmapped/C_ncpywfca;)Ljava/lang/String;
 		ARG 0 type
 		ARG 1 id
+	METHOD m_idgqbzqt getNamespace (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	CLASS C_iwplcojz Factory
+		FIELD f_tnbjmous file Ljava/io/File;
+		FIELD f_uooizylz builtin Z
+		METHOD <init> (Ljava/nio/file/Path;Z)V
+			ARG 1 path
+			ARG 2 builtin
+	CLASS C_xudwvgom LazyZipFileAccess
+		FIELD f_smehlvgh zipFile Ljava/util/zip/ZipFile;
+		FIELD f_xgiqgpfg file Ljava/io/File;
+		FIELD f_zbhvfodi failed Z
+		METHOD m_nepwpyjo getOrCreate ()Ljava/util/zip/ZipFile;

--- a/mappings/net/minecraft/resource/pack/metadata/PackFeatureFlagsMetadataSection.mapping
+++ b/mappings/net/minecraft/resource/pack/metadata/PackFeatureFlagsMetadataSection.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_lypxkvwl net/minecraft/resource/pack/metadata/PackFeatureFlagsMetadata
+CLASS net/minecraft/unmapped/C_lypxkvwl net/minecraft/resource/pack/metadata/PackFeatureFlagsMetadataSection
 	COMMENT Represents the feature flags metadata a resource pack may provide.
 	FIELD f_ycadmeqr TYPE Lnet/minecraft/unmapped/C_qevrzqez;
 	METHOD m_kfsupnwn (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;

--- a/mappings/net/minecraft/resource/pack/metadata/PackOverlayMetadataSection.mapping
+++ b/mappings/net/minecraft/resource/pack/metadata/PackOverlayMetadataSection.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/unmapped/C_eojbberc net/minecraft/resource/pack/metadata/PackOverlayMetadataSection
+	FIELD f_cztuhvqp DIRECTORY_VALIDATOR Ljava/util/regex/Pattern;
+	FIELD f_yndjulhf TYPE Lnet/minecraft/unmapped/C_qevrzqez;
+	METHOD m_bctxfuzs (ILnet/minecraft/unmapped/C_eojbberc$C_cgavsocw;)Z
+		ARG 1 entry
+	METHOD m_hqvdtoeu validateDirectory (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 dirPath
+	METHOD m_mofmrelx overlaysForVersion (I)Ljava/util/List;
+		ARG 1 version
+	CLASS C_cgavsocw Entry
+		METHOD m_wksxenuf supportsFormat (I)Z
+			ARG 1 version

--- a/mappings/net/minecraft/resource/pack/metadata/PackResourceMetadataSection.mapping
+++ b/mappings/net/minecraft/resource/pack/metadata/PackResourceMetadataSection.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_jyhxjfdl net/minecraft/resource/pack/metadata/PackResourceMetadata
+CLASS net/minecraft/unmapped/C_jyhxjfdl net/minecraft/resource/pack/metadata/PackResourceMetadataSection
 	FIELD f_imvpblnm description Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_rikewdij TYPE Lnet/minecraft/unmapped/C_qevrzqez;
 	FIELD f_zbqiuaji packFormat I

--- a/mappings/net/minecraft/resource/pack/metadata/ResourceFilterMetadataSection.mapping
+++ b/mappings/net/minecraft/resource/pack/metadata/ResourceFilterMetadataSection.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_yxyotkoe net/minecraft/resource/pack/metadata/ResourceFilterMetadata
+CLASS net/minecraft/unmapped/C_yxyotkoe net/minecraft/resource/pack/metadata/ResourceFilterMetadataSection
 	FIELD f_gnmupynl CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_pecgooiz filters Ljava/util/List;
 	FIELD f_thvlmmuq TYPE Lnet/minecraft/unmapped/C_qevrzqez;

--- a/mappings/net/minecraft/resource/pack/metadata/ResourceMetadataSectionReader.mapping
+++ b/mappings/net/minecraft/resource/pack/metadata/ResourceMetadataSectionReader.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_azwofart net/minecraft/resource/pack/metadata/ResourceMetadataReader
+CLASS net/minecraft/unmapped/C_azwofart net/minecraft/resource/pack/metadata/ResourceMetadataSectionReader
 	METHOD m_hxcqhfca fromJson (Lcom/google/gson/JsonObject;)Ljava/lang/Object;
 		ARG 1 json
 	METHOD m_jetcodyj getKey ()Ljava/lang/String;

--- a/mappings/net/minecraft/unmapped/C_dwkmbiso.mapping
+++ b/mappings/net/minecraft/unmapped/C_dwkmbiso.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_dwkmbiso
+	FIELD f_rtyclybi linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;

--- a/mappings/net/minecraft/unmapped/C_dwkmbiso.mapping
+++ b/mappings/net/minecraft/unmapped/C_dwkmbiso.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_dwkmbiso
-	FIELD f_rtyclybi linkValidator Lnet/minecraft/unmapped/C_jgxjjhjn;

--- a/mappings/net/minecraft/util/path/SymlinkValidator.mapping
+++ b/mappings/net/minecraft/util/path/SymlinkValidator.mapping
@@ -10,11 +10,11 @@ CLASS net/minecraft/unmapped/C_jgxjjhjn net/minecraft/util/path/SymlinkValidator
 		COMMENT <p>
 		COMMENT If you only want to verify whether the directory itself is an allowed symlink, pass {@code false}.
 		COMMENT
-		COMMENT @param dir the dir to validate
-		COMMENT @param validateContents whether to validate the contents of the directory, or the directory itself.
 		COMMENT @return any forbidden symlinks
 		ARG 1 dir
+			COMMENT the directory to validate
 		ARG 2 validateContents
+			COMMENT whether to validate the contents of the directory, or the directory itself
 	METHOD m_plelqbgv validateSymlink (Ljava/nio/file/Path;Ljava/util/List;)V
 		ARG 1 symlink
 		ARG 2 foundForbiddenLinks

--- a/mappings/net/minecraft/util/path/SymlinkValidator.mapping
+++ b/mappings/net/minecraft/util/path/SymlinkValidator.mapping
@@ -1,5 +1,28 @@
 CLASS net/minecraft/unmapped/C_jgxjjhjn net/minecraft/util/path/SymlinkValidator
-	FIELD f_svrtftfg pathMatcher Ljava/nio/file/PathMatcher;
+	FIELD f_svrtftfg allowedSymlinkMatcher Ljava/nio/file/PathMatcher;
+	METHOD m_euykifgm validateDirectory (Ljava/nio/file/Path;Z)Ljava/util/List;
+		COMMENT Validates a directory.
+		COMMENT <p>
+		COMMENT If {@code validateContents} is true, then the directory's contents (but not the directory itself!) is inspected
+		COMMENT for forbidden symlinks. Pass {@code true} if you don't care if the passed directory is a symlink elsewhere,
+		COMMENT but do care about the contents of the directory being safe. For example, Minecraft doesn't care if a world
+		COMMENT folder is a symlink elsewhere, but the contents of the world cannot contain forbidden symlinks.
+		COMMENT <p>
+		COMMENT If you only want to verify whether the directory itself is an allowed symlink, pass {@code false}.
+		COMMENT
+		COMMENT @param dir the dir to validate
+		COMMENT @param validateContents whether to validate the contents of the directory, or the directory itself.
+		COMMENT @return any forbidden symlinks
+		ARG 1 dir
+		ARG 2 validateContents
+	METHOD m_plelqbgv validateSymlink (Ljava/nio/file/Path;Ljava/util/List;)V
+		ARG 1 symlink
+		ARG 2 foundForbiddenLinks
+	METHOD m_wxpdofaa validateDirectoryContents (Ljava/nio/file/Path;Ljava/util/List;)V
+		ARG 1 dir
+		ARG 2 foundForbiddenLinks
+	METHOD m_ztjbybov validateSymlink (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 1 symlink
 	CLASS C_redzjhyo
 		METHOD m_snezytsc validateSymlink (Ljava/nio/file/Path;Ljava/nio/file/attribute/BasicFileAttributes;)V
 			ARG 1 path


### PR DESCRIPTION
Some of these mappings are needed for Resource Loader.

This PR includes a refactor that makes resource metadata sections actually called "sections" more consistently throughout the codebase.