### PR TITLE
Renaming non-abstract `AbstractButtonBlock` to `ButtonBlock`

### DIFF
--- a/mappings/net/minecraft/block/ButtonBlock.mapping
+++ b/mappings/net/minecraft/block/ButtonBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_mvguptux net/minecraft/block/AbstractButtonBlock
+CLASS net/minecraft/unmapped/C_mvguptux net/minecraft/block/ButtonBlock
 	FIELD f_fqunlwzs CEILING_Z_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_irjxpusc SOUTH_PRESSED_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_jdxwsqgj UNPRESSED_DEPTH I


### PR DESCRIPTION
As of 1.20.1, AbstractButtonBlock isn't Abstract.