### PR TITLE
Switch to the new Minecraft Wiki URL

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -15,7 +15,6 @@ mcfunction
 // caves and cliffs preview
 ccpreview
 sadface
-gamepedia
 wiki
 
 // hard core to the mega

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -220,7 +220,7 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		COMMENT Checks if this world is a debug world.
 		COMMENT <p>
 		COMMENT Debug worlds are not modifiable and are typically meant for development and debug use only.
-		COMMENT See <a href="https://minecraft.gamepedia.com/Debug_mode">the minecraft wiki</a> as well.
+		COMMENT See <a href="https://minecraft.wiki/w/Debug_mode">the Minecraft wiki</a> as well.
 	METHOD m_nysixjre getGameRules ()Lnet/minecraft/unmapped/C_xmldumst;
 	METHOD m_oazwjzyp isInBuildLimit (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 pos


### PR DESCRIPTION
[It happened!](https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom)