### PR TITLE
Some Allay and Warden related mappings. 

### DIFF
--- a/mappings/net/minecraft/entity/ai/brain/task/GiveItemsToTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GiveItemsToTargetTask.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_swaljdod net/minecraft/entity/ai/brain/task/GiveI
 	FIELD f_ssmvgpht ITEM_PICKUP_COOLDOWN_AFTER_THROWING I
 	METHOD m_cnkgfmul getThrowPosition (Lnet/minecraft/unmapped/C_upikatuq;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 0 target
+	METHOD m_dtyapbty throwItemStackToEntity (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_vgpupfxx;)V
 	METHOD m_happfkds (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_upikatuq;)V
 		ARG 2 pos
 	METHOD m_txuefktw canThrowItemToTarget (Lnet/minecraft/unmapped/C_usxaxydn;)Z

--- a/mappings/net/minecraft/entity/mob/warden/WardenEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/warden/WardenEntity.mapping
@@ -67,3 +67,6 @@ CLASS net/minecraft/unmapped/C_fynaplbn net/minecraft/entity/mob/warden/WardenEn
 		ARG 1 origin
 		ARG 2 source
 		ARG 3 range
+	CLASS C_xfllwcxz
+		FIELD f_eudouoeu range I
+		FIELD f_fepzznrp positionSource Lnet/minecraft/unmapped/C_duzerrml;

--- a/mappings/net/minecraft/entity/mob/warden/WardenEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/warden/WardenEntity.mapping
@@ -68,5 +68,5 @@ CLASS net/minecraft/unmapped/C_fynaplbn net/minecraft/entity/mob/warden/WardenEn
 		ARG 2 source
 		ARG 3 range
 	CLASS C_xfllwcxz
-		FIELD f_eudouoeu range I
+		FIELD f_eudouoeu RANGE I
 		FIELD f_fepzznrp positionSource Lnet/minecraft/unmapped/C_duzerrml;

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_fwzlovqf CAN_DUPLICATE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gqwygpsf sculkSensorListener Lnet/minecraft/unmapped/C_wpaexsvv;
 	FIELD f_iqgfejuv MEMORY_MODULES Lcom/google/common/collect/ImmutableList;
-	FIELD f_jxnwapwy thrownItemPitches Lcom/google/common/collect/ImmutableList;
+	FIELD f_jxnwapwy THROWN_ITEM_PITCHES Lcom/google/common/collect/ImmutableList;
 	FIELD f_kkdwnmbg DUPLICATION_INGREDIENT Lnet/minecraft/unmapped/C_tcpsydrv;
 	FIELD f_mtjnjlex DUPLICATION_COOLDOWN I
 	FIELD f_oqiruvkz DANCING Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_fwzlovqf CAN_DUPLICATE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gqwygpsf sculkSensorListener Lnet/minecraft/unmapped/C_wpaexsvv;
 	FIELD f_iqgfejuv MEMORY_MODULES Lcom/google/common/collect/ImmutableList;
-	FIELD f_jxnwapwy itemGivingPitches Lcom/google/common/collect/ImmutableList;
+	FIELD f_jxnwapwy itemThrownPitches Lcom/google/common/collect/ImmutableList;
 	FIELD f_kkdwnmbg DUPLICATION_INGREDIENT Lnet/minecraft/unmapped/C_tcpsydrv;
 	FIELD f_mtjnjlex DUPLICATION_COOLDOWN I
 	FIELD f_oqiruvkz DANCING Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_fwzlovqf CAN_DUPLICATE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gqwygpsf sculkSensorListener Lnet/minecraft/unmapped/C_wpaexsvv;
 	FIELD f_iqgfejuv MEMORY_MODULES Lcom/google/common/collect/ImmutableList;
+	FIELD f_jxnwapwy itemGivingPitches Lcom/google/common/collect/ImmutableList;
 	FIELD f_kkdwnmbg DUPLICATION_INGREDIENT Lnet/minecraft/unmapped/C_tcpsydrv;
 	FIELD f_mtjnjlex DUPLICATION_COOLDOWN I
 	FIELD f_oqiruvkz DANCING Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_fwzlovqf CAN_DUPLICATE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gqwygpsf sculkSensorListener Lnet/minecraft/unmapped/C_wpaexsvv;
 	FIELD f_iqgfejuv MEMORY_MODULES Lcom/google/common/collect/ImmutableList;
-	FIELD f_jxnwapwy itemThrownPitches Lcom/google/common/collect/ImmutableList;
+	FIELD f_jxnwapwy thrownItemPitches Lcom/google/common/collect/ImmutableList;
 	FIELD f_kkdwnmbg DUPLICATION_INGREDIENT Lnet/minecraft/unmapped/C_tcpsydrv;
 	FIELD f_mtjnjlex DUPLICATION_COOLDOWN I
 	FIELD f_oqiruvkz DANCING Lnet/minecraft/unmapped/C_rinmcaxy;


### PR DESCRIPTION
- Mapped fields in `WardenEntity ` inner class to `range` and `positionSource`.
- Mapped ImmutableList field in `AllayEntity` to `itemThrownPitches`.
- Mapped public static void method in `GiveItemsToTargetTask` to `throwItemStackToEntity`.