### PR TITLE
Map LootableInventory

### DIFF
--- a/mappings/net/minecraft/inventory/LootableInventory.mapping
+++ b/mappings/net/minecraft/inventory/LootableInventory.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/unmapped/C_ehawoasn net/minecraft/inventory/LootableInventory
+	FIELD f_yeibkfzd LOOT_TABLE_SEED_KEY Ljava/lang/String;
+	FIELD f_ztchflsp LOOT_TABLE_KEY Ljava/lang/String;
+	METHOD m_canflxyp setLootTableId (Lnet/minecraft/unmapped/C_ncpywfca;)V
+	METHOD m_drfdhyfv getLootTableId ()Lnet/minecraft/unmapped/C_ncpywfca;
+	METHOD m_mtzsyvbu setupLoot (Lnet/minecraft/unmapped/C_jzrpycqo;)V
+	METHOD m_njtcujiz readLootTableNbt (Lnet/minecraft/unmapped/C_hhlwcnih;)Z
+	METHOD m_qihknhoq getPos ()Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_rtxjwbev getWorld ()Lnet/minecraft/unmapped/C_cdctfzbn;
+	METHOD m_ssvygaxw setupLootTable (Lnet/minecraft/unmapped/C_ncpywfca;J)V
+	METHOD m_ubdtdnuf setLootTableSeed (J)V
+	METHOD m_uxrpqxab getLootTableSeed ()J
+	METHOD m_vhsehsrn setupLootTable (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ncpywfca;)V
+	METHOD m_ycwokqel writeLootTableNbt (Lnet/minecraft/unmapped/C_hhlwcnih;)Z


### PR DESCRIPTION
# This PR
This PR adds mappings for `C_ehawoasn` to fix a critical bug that crashed the game when breaking chests.

Most importantly, this maps `C_ehawoasn.method_10997` to `LootableInventory.getWorld` and `C_ehawoasn.method_11016` to `LootableInventory.getPos`.

# Associated
* This fixes #518.