### PR TITLE
Status effect mappings

### DIFF
--- a/mappings/net/minecraft/entity/effect/AbsorptionStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/AbsorptionStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ohdhxeqr net/minecraft/entity/effect/AbsorptionStatusEffect

--- a/mappings/net/minecraft/entity/effect/BadOmenStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/BadOmenStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_rqetedul net/minecraft/entity/effect/BadOmenStatusEffect

--- a/mappings/net/minecraft/entity/effect/HungerStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/HungerStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ukvkpidx net/minecraft/entity/effect/HungerStatusEffect

--- a/mappings/net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/unmapped/C_cbhpjzoa net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect
-	FIELD f_efjpyqqw isHarm Z
+	FIELD f_efjpyqqw isDamage Z
 	METHOD <init> (Lnet/minecraft/unmapped/C_mbktilxo;IZ)V
 		ARG 1 type
 		ARG 2 color

--- a/mappings/net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_cbhpjzoa net/minecraft/entity/effect/InstantHealthOrDamageStatusEffect
+	FIELD f_efjpyqqw isHarm Z
+	METHOD <init> (Lnet/minecraft/unmapped/C_mbktilxo;IZ)V
+		ARG 1 type
+		ARG 2 color

--- a/mappings/net/minecraft/entity/effect/PoisonStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/PoisonStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_fradzqif net/minecraft/entity/effect/PoisonStatusEffect

--- a/mappings/net/minecraft/entity/effect/RegenerationStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/RegenerationStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_jzwrvgjr net/minecraft/entity/effect/RegenerationStatusEffect

--- a/mappings/net/minecraft/entity/effect/SaturationStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/SaturationStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_mabzztne net/minecraft/entity/effect/SaturationStatusEffect

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_jaqasomh net/minecraft/entity/effect/StatusEffect
 	FIELD f_fcnodzqo color I
 	FIELD f_pnqtkxvc type Lnet/minecraft/unmapped/C_mbktilxo;
 	FIELD f_rqynlpsa attributeModifiers Ljava/util/Map;
+	FIELD f_umzrptqr blendDuration I
 	FIELD f_yqqwyxsb translationKey Ljava/lang/String;
 	METHOD <init> (Lnet/minecraft/unmapped/C_mbktilxo;I)V
 		ARG 1 type
@@ -11,17 +12,30 @@ CLASS net/minecraft/unmapped/C_jaqasomh net/minecraft/entity/effect/StatusEffect
 		ARG 2 amplifier
 	METHOD m_baqejeuf getTranslationKey ()Ljava/lang/String;
 	METHOD m_bpyxngol getColor ()I
+	METHOD m_cqhckmsk applyToEntity (Lnet/minecraft/unmapped/C_usxaxydn;I)V
+		ARG 1 entity
+		ARG 2 amplifier
 	METHOD m_despsamn applyUpdateEffect (Lnet/minecraft/unmapped/C_usxaxydn;I)Z
 		ARG 1 entity
 		ARG 2 amplifier
+	METHOD m_hgarvyvx withBlendDuration (I)Lnet/minecraft/unmapped/C_jaqasomh;
+		ARG 1 blendDuration
 	METHOD m_igvnkdng isBeneficial ()Z
+	METHOD m_ijocerbb getBlendDuration ()I
 	METHOD m_irzxckrv shouldApplyUpdateEffect (II)Z
 		ARG 1 tick
 		ARG 2 amplifier
+	METHOD m_lzrczzyu (Ljava/util/function/BiConsumer;ILnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_jaqasomh$C_xvxuthmo;)V
+		ARG 3 attribute
+		ARG 4 modifierCreator
 	METHOD m_nnnovhef addAttributeModifier (Lnet/minecraft/unmapped/C_cjzoxshv;Ljava/lang/String;DLnet/minecraft/unmapped/C_hdbqsqsm$C_pljpmmzs;)Lnet/minecraft/unmapped/C_jaqasomh;
+		ARG 1 attribute
 		ARG 2 uuid
 		ARG 3 amount
 		ARG 5 operation
+	METHOD m_qlsxoyxu createAttributeModifiers (ILjava/util/function/BiConsumer;)V
+		ARG 1 amplifier
+		ARG 2 consumer
 	METHOD m_qpdmsuqi getType ()Lnet/minecraft/unmapped/C_mbktilxo;
 	METHOD m_sdyrfndd loadTranslationKey ()Ljava/lang/String;
 	METHOD m_sfpvrsws onRemoved (Lnet/minecraft/unmapped/C_cohbwqne;)V
@@ -34,3 +48,7 @@ CLASS net/minecraft/unmapped/C_jaqasomh net/minecraft/entity/effect/StatusEffect
 		ARG 4 amplifier
 		ARG 5 proximity
 	METHOD m_yxnpxply isInstant ()Z
+	CLASS C_xvxuthmo EntryAttributeModifierCreator
+		METHOD m_zhiowqzb create (Ljava/lang/String;I)Lnet/minecraft/unmapped/C_hdbqsqsm;
+			ARG 1 name
+			ARG 2 amplifier

--- a/mappings/net/minecraft/entity/effect/StatusEffectInstance.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffectInstance.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_wpfizwve net/minecraft/entity/effect/StatusEffectInstance
 	FIELD f_bkslpncm amplifier I
+	FIELD f_boolcauu HIDDEN_EFFECT_KEY Ljava/lang/String;
 	FIELD f_cawgobpt LOGGER Lorg/slf4j/Logger;
 	FIELD f_cqswxreu hiddenEffect Lnet/minecraft/unmapped/C_wpfizwve;
 		COMMENT The effect hidden when upgrading effects. Duration decreases with this
@@ -7,12 +8,41 @@ CLASS net/minecraft/unmapped/C_wpfizwve net/minecraft/entity/effect/StatusEffect
 		COMMENT
 		COMMENT <p>This exists so that long-duration low-amplifier effects reappears
 		COMMENT after short-duration high-amplifier effects run out.
+	FIELD f_cwvkmixx DURATION_KEY Ljava/lang/String;
+	FIELD f_dkhxnpcm SHOW_PARTICLES_KEY Ljava/lang/String;
+	FIELD f_fflidhcu AMBIENT_KEY Ljava/lang/String;
+	FIELD f_fjrfbwth blendState Lnet/minecraft/unmapped/C_wpfizwve$C_wykyjmct;
+	FIELD f_gcxjykfm ID_KEY Ljava/lang/String;
 	FIELD f_hvgmvstv showParticles Z
 	FIELD f_ieofirpv ambient Z
+	FIELD f_mosslgcp AMPLIFIER_KEY Ljava/lang/String;
 	FIELD f_phnnfhqn duration I
 	FIELD f_roivswws type Lnet/minecraft/unmapped/C_cjzoxshv;
 	FIELD f_sfiyfhvh INFINITE_DURATION I
 	FIELD f_vciwymjw showIcon Z
+	FIELD f_vvovcdqn SHOW_ICON_KEY Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 1 type
+	METHOD <init> (Lnet/minecraft/unmapped/C_cjzoxshv;I)V
+		ARG 1 type
+		ARG 2 duration
+	METHOD <init> (Lnet/minecraft/unmapped/C_cjzoxshv;II)V
+		ARG 1 type
+		ARG 2 duration
+		ARG 3 amplifier
+	METHOD <init> (Lnet/minecraft/unmapped/C_cjzoxshv;IIZZ)V
+		ARG 1 type
+		ARG 2 duration
+		ARG 3 amplifier
+		ARG 4 ambient
+		ARG 5 visible
+	METHOD <init> (Lnet/minecraft/unmapped/C_cjzoxshv;IIZZZ)V
+		ARG 1 type
+		ARG 2 duration
+		ARG 3 amplifier
+		ARG 4 ambient
+		ARG 5 showParticles
+		ARG 6 showIcon
 	METHOD <init> (Lnet/minecraft/unmapped/C_wpfizwve;)V
 		ARG 1 that
 	METHOD compareTo compareTo (Ljava/lang/Object;)I
@@ -40,11 +70,24 @@ CLASS net/minecraft/unmapped/C_wpfizwve net/minecraft/entity/effect/StatusEffect
 	METHOD m_qqtmdstn shouldShowParticles ()Z
 	METHOD m_qxzigndt lastsShorterThan (Lnet/minecraft/unmapped/C_wpfizwve;)Z
 		ARG 1 effect
+	METHOD m_rmieevba (I)I
+		ARG 0 duration
+	METHOD m_rpnokfkv getBlendFactor (Lnet/minecraft/unmapped/C_usxaxydn;F)F
+		ARG 1 entity
+		ARG 2 tickDelta
+	METHOD m_ttewyopb isOfType (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 1 type
 	METHOD m_uhzuhbds isAmbient ()Z
 	METHOD m_ukwouxmh fromNbt (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hhlwcnih;)Lnet/minecraft/unmapped/C_wpfizwve;
+		ARG 0 type
 		ARG 1 nbt
-	METHOD m_vqnuhydc (Lnet/minecraft/unmapped/C_usxaxydn;)V
+	METHOD m_voaqtpqg copyBlendState (Lnet/minecraft/unmapped/C_wpfizwve;)V
+		ARG 1 other
+	METHOD m_vovzccxi (Lnet/minecraft/unmapped/C_hhlwcnih;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)Lnet/minecraft/unmapped/C_wpfizwve;
+		ARG 1 effectType
+	METHOD m_vqnuhydc applyToEntity (Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 entity
+	METHOD m_whnvneco skipBlending ()V
 	METHOD m_xedzspyz getTranslationKey ()Ljava/lang/String;
 	METHOD m_xwkrgskr copyFrom (Lnet/minecraft/unmapped/C_wpfizwve;)V
 		ARG 1 that
@@ -53,3 +96,19 @@ CLASS net/minecraft/unmapped/C_wpfizwve net/minecraft/entity/effect/StatusEffect
 	METHOD m_zhljuajd updateDuration ()I
 	METHOD m_ztseznln writeTypelessNbt (Lnet/minecraft/unmapped/C_hhlwcnih;)V
 		ARG 1 nbt
+	CLASS C_wykyjmct BlendState
+		FIELD f_joxeptyp prevFactor F
+		FIELD f_ptuqoimd factor F
+		METHOD m_bnhtmrsy copyFrom (Lnet/minecraft/unmapped/C_wpfizwve$C_wykyjmct;)V
+			ARG 1 blendState
+		METHOD m_esvbthsn computeFactorTarget (Lnet/minecraft/unmapped/C_wpfizwve;)F
+			ARG 0 effect
+		METHOD m_hpyzpybt setInstant (Lnet/minecraft/unmapped/C_wpfizwve;)V
+			ARG 1 effect
+		METHOD m_joeqbtcv tick (Lnet/minecraft/unmapped/C_wpfizwve;)V
+			ARG 1 effect
+		METHOD m_kektymyy getBlendDuration (Lnet/minecraft/unmapped/C_wpfizwve;)I
+			ARG 0 effect
+		METHOD m_psejherm getBlendFactor (Lnet/minecraft/unmapped/C_usxaxydn;F)F
+			ARG 1 entity
+			ARG 2 tickDelta

--- a/mappings/net/minecraft/entity/effect/StatusEffectUtil.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffectUtil.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_nspbkuta net/minecraft/entity/effect/StatusEffectUtil
 	METHOD m_dfebzmxb hasWaterBreathing (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 entity
+	METHOD m_fzjagddp (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_vgpupfxx;DLnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_wpfizwve;ILnet/minecraft/unmapped/C_mxrobsgg;)Z
+		ARG 7 player
 	METHOD m_jglgfnrq (Lnet/minecraft/unmapped/C_wpfizwve;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_mxrobsgg;)V
 		ARG 2 player
 	METHOD m_tbxxffvl getHasteAmplifier (Lnet/minecraft/unmapped/C_usxaxydn;)I
@@ -17,3 +19,4 @@ CLASS net/minecraft/unmapped/C_nspbkuta net/minecraft/entity/effect/StatusEffect
 	METHOD m_zoircsnl durationToString (Lnet/minecraft/unmapped/C_wpfizwve;FF)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 0 effect
 		ARG 1 multiplier
+		ARG 2 tickRate

--- a/mappings/net/minecraft/entity/effect/StatusEffects.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffects.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_srfncnhx net/minecraft/entity/effect/StatusEffects
 	FIELD f_htvhwvfu DARKNESS_PADDING_DURATION I
+	METHOD m_bbqqyogz bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_cjzoxshv;
 	METHOD m_jkusimtl register (Ljava/lang/String;Lnet/minecraft/unmapped/C_jaqasomh;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 0 id
 		ARG 1 entry

--- a/mappings/net/minecraft/entity/effect/WitherStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/WitherStatusEffect.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_gjaxwcua net/minecraft/entity/effect/WitherStatusEffect

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityStatusEffectUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityStatusEffectUpdateS2CPacket.mapping
@@ -6,10 +6,14 @@ CLASS net/minecraft/unmapped/C_acpvlppz net/minecraft/network/packet/s2c/play/En
 	FIELD f_vrjxatnl duration I
 	FIELD f_vswzayjb effect Lnet/minecraft/unmapped/C_cjzoxshv;
 	FIELD f_wkbihzch SHOW_ICON_MASK I
+	FIELD f_wqrumdqo BLEND_MASK I
 	FIELD f_xctbcvat amplifier B
+	METHOD <init> (ILnet/minecraft/unmapped/C_wpfizwve;Z)V
+		ARG 3 blend
 	METHOD <init> (Lnet/minecraft/unmapped/C_idfydwco;)V
 		ARG 1 buf
 	METHOD m_ahtkgbnq shouldShowParticles ()Z
+	METHOD m_dqsdynsy shouldBlend ()Z
 	METHOD m_ejqwrjsm getAmplifier ()B
 	METHOD m_gnnkoxnt getEntityId ()I
 	METHOD m_ippjoudz getDuration ()I

--- a/mappings/net/minecraft/util/ChatUtil.mapping
+++ b/mappings/net/minecraft/util/ChatUtil.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/unmapped/C_myfdnbpo net/minecraft/util/ChatUtil
 		ARG 0 text
 	METHOD m_rxjvteqh ticksToString (IF)Ljava/lang/String;
 		ARG 0 ticks
+		ARG 1 tickRate
 	METHOD m_unbbnfnr cutString (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 string
 	METHOD m_vvxzwzcp truncate (Ljava/lang/String;IZ)Ljava/lang/String;


### PR DESCRIPTION
100% on `n.m.entity.effect`! `StatusEffectInstance.BlendState` is a mojmap name, since I had no clue what the class did. From what I could gather, it's used to calculate a "blending factor" to give smooth fading out to effects. In `23w51b` its only used for the darkness effect