### PR TITLE
advancement mappings + codecs!

### DIFF
--- a/mappings/net/minecraft/advancement/Advancement.mapping
+++ b/mappings/net/minecraft/advancement/Advancement.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/unmapped/C_kdwyuhdb net/minecraft/advancement/Advancement
+	FIELD f_bpbcihch CRITERIA_CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_cbfwvpgh parent Ljava/util/Optional;
 	FIELD f_emngvigd requirements Lnet/minecraft/unmapped/C_wbfyxnvb;
 	FIELD f_eqsfnrjr criteria Ljava/util/Map;
 	FIELD f_eykiurph display Ljava/util/Optional;
+	FIELD f_ncipkedb CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_njhcraol name Ljava/util/Optional;
 	FIELD f_nwvdgawt sendsTelemetryEvent Z
 	FIELD f_uhuyjydl rewards Lnet/minecraft/unmapped/C_wptigggq;
@@ -15,13 +17,38 @@ CLASS net/minecraft/unmapped/C_kdwyuhdb net/minecraft/advancement/Advancement
 		ARG 6 sendsTelemetryEvent
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
+	METHOD m_ddukknkz (Ljava/util/Map;)Lcom/mojang/serialization/DataResult;
+		ARG 0 map
 	METHOD m_ggypmlkv sendsTelemetryEvent ()Z
+	METHOD m_gzpyltqd (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_cpwnhism;)Lnet/minecraft/unmapped/C_cpwnhism;
+		ARG 1 style
 	METHOD m_hpxxrezd fromPacket (Lnet/minecraft/unmapped/C_idfydwco;)Lnet/minecraft/unmapped/C_kdwyuhdb;
 		ARG 0 buf
 	METHOD m_htjukofs parent ()Ljava/util/Optional;
+	METHOD m_jvmczssc validateCriteria (Lnet/minecraft/unmapped/C_jtpvewkp;Lnet/minecraft/unmapped/C_srnkfpki;)V
+		ARG 1 reporter
+		ARG 2 dataLookup
+	METHOD m_kxwbsmcw (Lnet/minecraft/unmapped/C_jtpvewkp;Lnet/minecraft/unmapped/C_srnkfpki;Ljava/lang/String;Lnet/minecraft/unmapped/C_rzypsigz;)V
+		ARG 2 key
+		ARG 3 criterion
+	METHOD m_nlkunzez (Lnet/minecraft/unmapped/C_kdwyuhdb;)Ljava/util/Optional;
+		ARG 0 advancement
+	METHOD m_nltrnngb (Lnet/minecraft/unmapped/C_idfydwco;Lnet/minecraft/unmapped/C_bvqakncm;)V
+		ARG 1 display
 	METHOD m_ofikdsfj rewards ()Lnet/minecraft/unmapped/C_wptigggq;
+	METHOD m_pzwagfwo validate (Lnet/minecraft/unmapped/C_kdwyuhdb;)Lcom/mojang/serialization/DataResult;
+		ARG 0 advancement
 	METHOD m_swogstqz getText (Lnet/minecraft/unmapped/C_unoypvme;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 0 advancementHolder
+	METHOD m_szjzyjkp (Lnet/minecraft/unmapped/C_kdwyuhdb;Lnet/minecraft/unmapped/C_wbfyxnvb;)Lnet/minecraft/unmapped/C_kdwyuhdb;
+		ARG 1 criterionKey
+	METHOD m_tbqwjxrn (Ljava/util/Optional;Ljava/util/Optional;Lnet/minecraft/unmapped/C_wptigggq;Ljava/util/Map;Ljava/util/Optional;Ljava/lang/Boolean;)Lnet/minecraft/unmapped/C_kdwyuhdb;
+		ARG 0 id
+		ARG 1 display
+		ARG 2 rewards
+		ARG 3 criteria
+		ARG 4 requirements
+		ARG 5 sendsTelemetryEvent
 	METHOD m_vdmpoqil requirements ()Lnet/minecraft/unmapped/C_wbfyxnvb;
 	METHOD m_vfnevnhx name ()Ljava/util/Optional;
 	METHOD m_wngxatfp display ()Ljava/util/Optional;
@@ -29,6 +56,8 @@ CLASS net/minecraft/unmapped/C_kdwyuhdb net/minecraft/advancement/Advancement
 	METHOD m_xazdqguv criteria ()Ljava/util/Map;
 	METHOD m_xbcnitcp createText (Lnet/minecraft/unmapped/C_bvqakncm;)Lnet/minecraft/unmapped/C_rdaqiwdt;
 		ARG 0 display
+	METHOD m_xeyczyky (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
 	METHOD m_xfimowjn toPacket (Lnet/minecraft/unmapped/C_idfydwco;)V
 		ARG 1 buf
 	CLASS C_dukbjvrv Builder
@@ -41,11 +70,28 @@ CLASS net/minecraft/unmapped/C_kdwyuhdb net/minecraft/advancement/Advancement
 		FIELD f_wpvukjwy merger Lnet/minecraft/unmapped/C_wbfyxnvb$C_huwvdbdx;
 		METHOD m_ckalgnkc merger (Lnet/minecraft/unmapped/C_wbfyxnvb$C_huwvdbdx;)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
 			ARG 1 merger
+		METHOD m_htowdhjv display (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_onnxqlfg;ZZZ)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
+			ARG 2 title
+			ARG 3 description
+			ARG 4 background
+			ARG 5 type
+			ARG 6 showToast
+			ARG 7 announceToChat
+			ARG 8 hidden
 		METHOD m_jlhvlwgp display (Lnet/minecraft/unmapped/C_bvqakncm;)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
 			ARG 1 display
 		METHOD m_liavgrzl putCriteria (Ljava/lang/String;Lnet/minecraft/unmapped/C_rzypsigz;)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
 			ARG 1 name
 			ARG 2 criterion
+		METHOD m_mopntkkx display (Lnet/minecraft/unmapped/C_gmbqjnle;Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_onnxqlfg;ZZZ)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
+			ARG 1 item
+			ARG 2 title
+			ARG 3 description
+			ARG 4 background
+			ARG 5 type
+			ARG 6 showToast
+			ARG 7 announceToChat
+			ARG 8 hidden
 		METHOD m_mshncpue requirements (Lnet/minecraft/unmapped/C_wbfyxnvb;)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;
 			ARG 1 requirements
 		METHOD m_ofouvzjr parent (Lnet/minecraft/unmapped/C_unoypvme;)Lnet/minecraft/unmapped/C_kdwyuhdb$C_dukbjvrv;

--- a/mappings/net/minecraft/advancement/AdvancementCriterion.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementCriterion.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/unmapped/C_rzypsigz net/minecraft/advancement/AdvancementCriterion
 	FIELD f_bjqitkog trigger Lnet/minecraft/unmapped/C_mysyaxfs;
+	FIELD f_yezbocli MAP_CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_yiamcoxx conditions Lnet/minecraft/unmapped/C_zkhebbek;
 	METHOD m_djfutiin trigger ()Lnet/minecraft/unmapped/C_mysyaxfs;
+	METHOD m_hdyzfdac (Lnet/minecraft/unmapped/C_mysyaxfs;Lnet/minecraft/unmapped/C_zkhebbek;)Lnet/minecraft/unmapped/C_rzypsigz;
+		ARG 1 conditions
 	METHOD m_iuvjqrcn conditions ()Lnet/minecraft/unmapped/C_zkhebbek;
-	METHOD m_uxddutmc (Lnet/minecraft/unmapped/C_mysyaxfs;)Lcom/mojang/serialization/Codec;
+	METHOD m_uxddutmc getCodec (Lnet/minecraft/unmapped/C_mysyaxfs;)Lcom/mojang/serialization/Codec;
 		ARG 0 trigger

--- a/mappings/net/minecraft/advancement/AdvancementCriterion.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementCriterion.mapping
@@ -3,3 +3,5 @@ CLASS net/minecraft/unmapped/C_rzypsigz net/minecraft/advancement/AdvancementCri
 	FIELD f_yiamcoxx conditions Lnet/minecraft/unmapped/C_zkhebbek;
 	METHOD m_djfutiin trigger ()Lnet/minecraft/unmapped/C_mysyaxfs;
 	METHOD m_iuvjqrcn conditions ()Lnet/minecraft/unmapped/C_zkhebbek;
+	METHOD m_uxddutmc (Lnet/minecraft/unmapped/C_mysyaxfs;)Lcom/mojang/serialization/Codec;
+		ARG 0 trigger

--- a/mappings/net/minecraft/advancement/AdvancementDisplay.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementDisplay.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/unmapped/C_bvqakncm net/minecraft/advancement/AdvancementDis
 	FIELD f_jzkkgjeq y F
 	FIELD f_mbfqtzfa showToast Z
 	FIELD f_pmsclssl description Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_qnsndlza type Lnet/minecraft/unmapped/C_onnxqlfg;
 	FIELD f_rmagsfyq hidden Z
 	FIELD f_rrekahiq title Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_wlsljbis icon Lnet/minecraft/unmapped/C_sddaxwyk;
@@ -11,6 +12,8 @@ CLASS net/minecraft/unmapped/C_bvqakncm net/minecraft/advancement/AdvancementDis
 	METHOD m_asmgeqym fromPacket (Lnet/minecraft/unmapped/C_idfydwco;)Lnet/minecraft/unmapped/C_bvqakncm;
 		ARG 0 buf
 	METHOD m_axxsgbbh getTitle ()Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_erpazfvp (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
 	METHOD m_gxawxbty getDescription ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_hhbgzigh shouldAnnounceToChat ()Z
 	METHOD m_jhcmytjo toPacket (Lnet/minecraft/unmapped/C_idfydwco;)V
@@ -18,6 +21,7 @@ CLASS net/minecraft/unmapped/C_bvqakncm net/minecraft/advancement/AdvancementDis
 	METHOD m_pzykhctp getY ()F
 	METHOD m_qepjmlpk getX ()F
 	METHOD m_rrhjbvlh getBackground ()Ljava/util/Optional;
+	METHOD m_spcgkfjs getType ()Lnet/minecraft/unmapped/C_onnxqlfg;
 	METHOD m_szkyblby shouldShowToast ()Z
 	METHOD m_taxswuiw setPos (FF)V
 		ARG 1 x

--- a/mappings/net/minecraft/advancement/AdvancementRequirements.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementRequirements.mapping
@@ -1,11 +1,16 @@
 CLASS net/minecraft/unmapped/C_wbfyxnvb net/minecraft/advancement/AdvancementRequirements
 	FIELD f_tkcwteeq EMPTY Lnet/minecraft/unmapped/C_wbfyxnvb;
 	FIELD f_wauysoso requirements Ljava/util/List;
+	METHOD m_bnmpyfyz validate (Ljava/util/Set;)Lcom/mojang/serialization/DataResult;
+		ARG 1 requirements
 	METHOD m_ehrayjiz length ()I
 	METHOD m_gzkxpsoh anyMatch (Ljava/util/List;Ljava/util/function/Predicate;)Z
+		ARG 0 requirements
 		ARG 1 predicate
 	METHOD m_hdmfabfc allMatch (Ljava/util/function/Predicate;)Z
 		ARG 1 predicate
+	METHOD m_hzrzuiom (Lnet/minecraft/unmapped/C_idfydwco;Ljava/util/List;)V
+		ARG 1 requirements
 	METHOD m_jupbcyte anyOf (Ljava/util/Collection;)Lnet/minecraft/unmapped/C_wbfyxnvb;
 		ARG 0 collection
 	METHOD m_nxtypetc toSet ()Ljava/util/Set;

--- a/mappings/net/minecraft/advancement/AdvancementType.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_onnxqlfg net/minecraft/text/component/AdvancementComponent
+CLASS net/minecraft/unmapped/C_onnxqlfg net/minecraft/advancement/AdvancementType
 	FIELD f_vfxofohl toast Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_wnqqatxq formatting Lnet/minecraft/unmapped/C_tnezalvh;
 	FIELD f_xzhurgdz key Ljava/lang/String;

--- a/mappings/net/minecraft/advancement/criterion/AbstractCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/AbstractCriterionTrigger.mapping
@@ -6,3 +6,4 @@ CLASS net/minecraft/unmapped/C_bmtrgtzi net/minecraft/advancement/criterion/Abst
 	METHOD m_whzofkzk (Lnet/minecraft/unmapped/C_hyeqtgvx;)Ljava/util/Set;
 		ARG 0 manager
 	CLASS C_hjljikdm Conditions
+		METHOD m_klqamsnl player ()Ljava/util/Optional;

--- a/mappings/net/minecraft/advancement/criterion/BeeNestDestroyedCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/BeeNestDestroyedCriterionTrigger.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/unmapped/C_eyqqwstf net/minecraft/advancement/criterion/BeeN
 		ARG 2 state
 		ARG 3 stack
 		ARG 4 beeCount
+	METHOD m_zbyuvsjg (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_sddaxwyk;ILnet/minecraft/unmapped/C_eyqqwstf$C_vzisdrlj;)Z
+		ARG 3 conditions
 	CLASS C_vzisdrlj Conditions
 		FIELD f_beqjwoos item Ljava/util/Optional;
 		FIELD f_iaebcety block Ljava/util/Optional;
@@ -11,6 +13,8 @@ CLASS net/minecraft/unmapped/C_eyqqwstf net/minecraft/advancement/criterion/BeeN
 			ARG 0 block
 			ARG 1 itemPredicateBuilder
 			ARG 2 beeCountRange
+		METHOD m_gymopdux (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
 		METHOD m_jprnzaoc matches (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_sddaxwyk;I)Z
 			ARG 1 state
 			ARG 2 stack

--- a/mappings/net/minecraft/advancement/criterion/BrewedPotionCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/BrewedPotionCriterionTrigger.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_opfhzgki net/minecraft/advancement/criterion/BrewedPotionCriterionTrigger
 	METHOD m_jlnjsigz trigger (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_cjzoxshv;)V
 		ARG 1 player
+		ARG 2 potion
 	CLASS C_nhlhuijz Conditions
 		FIELD f_stylqccy potion Ljava/util/Optional;
 		METHOD m_nwhpawqe create ()Lnet/minecraft/unmapped/C_rzypsigz;
 		METHOD m_smuruvko matches (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+			ARG 1 potion
+		METHOD m_ugbouwxj (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance

--- a/mappings/net/minecraft/advancement/criterion/Criteria.mapping
+++ b/mappings/net/minecraft/advancement/criterion/Criteria.mapping
@@ -54,3 +54,4 @@ CLASS net/minecraft/unmapped/C_hmkjzbjo net/minecraft/advancement/criterion/Crit
 	METHOD m_iyxgljbn register (Ljava/lang/String;Lnet/minecraft/unmapped/C_mysyaxfs;)Lnet/minecraft/unmapped/C_mysyaxfs;
 		ARG 0 id
 		ARG 1 object
+	METHOD m_jgbggipj impossible (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_mysyaxfs;

--- a/mappings/net/minecraft/advancement/criterion/CriterionConditions.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionConditions.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/unmapped/C_zkhebbek net/minecraft/advancement/criterion/CriterionConditions
+	METHOD m_mmotanow validate (Lnet/minecraft/unmapped/C_zybjffid;)V
+		ARG 1 validator

--- a/mappings/net/minecraft/advancement/criterion/CriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionTrigger.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/unmapped/C_mysyaxfs net/minecraft/advancement/criterion/Crit
 		ARG 2 conditions
 	METHOD m_xalcdvzt endTracking (Lnet/minecraft/unmapped/C_hyeqtgvx;)V
 		ARG 1 tracker
+	METHOD m_xrbtiope getCodec ()Lcom/mojang/serialization/Codec;
 	CLASS C_lklaplvi ConditionsContainer
 		FIELD f_hndsseux conditions Lnet/minecraft/unmapped/C_zkhebbek;
 		FIELD f_tqucppsr advancement Lnet/minecraft/unmapped/C_unoypvme;

--- a/mappings/net/minecraft/advancement/criterion/CriterionValidator.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionValidator.mapping
@@ -1,0 +1,22 @@
+CLASS net/minecraft/unmapped/C_zybjffid net/minecraft/advancement/criterion/CriterionValidator
+	FIELD f_ollohygd dataLookup Lnet/minecraft/unmapped/C_srnkfpki;
+	FIELD f_zezlkhtp errorReporter Lnet/minecraft/unmapped/C_jtpvewkp;
+	METHOD m_fgshsjad validate (Lnet/minecraft/unmapped/C_ctsfmifk;Lnet/minecraft/unmapped/C_vczsvjil;Ljava/lang/String;)V
+		ARG 1 predicate
+		ARG 2 type
+		ARG 3 path
+	METHOD m_lpljjrzx validate (Ljava/util/List;Lnet/minecraft/unmapped/C_vczsvjil;Ljava/lang/String;)V
+		ARG 1 predicates
+		ARG 2 type
+		ARG 3 path
+	METHOD m_nhvyihxi validateEntity (Ljava/util/Optional;Ljava/lang/String;)V
+		ARG 1 optionalPredicate
+		ARG 2 path
+	METHOD m_svooszyh validateEntities (Ljava/util/List;Ljava/lang/String;)V
+		ARG 1 predicates
+		ARG 2 path
+	METHOD m_yqxxtueo validateEntity (Lnet/minecraft/unmapped/C_ctsfmifk;Ljava/lang/String;)V
+		ARG 1 predicate
+		ARG 2 path
+	METHOD m_zooqvlxs (Ljava/lang/String;Lnet/minecraft/unmapped/C_ctsfmifk;)V
+		ARG 2 predicate

--- a/mappings/net/minecraft/advancement/criterion/EnterBlockCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/EnterBlockCriterionTrigger.mapping
@@ -1,11 +1,17 @@
 CLASS net/minecraft/unmapped/C_rvwlswnk net/minecraft/advancement/criterion/EnterBlockCriterionTrigger
+	METHOD m_uzzvgkpq (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_rvwlswnk$C_fcmyqfbr;)Z
+		ARG 1 conditions
 	METHOD m_vfmlslzb trigger (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 player
 		ARG 2 state
 	CLASS C_fcmyqfbr Conditions
 		FIELD f_xkcfevos state Ljava/util/Optional;
 		FIELD f_yihynpxv block Ljava/util/Optional;
+		METHOD m_dolrxfkz (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
 		METHOD m_iomnpyzy create (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_rzypsigz;
 			ARG 0 block
 		METHOD m_jihxqndx matches (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 			ARG 1 state
+		METHOD m_vysuztfg validate (Lnet/minecraft/unmapped/C_rvwlswnk$C_fcmyqfbr;)Lcom/mojang/serialization/DataResult;
+			ARG 0 conditions

--- a/mappings/net/minecraft/advancement/criterion/InventoryChangedCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/InventoryChangedCriterionTrigger.mapping
@@ -19,9 +19,20 @@ CLASS net/minecraft/unmapped/C_wqesddch net/minecraft/advancement/criterion/Inve
 			ARG 3 full
 			ARG 4 empty
 			ARG 5 occupied
+		METHOD m_bnlggwix (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
 		METHOD m_gpaduibw create ([Lnet/minecraft/unmapped/C_afravpde$C_qwujnjpk;)Lnet/minecraft/unmapped/C_rzypsigz;
 			ARG 0 builders
 		METHOD m_jqkxsium create ([Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_rzypsigz;
 			ARG 0 items
 		METHOD m_vsjhnjag create ([Lnet/minecraft/unmapped/C_afravpde;)Lnet/minecraft/unmapped/C_rzypsigz;
 			ARG 0 items
+		CLASS C_iakmulom SlotDataCriterion
+			COMMENT Tests the amount of inventory slots of the types {@code occupied}, {@code full}, and {@code empty} against provided ranges.
+			FIELD f_yrzishql ANY Lnet/minecraft/unmapped/C_wqesddch$C_bvmbsujf$C_iakmulom;
+			METHOD m_lybqiqsd (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+				ARG 0 instance
+			METHOD m_oshpoxks test (III)Z
+				ARG 1 full
+				ARG 2 empty
+				ARG 3 occupied

--- a/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterionTrigger.mapping
+++ b/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterionTrigger.mapping
@@ -1,11 +1,17 @@
 CLASS net/minecraft/unmapped/C_guvqoceu net/minecraft/advancement/criterion/SlideDownBlockCriterionTrigger
+	METHOD m_uwxqrdgt (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_guvqoceu$C_rzzwrqgc;)Z
+		ARG 1 conditions
 	METHOD m_ybycnors trigger (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 player
 		ARG 2 state
 	CLASS C_rzzwrqgc Conditions
 		FIELD f_lnvqlhga state Ljava/util/Optional;
 		FIELD f_yazmngap block Ljava/util/Optional;
+		METHOD m_bixaoghf (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
 		METHOD m_bovizfbr create (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_rzypsigz;
 			ARG 0 block
+		METHOD m_wrmmefke validate (Lnet/minecraft/unmapped/C_guvqoceu$C_rzzwrqgc;)Lcom/mojang/serialization/DataResult;
+			ARG 0 conditions
 		METHOD m_yohpcszm matches (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 			ARG 1 state

--- a/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
+++ b/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
@@ -1,9 +1,17 @@
 CLASS net/minecraft/unmapped/C_ijynualg net/minecraft/loot/condition/LootConditionTypes
+	FIELD f_ndsvfguh TYPED_CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_tzpkbvhm CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_bxfjipfr joinAnd (Ljava/util/List;)Ljava/util/function/Predicate;
+		ARG 0 predicates
 	METHOD m_hfawsflu joinOr (Ljava/util/List;)Ljava/util/function/Predicate;
+		ARG 0 predicates
 	METHOD m_kmrftxnf (Ljava/lang/Object;)Z
 		ARG 0 operand
+	METHOD m_lgrkkgei (Ljava/util/List;Ljava/lang/Object;)Z
+		ARG 1 operand
 	METHOD m_osmoobxn (Ljava/lang/Object;)Z
 		ARG 0 operand
 	METHOD m_pwffgfiz register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/unmapped/C_debunopu;
 		ARG 0 id
+	METHOD m_qiykfwny (Ljava/util/List;Ljava/lang/Object;)Z
+		ARG 1 operand

--- a/mappings/net/minecraft/predicate/ContextAwarePredicate.mapping
+++ b/mappings/net/minecraft/predicate/ContextAwarePredicate.mapping
@@ -5,3 +5,5 @@ CLASS net/minecraft/unmapped/C_ctsfmifk net/minecraft/predicate/ContextAwarePred
 		ARG 0 lootConditions
 	METHOD m_iuimbrve test (Lnet/minecraft/unmapped/C_iakykpgh;)Z
 		ARG 1 context
+	METHOD m_zuojxyqu validateConditions (Lnet/minecraft/unmapped/C_eumtgsbp;)V
+		ARG 1 reporter

--- a/mappings/net/minecraft/predicate/StatePredicate.mapping
+++ b/mappings/net/minecraft/predicate/StatePredicate.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/unmapped/C_fsjpkzrx net/minecraft/predicate/StatePredicate
 	METHOD m_bbmuquuo test (Lnet/minecraft/unmapped/C_ezfeikaq;Lnet/minecraft/unmapped/C_jccsnmmo;)Z
 		ARG 1 stateManager
 		ARG 2 container
+	METHOD m_flzybrzb (Lnet/minecraft/unmapped/C_ezfeikaq;)Ljava/util/Optional;
+		ARG 1 stateManager
 	METHOD m_gmelzunj test (Lnet/minecraft/unmapped/C_xqketiuf;)Z
 		ARG 1 state
 	METHOD m_igwihkjs test (Lnet/minecraft/unmapped/C_txtbiemp;)Z

--- a/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
@@ -3,17 +3,21 @@ CLASS net/minecraft/unmapped/C_kvkvpjlm net/minecraft/predicate/entity/EntityPre
 	FIELD f_eieyszej location Ljava/util/Optional;
 	FIELD f_ggbragpd targetedEntity Ljava/util/Optional;
 	FIELD f_ifyilwup passenger Ljava/util/Optional;
+	FIELD f_krniofyg CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_lmuipoqi steppingOn Ljava/util/Optional;
 	FIELD f_mxeamups team Ljava/util/Optional;
 	FIELD f_niwouezd typeSpecific Ljava/util/Optional;
 	FIELD f_osweyokb flags Ljava/util/Optional;
 	FIELD f_scvxyefk effects Ljava/util/Optional;
 	FIELD f_tptkhefk distance Ljava/util/Optional;
+	FIELD f_uvagahsk ADVANCEMENT_CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_xozemqxy type Ljava/util/Optional;
 	FIELD f_ycxvlbvr equipment Ljava/util/Optional;
 	FIELD f_yvrkjogt vehicle Ljava/util/Optional;
 	METHOD m_lenpszae fromBuilder (Lnet/minecraft/unmapped/C_kvkvpjlm$C_fnhnavbg;)Lnet/minecraft/unmapped/C_ctsfmifk;
 		ARG 0 builder
+	METHOD m_lpmriazj (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 1 instance
 	METHOD m_npdomabq test (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/text/TextCodecs.mapping
+++ b/mappings/net/minecraft/text/TextCodecs.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_qrzzgymy net/minecraft/text/TextCodecs

--- a/mappings/net/minecraft/util/ErrorReporter.mapping
+++ b/mappings/net/minecraft/util/ErrorReporter.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/unmapped/C_jtpvewkp net/minecraft/util/ErrorReporter
+	METHOD m_nnxeyyzv forChild (Ljava/lang/String;)Lnet/minecraft/unmapped/C_jtpvewkp;
+		ARG 1 name
+	METHOD m_qtdgardw report (Ljava/lang/String;)V
+		ARG 1 message
+	CLASS C_jbcmnrpq Impl
+		FIELD f_bbfpemek errors Lcom/google/common/collect/Multimap;
+		FIELD f_vksywrdq pathSupplier Ljava/util/function/Supplier;
+		FIELD f_vnjffosi pathCache Ljava/lang/String;
+		METHOD m_fdjwfdmg copyErrors ()Lcom/google/common/collect/Multimap;
+		METHOD m_oscjmxcu getPath ()Ljava/lang/String;

--- a/mappings/net/minecraft/util/dynamic/Codecs.mapping
+++ b/mappings/net/minecraft/util/dynamic/Codecs.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 	COMMENT <p>It has a few methods to create checkers for {@code Codec.flatXmap} to add
 	COMMENT extra value validation to encoding and decoding. See the implementation of
 	COMMENT {@link #withNonEmptyList(Codec)}.
-	FIELD f_aylcbfcj IDENTIFIER_PATH Lcom/mojang/serialization/Codec;
+	FIELD f_aylcbfcj identifierPath Lcom/mojang/serialization/Codec;
 	FIELD f_bcprdsha FROM_OPTIONAL_LONG Ljava/util/function/Function;
 	FIELD f_bdcamgfc FLAT_JSON Lcom/mojang/serialization/Codec;
 	FIELD f_bwjbifvs BIT_SET Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/util/dynamic/Codecs.mapping
+++ b/mappings/net/minecraft/util/dynamic/Codecs.mapping
@@ -92,7 +92,7 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 	METHOD m_ihvqsgya retrieveContext (Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 retriever
 	METHOD m_iuewvnnu ([B)Ljava/lang/String;
-		ARG 0 bs
+		ARG 0 bytes
 	METHOD m_ivlefwee (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
 		ARG 0 string
 	METHOD m_ixzsdsbs (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)Ljava/util/List;

--- a/mappings/net/minecraft/util/dynamic/Codecs.mapping
+++ b/mappings/net/minecraft/util/dynamic/Codecs.mapping
@@ -4,7 +4,9 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 	COMMENT <p>It has a few methods to create checkers for {@code Codec.flatXmap} to add
 	COMMENT extra value validation to encoding and decoding. See the implementation of
 	COMMENT {@link #withNonEmptyList(Codec)}.
+	FIELD f_aylcbfcj IDENTIFIER_PATH Lcom/mojang/serialization/Codec;
 	FIELD f_bcprdsha FROM_OPTIONAL_LONG Ljava/util/function/Function;
+	FIELD f_bdcamgfc FLAT_JSON Lcom/mojang/serialization/Codec;
 	FIELD f_bwjbifvs BIT_SET Lcom/mojang/serialization/Codec;
 	FIELD f_dawkqtjs POSITIVE_FLOAT Lcom/mojang/serialization/Codec;
 	FIELD f_gkaqcuyx GAME_PROFILE Lcom/mojang/serialization/Codec;
@@ -18,25 +20,93 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 	FIELD f_ozwtoxnd INSTANT Lcom/mojang/serialization/Codec;
 	FIELD f_pfcngcne PATTERN Lcom/mojang/serialization/Codec;
 	FIELD f_pkhgdcwg BASE64_STRING Lcom/mojang/serialization/Codec;
-	FIELD f_qgiapsmp JSON_PASSTHROUGH_CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_qgiapsmp JSON_ELEMENT Lcom/mojang/serialization/Codec;
+	FIELD f_sumxgdro ESCAPED_STRING Lcom/mojang/serialization/Codec;
 	FIELD f_thyofzrm POSITIVE_INT Lcom/mojang/serialization/Codec;
 	FIELD f_tppidfcj matrix4f Lcom/mojang/serialization/Codec;
 	FIELD f_vzxbwyel INT_CODEPOINT Lcom/mojang/serialization/Codec;
 	FIELD f_wqiemdiy NON_EMPTY_STRING Lcom/mojang/serialization/Codec;
+	FIELD f_xoyqtfku JAVA_OBJECT Lcom/mojang/serialization/Codec;
 	FIELD f_xprfobkx AXISANGLE4F Lcom/mojang/serialization/Codec;
 	FIELD f_zhwzaxnp VECTOR3F Lcom/mojang/serialization/Codec;
+	FIELD f_zwudgozf GAME_PROFILE_WITHOUT_PROPERTIES Lcom/mojang/serialization/MapCodec;
+	METHOD m_aeryaqrd createStrictOptionalField (Lcom/mojang/serialization/Codec;Ljava/lang/String;Ljava/lang/Object;)Lcom/mojang/serialization/MapCodec;
+		ARG 1 name
+		ARG 2 fallback
+	METHOD m_awjfgfbh (Lcom/mojang/datafixers/util/Either;)Lcom/mojang/authlib/properties/PropertyMap;
+		ARG 0 either
+	METHOD m_azagsdch (Ljava/util/BitSet;)Ljava/util/stream/LongStream;
+		ARG 0 bitSet
+	METHOD m_bbclwurz (Lcom/mojang/authlib/properties/Property;)Ljava/util/Optional;
+		ARG 0 property
+	METHOD m_bqtubtow (Ljava/util/function/Function;Ljava/util/Collection;)Lcom/mojang/serialization/DataResult;
+		ARG 1 collection
 	METHOD m_ceufsyxl withLifecycle (Lcom/mojang/serialization/Codec;Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 codec
 		ARG 1 applyFunction
 		ARG 2 coApplyFunction
+	METHOD m_cjkdnnjx (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_cjqijzpr createStrictOptionalField (Lcom/mojang/serialization/Codec;Ljava/lang/String;)Lcom/mojang/serialization/MapCodec;
+		ARG 1 name
+	METHOD m_cqinaoub (IILjava/util/function/Function;Ljava/lang/Integer;)Lcom/mojang/serialization/DataResult;
+		ARG 3 integer
+	METHOD m_dgtnqbdd withOptionalParameters (Ljava/lang/String;Ljava/lang/String;Lcom/mojang/serialization/Codec;Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 typeKey
+		ARG 1 parametersKey
+		ARG 2 typeCodec
+		ARG 3 typeGetter
+		ARG 4 parameterCodecGetter
+	METHOD m_dmqewsll (Lorg/joml/Quaternionf;)Ljava/util/List;
+		ARG 0 quaternionf
+	METHOD m_dnfhmcbw (Ljava/util/function/Function;Lcom/mojang/datafixers/util/Either;)Ljava/lang/Object;
+		ARG 1 either
 	METHOD m_dujfhivb orElsePartial (Ljava/lang/Object;)Lcom/mojang/serialization/Codec$ResultFunction;
 		ARG 0 partial
+	METHOD m_eypcvcqq (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD m_flhgmmki fromOps (Lcom/mojang/serialization/DynamicOps;)Lcom/mojang/serialization/Codec;
+	METHOD m_fvpeuyuk (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_gcywmtgx (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD m_gglkhqew (Ljava/util/List;)Lorg/joml/Matrix4f;
+		ARG 0 list1
+	METHOD m_gtuotoel createStrictUnboundedMap (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)Lnet/minecraft/unmapped/C_tyjpezxh$C_psivvwhx;
+		ARG 0 keyCodec
+		ARG 1 elementCodec
+	METHOD m_gyrtopxy (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_gywbxzse (Lcom/mojang/serialization/Codec;Ljava/lang/String;Ljava/lang/String;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 3 instance
+	METHOD m_hpsmlhqm (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 0 list
+	METHOD m_hsukemqs (Ljava/util/function/IntFunction;Ljava/lang/Integer;)Lcom/mojang/serialization/DataResult;
+		ARG 1 id
+	METHOD m_htlmmuvh (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 object
+	METHOD m_ifdvuwzy formattedTime (Ljava/time/format/DateTimeFormatter;)Lcom/mojang/serialization/Codec;
+		ARG 0 formatter
+	METHOD m_ihmqisju (FFLjava/util/function/Function;Ljava/lang/Float;)Lcom/mojang/serialization/DataResult;
+		ARG 3 f
 	METHOD m_ihvqsgya retrieveContext (Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 retriever
+	METHOD m_iuewvnnu ([B)Ljava/lang/String;
+		ARG 0 bs
+	METHOD m_ivlefwee (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_ixzsdsbs (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)Ljava/util/List;
+		ARG 2 object
+	METHOD m_izqjachd (Ljava/util/function/Function;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+		ARG 1 element
+	METHOD m_jrgbljpx (Ljava/lang/Object;Ljava/util/Optional;)Ljava/lang/Object;
+		ARG 1 optional
 	METHOD m_juozehmq withNonEmptyHolderSet (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		ARG 0 codec
 	METHOD m_kbffjffi exceptionCatchingDecoder (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		ARG 0 codec
+	METHOD m_kcbwhxls (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 0 list
 	METHOD m_kcyhqcjs xor (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		COMMENT Returns an exclusive-or codec for {@link Either} instances.
 		COMMENT
@@ -66,18 +136,53 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 	METHOD m_ljxipwty validate (Lcom/mojang/serialization/MapCodec;Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 codec
 		ARG 1 validator
+	METHOD m_lprwixza either (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 first
+		ARG 1 second
+	METHOD m_lqfxmpnv (Ljava/util/Optional;)Ljava/util/OptionalLong;
+		ARG 0 optional
+	METHOD m_lrcwcdqs orCompressed (Lcom/mojang/serialization/MapCodec;Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 uncompressed
+		ARG 1 compressed
 	METHOD m_lruqlezz asOptionalLong (Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 codec
+	METHOD m_lscrzsve (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_tyjpezxh$C_pdblrsjv;
+		ARG 0 id
+	METHOD m_lxagintb (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/Dynamic;
+		ARG 1 object
 	METHOD m_lybgbxfe createEqualTypeChecker (Ljava/util/function/Function;)Ljava/util/function/Function;
 		ARG 0 typeGetter
 	METHOD m_lytzwisw validate (Lcom/mojang/serialization/Codec;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 codec
 		ARG 1 validator
+	METHOD m_mcwzjvkz (Lcom/google/gson/JsonElement;)Lcom/mojang/serialization/DataResult;
+		ARG 0 json
+	METHOD m_mfpnjepb (Ljava/util/List;)Lorg/joml/Vector3f;
+		ARG 0 list1
+	METHOD m_mgvopkql (Lcom/mojang/authlib/properties/PropertyMap;Ljava/util/List;)V
+		ARG 1 list
+	METHOD m_mhgxozyd (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_miveqlyt (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 object
+	METHOD m_mrsshdck createEither (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)Lnet/minecraft/unmapped/C_tyjpezxh$C_utmdutep;
+		ARG 0 first
+		ARG 1 second
+	METHOD m_mxydmzvu (Lorg/joml/Matrix4f;)Ljava/util/List;
+		ARG 0 matrix4f
 	METHOD m_nsiytucc withNonEmptyList (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 		ARG 0 originalCodec
 	METHOD m_nuxvjbjt createRangedInt (II)Lcom/mojang/serialization/Codec;
 		ARG 0 min
 		ARG 1 max
+	METHOD m_nvmahqoi (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD m_nyqaucfx (Ljava/util/function/BiFunction;Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 1 list
+	METHOD m_paojkcnu (Lcom/mojang/authlib/properties/PropertyMap;)Lcom/mojang/datafixers/util/Either;
+		ARG 0 propertyMap
+	METHOD m_pbrvpbbc (Lorg/joml/AxisAngle4f;)Ljava/lang/Float;
+		ARG 0 axisAngle4f
 	METHOD m_pknstmhl createCodecForPairObject (Lcom/mojang/serialization/Codec;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/BiFunction;Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 codec
 		ARG 1 leftFieldName
@@ -85,22 +190,104 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 		ARG 3 combineFunction
 		ARG 4 leftFunction
 		ARG 5 rightFunction
+	METHOD m_pqmgxbkr (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 0 list
+	METHOD m_pwhzhqyq (Ljava/util/function/BiFunction;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/serialization/DataResult;
+		ARG 1 pair
+	METHOD m_qhmqfpeu (Ljava/time/format/DateTimeFormatter;Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 1 string
+	METHOD m_qnecbchq (IILjava/lang/Integer;)Ljava/lang/String;
+		ARG 2 integer
+	METHOD m_qunssoca (IILjava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 2 string
+	METHOD m_qwhsnheh (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 object
+	METHOD m_rigpzump (Lcom/mojang/datafixers/util/Either;)Ljava/lang/Object;
+		ARG 0 either
+	METHOD m_riwoifsz (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_rtlolhzf (Ljava/util/stream/LongStream;)Ljava/util/BitSet;
+		ARG 0 longStream
+	METHOD m_segfvobg createRecursive (Ljava/lang/String;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
+		ARG 0 name
+		ARG 1 codecFunction
+	METHOD m_shkjkhku (Lcom/mojang/authlib/GameProfile;Ljava/lang/String;Lcom/mojang/authlib/properties/Property;)V
+		ARG 1 key
+		ARG 2 property
 	METHOD m_sltnwzrc createRangedFloat (FFLjava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 min
 		ARG 1 max
 		ARG 2 messageFactory
+	METHOD m_sohjlqwr (Ljava/util/function/BiFunction;Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 1 list1
+	METHOD m_spzosery (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD m_szibgwdf (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
 	METHOD m_szwqjlsd createStringResolverCodec (Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 elementToString
 		ARG 1 stringToElement
+	METHOD m_tcqadgvx (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_tyjpezxh$C_pdblrsjv;
+		ARG 0 id
 	METHOD m_tewufcxl either (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
 		ARG 0 serialized
 		ARG 1 alternative
 		ARG 2 alternativeMapper
+	METHOD m_tjbitvra (Ljava/lang/Integer;)Ljava/lang/String;
+		ARG 0 i
+	METHOD m_traryqmn (Ljava/util/List;)Lorg/joml/Quaternionf;
+		ARG 0 list1
+	METHOD m_tuzltnkq (Ljava/lang/Integer;)Ljava/lang/String;
+		ARG 0 i
+	METHOD m_twpkqstu (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)Lcom/mojang/datafixers/util/Pair;
+		ARG 2 object
+	METHOD m_uecgbzal (Lcom/mojang/authlib/properties/PropertyMap;Ljava/util/Map;)V
+		ARG 1 map
+	METHOD m_ukhaibge (Lnet/minecraft/unmapped/C_odfnijdo;)Lcom/mojang/serialization/DataResult;
+		ARG 0 holderSet
+	METHOD m_usbyrfkj (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 0 list
+	METHOD m_uyhsvlud orCompressed (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 uncompressed
+		ARG 1 compressed
+	METHOD m_uywslctn (Lorg/joml/AxisAngle4f;)Lorg/joml/Vector3f;
+		ARG 0 axisAngle4f
 	METHOD m_vcaoiues sizeLimitedString (II)Lcom/mojang/serialization/Codec;
 		ARG 0 min
 		ARG 1 max
+	METHOD m_vwvcmdbr (Ljava/util/OptionalLong;)Ljava/util/Optional;
+		ARG 0 optional
+	METHOD m_wdvkpnng (Lcom/mojang/authlib/GameProfile;Lcom/mojang/authlib/properties/PropertyMap;)Lcom/mojang/authlib/GameProfile;
+		ARG 0 gameProfile
+		ARG 1 propertyMap
+	METHOD m_whwogkgz (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_wifswwjp object2BooleanMap (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+	METHOD m_wnlfxiwt (Lorg/joml/Vector3f;)Ljava/util/List;
+		ARG 0 vector3f
+	METHOD m_wxgzhhdm (Ljava/util/function/ToIntFunction;ILjava/lang/Object;)Lcom/mojang/serialization/DataResult;
+		ARG 2 element
+	METHOD m_wxkgkkvl (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)Lcom/mojang/datafixers/util/Either;
+		ARG 2 object
+	METHOD m_wyxpcupd (Ljava/util/function/BiFunction;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+		ARG 1 object
+	METHOD m_xtpmdryr (Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Optional;
+		ARG 1 object
+	METHOD m_yffzvlqa (Lcom/mojang/authlib/properties/PropertyMap;Ljava/lang/String;Ljava/util/List;)V
+		ARG 1 key
+		ARG 2 propertyList
+	METHOD m_ykbqyyyz (Ljava/lang/String;Ljava/lang/String;Ljava/util/Optional;)Lcom/mojang/authlib/properties/Property;
+		ARG 0 name
+		ARG 1 value
+		ARG 2 signature
+	METHOD m_ywccywds (Ljava/util/function/Function;Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 1 string
+	METHOD m_ywzojanw (Ljava/util/function/BiFunction;Lcom/mojang/datafixers/util/Either;)Lcom/mojang/serialization/DataResult;
+		ARG 1 either
 	METHOD m_yxbdjpqp createLazy (Ljava/util/function/Supplier;)Lcom/mojang/serialization/Codec;
 		ARG 0 supplier
+	METHOD m_zvytsfav (Ljava/lang/Float;)Ljava/lang/String;
+		ARG 0 f
 	CLASS C_cuphesbl Xor
 		COMMENT An xor codec that only permits exactly one of the two data choices to be
 		COMMENT present.
@@ -125,6 +312,13 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 			ARG 0 pair
 		METHOD m_ebehnqny (Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;
 			ARG 0 pair
+		METHOD m_mlakbzhk (Lcom/mojang/datafixers/util/Pair;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;
+			ARG 0 first
+			ARG 1 second
+		METHOD m_pwlojblc (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 3 object
+		METHOD m_rzbixqwx (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 3 object
 	CLASS C_cuqomsnk ContextRetrievalCodec
 		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
 			ARG 1 ops
@@ -135,6 +329,35 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 			ARG 3 builder
 		METHOD keys keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
 			ARG 1 ops
+	CLASS C_lduttodi
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+	CLASS C_ltlpgnmp
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+		METHOD encode encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 element
+			ARG 3 input
+		METHOD keys keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
+	CLASS C_ncfjkoml RecursiveCodec
+		FIELD f_ffpqnhwd name Ljava/lang/String;
+		FIELD f_igtdaxcv supplier Ljava/util/function/Supplier;
+		METHOD <init> (Ljava/lang/String;Ljava/util/function/Function;)V
+			ARG 2 codecFunction
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+		METHOD encode encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 1 input
+			ARG 3 prefix
+	CLASS C_nxvxcuuo
+		METHOD apply apply (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;Lcom/mojang/serialization/DataResult;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+			ARG 3 result
+		METHOD coApply coApply (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;Lcom/mojang/serialization/DataResult;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+			ARG 3 result
+		METHOD m_mcgagjbh (Lcom/mojang/serialization/DataResult;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/serialization/DataResult;
+			ARG 2 pair
 	CLASS C_pdblrsjv TagEntryId
 		FIELD f_fbymtsno tag Z
 		FIELD f_gbgbiokr id Lnet/minecraft/unmapped/C_ncpywfca;
@@ -146,6 +369,18 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 		METHOD m_jnowveiu id ()Lnet/minecraft/unmapped/C_ncpywfca;
 		METHOD m_wsndmyfc tag ()Z
 		METHOD m_zearifuy asString ()Ljava/lang/String;
+	CLASS C_psivvwhx StrictUnboundedMapCodec
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 2 mapLike
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+		METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+			ARG 1 input
+			ARG 3 prefix
+		METHOD m_ncilciyk (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 2 mapLike
+		METHOD m_ywaubwiz (Ljava/lang/Object;Ljava/util/Map;)Lcom/mojang/datafixers/util/Pair;
+			ARG 1 map
 	CLASS C_rmkztixd
 		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
 			ARG 1 ops
@@ -154,6 +389,14 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 			ARG 1 element
 			ARG 2 ops
 			ARG 3 input
+	CLASS C_socfmgrv StrictOptionalFieldCodec
+		FIELD f_stluamfx name Ljava/lang/String;
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+		METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 input
+			ARG 3 prefix
+		METHOD keys keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
 	CLASS C_utmdutep EitherCodec
 		FIELD f_nlqguygj right Lcom/mojang/serialization/Codec;
 		FIELD f_okalfhwr left Lcom/mojang/serialization/Codec;
@@ -189,3 +432,14 @@ CLASS net/minecraft/unmapped/C_tyjpezxh net/minecraft/util/dynamic/Codecs
 			ARG 1 ops
 			ARG 2 value
 			ARG 3 result
+	CLASS C_xmqgqbsp
+		METHOD decode decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input
+		METHOD encode encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 input
+			ARG 3 prefix
+		METHOD keys keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
+		METHOD m_awewiabf (Lcom/mojang/serialization/MapLike;Ljava/lang/String;Lcom/mojang/serialization/DynamicOps;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/serialization/DataResult;
+			ARG 4 pair
+		METHOD m_dsdzbjrq encodeStart (Lcom/mojang/serialization/Codec;Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;)Lcom/mojang/serialization/DataResult;
+			ARG 2 input


### PR DESCRIPTION
100%s `Codecs` and `n.m.advancement`. one major refactor: `AdvancementComponent` -> `AdvancementType`. The old name was plain wrong as this class is used to determine which frame should be displayed around the advancement, out of Minecraft's three options