### PR TITLE
Various mapping updates

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -4,6 +4,7 @@ autojump
 eula
 gameplay
 griefing
+microsoft
 minceraft
 minecraft
 modded

--- a/mappings/net/minecraft/potion/Potion.mapping
+++ b/mappings/net/minecraft/potion/Potion.mapping
@@ -10,5 +10,6 @@ CLASS net/minecraft/unmapped/C_almkolgw net/minecraft/potion/Potion
 	METHOD m_iznchtgm byId (Ljava/lang/String;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 0 id
 	METHOD m_xgytuyzt finishTranslationKey (Lnet/minecraft/unmapped/C_cjzoxshv;Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 potion
 		ARG 1 prefix
 	METHOD m_xnxlkmme hasInstantEffect ()Z

--- a/mappings/net/minecraft/potion/PotionUtil.mapping
+++ b/mappings/net/minecraft/potion/PotionUtil.mapping
@@ -4,23 +4,44 @@ CLASS net/minecraft/unmapped/C_lyeejpyw net/minecraft/potion/PotionUtil
 	FIELD f_nhxhukqw CUSTOM_POTION_EFFECTS_KEY Ljava/lang/String;
 	FIELD f_xegyypfv POTION_KEY Ljava/lang/String;
 	FIELD f_ztviptib NONE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_cumlcwmw getPotionType (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_cjzoxshv;
 	METHOD m_cxismorv getColor (Ljava/util/Collection;)I
 		ARG 0 effects
 	METHOD m_dtettsff getColor (Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 0 stack
 	METHOD m_gqtddnts getPotionEffects (Lnet/minecraft/unmapped/C_hhlwcnih;)Ljava/util/List;
 		ARG 0 nbt
+	METHOD m_hghrjxut getPotionEffects (Lnet/minecraft/unmapped/C_cjzoxshv;Ljava/util/Collection;)Ljava/util/List;
+		ARG 0 potion
+		ARG 1 effects
 	METHOD m_iqllvmwp getCustomPotionEffects (Lnet/minecraft/unmapped/C_hhlwcnih;Ljava/util/List;)V
 		ARG 0 nbt
 		ARG 1 list
 	METHOD m_iqqmkeff setPotion (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 stack
+		ARG 1 holder
 	METHOD m_kuwrwubg getCustomPotionEffects (Lnet/minecraft/unmapped/C_hhlwcnih;)Ljava/util/List;
 		ARG 0 nbt
 	METHOD m_moqtnegs getPotionEffects (Lnet/minecraft/unmapped/C_sddaxwyk;)Ljava/util/List;
 		ARG 0 stack
+	METHOD m_mqnfubjz createTooltipText (Lnet/minecraft/unmapped/C_sddaxwyk;Ljava/util/List;FF)V
+		ARG 1 tooltip
+		ARG 2 multiplier
+		ARG 3 tickRate
+	METHOD m_qwfkdagq createTooltipText (Ljava/util/List;Ljava/util/List;FF)V
+		ARG 0 effects
+		ARG 1 tooltip
+		ARG 2 multiplier
+		ARG 3 tickRate
 	METHOD m_rgsfpgwl getCustomPotionEffects (Lnet/minecraft/unmapped/C_sddaxwyk;)Ljava/util/List;
 		ARG 0 stack
+	METHOD m_sbcocmbv (Ljava/util/List;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 attribute
+		ARG 2 modifier
 	METHOD m_ufqfxnrq setCustomPotionEffects (Lnet/minecraft/unmapped/C_sddaxwyk;Ljava/util/Collection;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 stack
 		ARG 1 effects
+	METHOD m_uqkqvgus getColor (Lnet/minecraft/unmapped/C_cjzoxshv;)I
+		ARG 0 holder
+	METHOD m_wufkjlwn getPotionType (Lnet/minecraft/unmapped/C_hhlwcnih;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 0 nbt

--- a/mappings/net/minecraft/potion/Potions.mapping
+++ b/mappings/net/minecraft/potion/Potions.mapping
@@ -21,3 +21,9 @@ CLASS net/minecraft/unmapped/C_bvmvcjvn net/minecraft/potion/Potions
 	FIELD f_wdebhrfm LONG_STRENGTH Lnet/minecraft/unmapped/C_cjzoxshv;
 	FIELD f_wdkfcvgu LONG_SLOW_FALLING Lnet/minecraft/unmapped/C_cjzoxshv;
 	FIELD f_whpdzgwd HARMING Lnet/minecraft/unmapped/C_cjzoxshv;
+	METHOD m_oaevlkxc register (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_almkolgw;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 1 potion
+	METHOD m_szesifrd empty (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_cjzoxshv;
+	METHOD m_ypceijgz register (Ljava/lang/String;Lnet/minecraft/unmapped/C_almkolgw;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 0 name
+		ARG 1 potion

--- a/mappings/net/minecraft/util/ItemScatterer.mapping
+++ b/mappings/net/minecraft/util/ItemScatterer.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/unmapped/C_wcgotvim net/minecraft/util/ItemScatterer
+	METHOD m_gykumtcr scatterInventory (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 0 state
+		ARG 1 newState
 	METHOD m_jrnialmf spawn (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_pjtstjoq;)V
 		ARG 0 world
 		ARG 1 entity

--- a/mappings/net/minecraft/util/UrlConstants.mapping
+++ b/mappings/net/minecraft/util/UrlConstants.mapping
@@ -12,8 +12,15 @@ CLASS net/minecraft/unmapped/C_goxaugqo net/minecraft/util/UrlConstants
 	FIELD f_nsjugyzs BUY_JAVA_REALMS Ljava/lang/String;
 	FIELD f_pmlcwiug JAVA_LICENSES Ljava/lang/String;
 	FIELD f_qrdgtpsy JAVA_ATTRIBUTION Ljava/lang/String;
+	FIELD f_qwdxrntl MICROSOFT_SUPPORT Ljava/lang/String;
 	FIELD f_rijpagjo GDPR Ljava/lang/String;
+	FIELD f_sqgsrrfx PRIVACY_STATEMENT Ljava/lang/String;
 	FIELD f_tsimafix START_JAVA_REALMS_TRIAL Ljava/lang/String;
 	FIELD f_wgmbuhlh REALMS_CONTENT_CREATOR Ljava/lang/String;
 	FIELD f_wzgmmycp BUY_MINECRAFT_JAVA Ljava/lang/String;
 	FIELD f_xfpngjod SYMLINKS Ljava/lang/String;
+	METHOD m_bntwjjjx getExtendJavaRealmsUrl (Ljava/lang/String;Ljava/util/UUID;)Ljava/lang/String;
+		ARG 0 subscriptionId
+	METHOD m_raztlxpf getExtendJavaRealmsUrl (Ljava/lang/String;Ljava/util/UUID;Z)Ljava/lang/String;
+		ARG 0 subscriptionId
+		ARG 2 trialOrRealm

--- a/mappings/net/minecraft/util/UserCache.mapping
+++ b/mappings/net/minecraft/util/UserCache.mapping
@@ -21,6 +21,8 @@ CLASS net/minecraft/unmapped/C_jyqwslie net/minecraft/util/UserCache
 	METHOD m_ecsofuym incrementAndGetAccessCount ()J
 	METHOD m_fvtljgha add (Lnet/minecraft/unmapped/C_jyqwslie$C_qruesmfp;)V
 		ARG 1 entry
+	METHOD m_grhslbaa (Lcom/google/gson/JsonArray;Ljava/text/DateFormat;Lnet/minecraft/unmapped/C_jyqwslie$C_qruesmfp;)V
+		ARG 2 entry
 	METHOD m_ibnbskll getByUuid (Ljava/util/UUID;)Ljava/util/Optional;
 		ARG 1 uuid
 	METHOD m_isvipnku clearExecutor ()V
@@ -42,10 +44,17 @@ CLASS net/minecraft/unmapped/C_jyqwslie net/minecraft/util/UserCache
 		ARG 0 value
 	METHOD m_wsmmmysu findByNameAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 username
+	METHOD m_xnfvpkqi (Ljava/text/DateFormat;Ljava/util/List;Lcom/google/gson/JsonElement;)V
+		ARG 2 element
 	METHOD m_xyjytdmc entryToJson (Lnet/minecraft/unmapped/C_jyqwslie$C_qruesmfp;Ljava/text/DateFormat;)Lcom/google/gson/JsonElement;
 		ARG 0 entry
 		ARG 1 dateFormat
+	METHOD m_yhajgtgq getOfflineProfile (Ljava/lang/String;)Ljava/util/Optional;
+		ARG 0 username
 	CLASS C_fynkihtr
+		METHOD onProfileLookupFailed onProfileLookupFailed (Ljava/lang/String;Ljava/lang/Exception;)V
+			ARG 1 username
+			ARG 2 exception
 		METHOD onProfileLookupSucceeded onProfileLookupSucceeded (Lcom/mojang/authlib/GameProfile;)V
 			ARG 1 profile
 	CLASS C_qruesmfp Entry

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 	FIELD f_ahvemmlp NIL_UUID Ljava/util/UUID;
+	FIELD f_ajmhlkot DOWNLOAD_WORKER_EXECUTOR Ljava/util/concurrent/ExecutorService;
 	FIELD f_faeenrac LOGGER Lorg/slf4j/Logger;
 	FIELD f_gsxvektl TICKER Lcom/google/common/base/Ticker;
 	FIELD f_kmtdmvfj IO_WORKER_EXECUTOR Ljava/util/concurrent/ExecutorService;
@@ -20,6 +21,8 @@ CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 	METHOD m_cclbyaoh getChoiceTypeInternal (Lcom/mojang/datafixers/DSL$TypeReference;Ljava/lang/String;)Lcom/mojang/datafixers/types/Type;
 		ARG 0 typeReference
 		ARG 1 id
+	METHOD m_ccqxalmw (Ljava/util/function/Function;)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 function
 	METHOD m_chvwiayy getMaxBackgroundThreads ()I
 	METHOD m_drhjlchv fixedSizeList (Ljava/util/stream/IntStream;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 stream
@@ -52,6 +55,9 @@ CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 	METHOD m_gxlhducm getInnermostMessage (Ljava/lang/Throwable;)Ljava/lang/String;
 		ARG 0 t
 	METHOD m_hnnezaif getMainWorkerExecutor ()Ljava/util/concurrent/ExecutorService;
+	METHOD m_jsqsuqek (Ljava/lang/Runnable;Ljava/util/function/Supplier;)Ljava/lang/Runnable;
+		ARG 0 runnable
+	METHOD m_jxtdpimf getDownloadWorkerExecutor ()Ljava/util/concurrent/ExecutorService;
 	METHOD m_jzncpgce getLast (Ljava/util/List;)Ljava/lang/Object;
 		ARG 0 list
 	METHOD m_kbwjpgkm deleteTask (Ljava/nio/file/Path;)Ljava/util/function/BooleanSupplier;
@@ -69,6 +75,9 @@ CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 		COMMENT @see #combine(List)
 		ARG 0 futures
 			COMMENT the completable futures to combine
+	METHOD m_kszryhbt (Ljava/util/stream/LongStream;I)Lcom/mojang/serialization/DataResult;
+		ARG 0 longStream
+		ARG 1 length
 	METHOD m_lgfbfuzz replaceInvalidChars (Ljava/lang/String;Lnet/minecraft/unmapped/C_zpuwkbhr;)Ljava/lang/String;
 		ARG 0 string
 		ARG 1 predicate
@@ -94,6 +103,11 @@ CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 	METHOD m_oaamqqhk attemptShutdown (Ljava/util/concurrent/ExecutorService;)V
 		ARG 0 service
 	METHOD m_oigccakw startTimerHack ()V
+	METHOD m_onipypca (Ljava/util/function/Function;Ljava/util/function/Predicate;)Ljava/lang/Object;
+		ARG 0 function
+		ARG 1 predicate
+	METHOD m_ouznsrgl (Ljava/lang/String;Ljava/util/concurrent/atomic/AtomicInteger;ZLjava/lang/Runnable;)Ljava/lang/Thread;
+		ARG 3 runnable
 	METHOD m_qiauzzux isBlank (Ljava/lang/String;)Z
 		ARG 0 string
 	METHOD m_qjjrrmre getMeasuringTimeMs ()J
@@ -214,8 +228,12 @@ CLASS net/minecraft/unmapped/C_lvarvugc net/minecraft/util/Util
 		METHOD apply apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	CLASS C_qgeblktr
 		METHOD getAsBoolean getAsBoolean ()Z
+	CLASS C_qygfqbqw
+		METHOD onTermination (Ljava/lang/Throwable;)V
+			ARG 1 throwable
 	CLASS C_tceggguc
 		FIELD f_boyitqoh cache Ljava/util/Map;
 		METHOD apply apply (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 object
 	CLASS C_vroykftd
 		METHOD getAsBoolean getAsBoolean ()Z

--- a/mappings/net/minecraft/util/UuidUtil.mapping
+++ b/mappings/net/minecraft/util/UuidUtil.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/unmapped/C_lnkdxaag net/minecraft/util/UuidUtil
 	FIELD f_skkpzqgc BYTES I
 	FIELD f_ucvvescp INT_STREAM_CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_ycyzmtsu codec Lcom/mojang/serialization/Codec;
+	METHOD m_athamxxt getOfflineProfile (Ljava/lang/String;)Lcom/mojang/authlib/GameProfile;
+		ARG 0 username
 	METHOD m_dhjcvmlb toIntArray (JJ)[I
 		ARG 0 uuidMost
 		ARG 2 uuidLeast
@@ -21,3 +23,7 @@ CLASS net/minecraft/unmapped/C_lnkdxaag net/minecraft/util/UuidUtil
 		ARG 0 uuidStream
 	METHOD m_ugkvxljh fromIntArray ([I)Ljava/util/UUID;
 		ARG 0 array
+	METHOD m_vphfgbgg (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string
+	METHOD m_ysutzbag (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 string

--- a/mappings/net/minecraft/util/collection/DataPool.mapping
+++ b/mappings/net/minecraft/util/collection/DataPool.mapping
@@ -10,4 +10,9 @@ CLASS net/minecraft/unmapped/C_owfsqzhr net/minecraft/util/collection/DataPool
 	METHOD m_sepjgpgp wrapCodecToAllowEmpty (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
 	CLASS C_eaytywro Builder
 		FIELD f_gfrmxqai entries Lcom/google/common/collect/ImmutableList$Builder;
+		METHOD m_djjyqyvx add (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_owfsqzhr$C_eaytywro;
+			ARG 1 data
+		METHOD m_flncuvzo addWeighted (Ljava/lang/Object;I)Lnet/minecraft/unmapped/C_owfsqzhr$C_eaytywro;
+			ARG 1 data
+			ARG 2 weight
 		METHOD m_ozenxjmx build ()Lnet/minecraft/unmapped/C_owfsqzhr;

--- a/mappings/net/minecraft/util/math/BlockPointer.mapping
+++ b/mappings/net/minecraft/util/math/BlockPointer.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/unmapped/C_wzdnszcs net/minecraft/util/math/BlockPointer
+	METHOD m_jqrqggsy center ()Lnet/minecraft/unmapped/C_vgpupfxx;

--- a/mappings/net/minecraft/util/math/random/RandomSequence.mapping
+++ b/mappings/net/minecraft/util/math/random/RandomSequence.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/unmapped/C_iwqnnqvx net/minecraft/util/math/random/RandomSeq
 	METHOD m_xryijlyt getSource ()Lnet/minecraft/unmapped/C_rlomrsco;
 	METHOD m_zyeozlvt createSource (JLjava/util/Optional;)Lnet/minecraft/unmapped/C_ecgonqaw;
 		ARG 0 seed
+		ARG 2 identifier

--- a/mappings/net/minecraft/util/profiler/Profiler.mapping
+++ b/mappings/net/minecraft/util/profiler/Profiler.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/unmapped/C_eslcbfsq net/minecraft/util/profiler/Profiler
 		COMMENT wise expensive methods.
 		ARG 1 marker
 			COMMENT a unique marker
+		ARG 2 visits
 	METHOD m_ppktxxru startTick ()V
 	METHOD m_qgopqkdg pop ()V
 	METHOD m_rifejyps visit (Ljava/lang/String;)V
@@ -53,3 +54,4 @@ CLASS net/minecraft/unmapped/C_eslcbfsq net/minecraft/util/profiler/Profiler
 		COMMENT supplier won't be called if the profiler is disabled.
 		ARG 1 markerGetter
 			COMMENT the getter for a unique marker
+		ARG 2 visits

--- a/mappings/net/minecraft/util/profiling/jfr/JvmProfiler.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JvmProfiler.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_pdegcfzu net/minecraft/util/profiling/jfr/JvmProf
 	METHOD m_ampfjuyj isRunning ()Z
 	METHOD m_fcajjqtj isAvailable ()Z
 	METHOD m_fkxuyhmv onPacketSent (Lnet/minecraft/unmapped/C_kxdobmrm;ILjava/net/SocketAddress;I)V
+		ARG 1 state
 		ARG 2 protocolId
 		ARG 3 remoteAddress
 		ARG 4 packetId
@@ -12,6 +13,7 @@ CLASS net/minecraft/unmapped/C_pdegcfzu net/minecraft/util/profiling/jfr/JvmProf
 		ARG 3 targetStatus
 	METHOD m_lpccagqc stop ()Ljava/nio/file/Path;
 	METHOD m_momqlrwh onPacketReceived (Lnet/minecraft/unmapped/C_kxdobmrm;ILjava/net/SocketAddress;I)V
+		ARG 1 state
 		ARG 2 protocolId
 		ARG 3 remoteAddress
 		ARG 4 packetId

--- a/mappings/net/minecraft/util/profiling/jfr/event/network/PacketEvent.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/event/network/PacketEvent.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/unmapped/C_ktrbyrtb net/minecraft/util/profiling/jfr/event/network/PacketEvent
 	FIELD bytes bytes I
 	FIELD packetId packetId I
+	FIELD protocolId protocolId Ljava/lang/String;
 	FIELD remoteAddress remoteAddress Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;ILjava/net/SocketAddress;I)V
+		ARG 3 socketAddress
 	CLASS C_cdarqmpl EventFields
 		FIELD f_hvkhaldl BYTES Ljava/lang/String;
 		FIELD f_oasfnvaj PACKET_ID Ljava/lang/String;

--- a/mappings/net/minecraft/util/profiling/jfr/stats/NetworkPacketSummary.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/stats/NetworkPacketSummary.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/unmapped/C_olefuomi net/minecraft/util/profiling/jfr/stats/N
 	FIELD f_dopncupk recordingDuration Ljava/time/Duration;
 	FIELD f_dwjcmefx largestSizeContributors Ljava/util/List;
 	FIELD f_tqjmbmdh totalPacketCountAndSize Lnet/minecraft/unmapped/C_olefuomi$C_teflgjgv;
+	METHOD <init> (Ljava/time/Duration;Ljava/util/List;)V
+		ARG 2 packets
 	METHOD m_ghtxqwyy largestSizeContributors ()Ljava/util/List;
 	METHOD m_ldfxbzdl getCountsPerSecond ()D
 	METHOD m_nhigqill getSizePerSecond ()D
@@ -15,7 +17,11 @@ CLASS net/minecraft/unmapped/C_olefuomi net/minecraft/util/profiling/jfr/stats/N
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
 		METHOD m_erruwkfs packetId ()I
+		METHOD m_favwwwzs (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_exeqxqdd;Lnet/minecraft/unmapped/C_kxdobmrm;Ljava/lang/Integer;Ljava/lang/Class;)V
+			ARG 3 id
+			ARG 4 packet
 		METHOD m_hitqqlxo from (Ljdk/jfr/consumer/RecordedEvent;)Lnet/minecraft/unmapped/C_olefuomi$C_royzrend;
+			ARG 0 event
 		METHOD m_mygarwph protocolId ()Ljava/lang/String;
 		METHOD m_nnoidnwg packetName ()Ljava/lang/String;
 		METHOD m_xvfqwevk direction ()Lnet/minecraft/unmapped/C_exeqxqdd;

--- a/mappings/net/minecraft/util/random/RandomSeed.mapping
+++ b/mappings/net/minecraft/util/random/RandomSeed.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_gcyxxyhj net/minecraft/util/random/RandomSeed
+	FIELD f_cezheigh MD5 Lcom/google/common/hash/HashFunction;
 	FIELD f_dybfjwue SILVER_RATIO_64 J
 		COMMENT Used as fallback {@link Xoroshiro128PlusPlusRandomImpl#seedHi} for
 		COMMENT {@link Xoroshiro128PlusPlusRandomImpl}
@@ -9,12 +10,14 @@ CLASS net/minecraft/unmapped/C_gcyxxyhj net/minecraft/util/random/RandomSeed
 	METHOD m_gvsusubq createXoroshiroSeed (J)Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
 		ARG 0 seed
 	METHOD m_ifayuezb createXoroshiroSeed (Ljava/lang/String;)Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
+		ARG 0 string
 	METHOD m_kfhqwhyf (J)J
 		ARG 0 l
 	METHOD m_xpjoobcv mixStafford13 (J)J
 		ARG 0 seed
 	METHOD m_ylmbrajm generateUniqueSeed ()J
 	METHOD m_zklrptct createUnmixedXoroshiroSeed (J)Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
+		ARG 0 seed
 	CLASS C_lpqjwwwg Seed
 		FIELD f_bzcdrrce seedLow J
 		FIELD f_dvaubyeo seedHigh J
@@ -23,7 +26,11 @@ CLASS net/minecraft/unmapped/C_gcyxxyhj net/minecraft/util/random/RandomSeed
 			ARG 3 seedHigh
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
+		METHOD m_gdypiyoe (JJ)Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
+			ARG 1 lowXor
+			ARG 3 highXor
 		METHOD m_nbqrvqvq mix ()Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
 		METHOD m_ooublqko xor (Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;)Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;
+			ARG 1 seed
 		METHOD m_qychnmdr seedHigh ()J
 		METHOD m_zysillsy seedLow ()J

--- a/mappings/net/minecraft/util/random/Xoroshiro128PlusPlusRandom.mapping
+++ b/mappings/net/minecraft/util/random/Xoroshiro128PlusPlusRandom.mapping
@@ -11,6 +11,10 @@ CLASS net/minecraft/unmapped/C_ecgonqaw net/minecraft/util/random/Xoroshiro128Pl
 	METHOD <init> (JJ)V
 		ARG 1 seedLo
 		ARG 3 seedHi
+	METHOD <init> (Lnet/minecraft/unmapped/C_gcyxxyhj$C_lpqjwwwg;)V
+		ARG 1 seed
+	METHOD m_lciwsxte (Lnet/minecraft/unmapped/C_ywtymkjq;)Lnet/minecraft/unmapped/C_ecgonqaw;
+		ARG 0 seed
 	METHOD m_whhjkmse nextBits (I)J
 		COMMENT {@return {@code bits} upper bits of random value}
 		COMMENT

--- a/mappings/net/minecraft/util/shape/BitSetVoxelSet.mapping
+++ b/mappings/net/minecraft/util/shape/BitSetVoxelSet.mapping
@@ -34,3 +34,7 @@ CLASS net/minecraft/unmapped/C_ggaqmxld net/minecraft/util/shape/BitSetVoxelSet
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+	METHOD m_yxphxkdc (Lnet/minecraft/unmapped/C_bipoyzjn;Lnet/minecraft/unmapped/C_bipoyzjn$C_getdvbzp;Z)V
+		ARG 0 voxels
+		ARG 1 consumer
+		ARG 2 largest

--- a/mappings/net/minecraft/util/shape/FractionalDoubleList.mapping
+++ b/mappings/net/minecraft/util/shape/FractionalDoubleList.mapping
@@ -4,3 +4,4 @@ CLASS net/minecraft/unmapped/C_hvdtbvlg net/minecraft/util/shape/FractionalDoubl
 		ARG 1 sectionCount
 	METHOD getDouble (I)D
 		ARG 1 position
+	METHOD size size ()I

--- a/mappings/net/minecraft/util/shape/SimplePairList.mapping
+++ b/mappings/net/minecraft/util/shape/SimplePairList.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_czwlpkut net/minecraft/util/shape/SimplePairList
+	FIELD f_duhpwruk size I
 	FIELD f_lbkxfdxf minValues [I
 	FIELD f_pvcihbdy valueIndices [D
 	FIELD f_tepomuqv maxValues [I


### PR DESCRIPTION
This finishes mappings for `net/minecraft/potion`, as well as mostly finishing the `com/mojang/blaze3d` mappings. There are a few magic constants in blaze3d that I can't figure out, so I didn't map those, but if those are figured out, that should mean that blaze3d is fully mapped. There's also a bunch of updates in `net/minecraft/util`, with highlights being `profiler`, `profiling`, `UrlConstants`, and `UserCache` being fully mapped.