### PR TITLE
Rename `Crafter` to `CrafterBlock`

### DIFF
--- a/mappings/net/minecraft/block/CrafterBlock.mapping
+++ b/mappings/net/minecraft/block/CrafterBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_dmnruvyr net/minecraft/block/Crafter
+CLASS net/minecraft/unmapped/C_dmnruvyr net/minecraft/block/CrafterBlock
 	FIELD f_agoiltbq TRIGGER_DELAY I
 	FIELD f_lebcsueu TRIGGERED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_lefdstyp MAX_CRAFTING_TICKS I


### PR DESCRIPTION
I noticed it was missing the block suffix a bit ago