### PR TITLE
Fix crafter screen mappings

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -404,6 +404,7 @@ unblocker
 uncached
 unmap
 unpowering
+unpowered
 unpress
 unquantize
 unskew

--- a/mappings/net/minecraft/client/gui/screen/ingame/CrafterScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CrafterScreen.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/unmapped/C_ffdwiayx net/minecraft/client/gui/screen/ingame/CrafterScreen
 	FIELD f_dolcfkge TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_fbkkgpfx UNPOWERED_ARROW_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
-	FIELD f_gffwbkyz TOGGLABLE_SLOT_TOOLTIP Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_gffwbkyz TOGGLEABLE_SLOT_TOOLTIP Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_klgzdzze POWERED_ARROW_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_kqjpnlzo DISABLED_SLOT_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
 	METHOD m_bofodtgw enableSlot (I)V

--- a/mappings/net/minecraft/client/gui/screen/ingame/CrafterScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CrafterScreen.mapping
@@ -1,13 +1,14 @@
-CLASS net/minecraft/unmapped/C_czkdrxgh net/minecraft/client/gui/screen/ingame/CrafterScreen
-	FIELD f_dcjzsosk playerEntity Lnet/minecraft/unmapped/C_jzrpycqo;
-	FIELD f_pdiupkfn propertyDelegate Lnet/minecraft/unmapped/C_fwwsyhuv;
-	FIELD f_veicmyyf inventory Lnet/minecraft/unmapped/C_fcvwjvlq;
-	FIELD f_yiamcegp craftingResultInventory Lnet/minecraft/unmapped/C_gxwuusgh;
-	METHOD <init> (ILnet/minecraft/unmapped/C_sxzqocrm;)V
-		ARG 2 playerInventory
-	METHOD <init> (ILnet/minecraft/unmapped/C_sxzqocrm;Lnet/minecraft/unmapped/C_fcvwjvlq;Lnet/minecraft/unmapped/C_fwwsyhuv;)V
-		ARG 2 playerInventory
-	METHOD m_jbxaewfz update ()V
-	METHOD m_xsoclhnb getInventory ()Lnet/minecraft/unmapped/C_pjtstjoq;
-	METHOD m_zhwjtaii (Lnet/minecraft/unmapped/C_sxzqocrm;)V
-		ARG 1 playerInventory
+CLASS net/minecraft/unmapped/C_ffdwiayx net/minecraft/client/gui/screen/ingame/CrafterScreen
+	FIELD f_dolcfkge TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_fbkkgpfx UNPOWERED_ARROW_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_gffwbkyz TOGGLABLE_SLOT_TOOLTIP Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_klgzdzze POWERED_ARROW_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_kqjpnlzo DISABLED_SLOT_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	METHOD m_bofodtgw enableSlot (I)V
+	METHOD m_csyonubj disableSlot (I)V
+	METHOD m_saucrxvx drawDisabledSlot (Lnet/minecraft/unmapped/C_sedilmty;Lnet/minecraft/unmapped/C_aklocaaw;)V
+		ARG 2 slot
+	METHOD m_wsyqlhaf setSlotEnabled (IZ)V
+		ARG 1 slot
+		ARG 2 enabled
+	METHOD m_xbaooyab drawArrowTexture (Lnet/minecraft/unmapped/C_sedilmty;)V

--- a/mappings/net/minecraft/screen/CrafterScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/CrafterScreenHandler.mapping
@@ -1,0 +1,26 @@
+CLASS net/minecraft/unmapped/C_czkdrxgh net/minecraft/screen/CrafterScreenHandler
+	FIELD f_dcjzsosk player Lnet/minecraft/unmapped/C_jzrpycqo;
+	FIELD f_pdiupkfn propertyDelegate Lnet/minecraft/unmapped/C_fwwsyhuv;
+	FIELD f_rvocmvxj HOTBAR_SLOTS_END I
+	FIELD f_tcyulcmv INVENTORY_SLOTS_START I
+	FIELD f_uuszxnri SLOT_COUNT I
+	FIELD f_veicmyyf inventory Lnet/minecraft/unmapped/C_fcvwjvlq;
+	FIELD f_vidvtafw HOTBAR_SLOTS_START I
+	FIELD f_wvksesdo INVENTORY_SLOTS_END I
+	FIELD f_yiamcegp resultInventory Lnet/minecraft/unmapped/C_gxwuusgh;
+	METHOD <init> (ILnet/minecraft/unmapped/C_sxzqocrm;)V
+		ARG 2 playerInventory
+	METHOD <init> (ILnet/minecraft/unmapped/C_sxzqocrm;Lnet/minecraft/unmapped/C_fcvwjvlq;Lnet/minecraft/unmapped/C_fwwsyhuv;)V
+		ARG 2 playerInventory
+	METHOD m_eqfrxzzc isSlotDisabled (I)Z
+		ARG 1 slot
+	METHOD m_jbxaewfz update ()V
+	METHOD m_jwdwepun (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_pvphvxig;)Lnet/minecraft/unmapped/C_sddaxwyk;
+		ARG 2 recipe
+	METHOD m_jwwklrgf isPowered ()Z
+	METHOD m_swoiymft setSlotEnabled (IZ)V
+		ARG 1 slot
+		ARG 2 enabled
+	METHOD m_xsoclhnb getInventory ()Lnet/minecraft/unmapped/C_pjtstjoq;
+	METHOD m_zhwjtaii addSlots (Lnet/minecraft/unmapped/C_sxzqocrm;)V
+		ARG 1 playerInventory

--- a/mappings/net/minecraft/screen/Generic3x3ContainerScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/Generic3x3ContainerScreenHandler.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/unmapped/C_lwaresgj net/minecraft/screen/Generic3x3ContainerScreenHandler
 	FIELD f_fitzmyvb HOTBAR_SLOTS_START I
-	FIELD f_gykgycuv SLOTS_COUNT I
+	FIELD f_gykgycuv SLOT_COUNT I
 	FIELD f_pmlhdsbe inventory Lnet/minecraft/unmapped/C_pjtstjoq;
 	FIELD f_shduljgh INVENTORY_SLOTS_END I
 	FIELD f_vwhpevdp INVENTORY_SLOTS_START I

--- a/mappings/net/minecraft/screen/slot/CrafterOutputSlot.mapping
+++ b/mappings/net/minecraft/screen/slot/CrafterOutputSlot.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_iwgoxhvo net/minecraft/screen/slot/CrafterOutputSlot

--- a/mappings/net/minecraft/screen/slot/CrafterSlot.mapping
+++ b/mappings/net/minecraft/screen/slot/CrafterSlot.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_aklocaaw net/minecraft/screen/slot/CrafterSlot
+	FIELD f_hsvkkroi screenHandler Lnet/minecraft/unmapped/C_czkdrxgh;


### PR DESCRIPTION
What's named `CrafterScreen` in the current mappings is actually the screen handler