### PR TITLE
Update github actions workflow steps

### DIFF
--- a/.github/actions/diff-uploader/action.yml
+++ b/.github/actions/diff-uploader/action.yml
@@ -11,5 +11,5 @@ outputs:
   result:
     description: 'Result of the action'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/update-base/action.yml
+++ b/.github/actions/update-base/action.yml
@@ -11,5 +11,5 @@ outputs:
   result:
     description: 'Result of the action'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
       image: eclipse-temurin:${{ matrix.java }}
       options: --user root
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v2
       - run: ./gradlew build javadocJar --stacktrace
       - name: Build artifacts
         if: ${{ matrix.java == 17 }}

--- a/.github/workflows/generate-diff.yml
+++ b/.github/workflows/generate-diff.yml
@@ -10,18 +10,18 @@ jobs:
       image: eclipse-temurin:${{ matrix.java }}
       options: --user root
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v2
       - run: ./gradlew decompileVineflower decompileTargetVineflower --stacktrace
         if: ${{ matrix.java == 17 }}
       - name: Check Target Decompiled
         id: can-create-diff
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@v3
         with:
           files: "namedTargetSrc/net/minecraft/client/main/Main.java"
       - name: Create diff

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ jobs:
       image: eclipse-temurin:17
       options: --user root
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2
 
       # Ensure that releases are not ran in parallel, this ensures that the latest commit is the latest release
       # See https://github.com/softprops/turnstyle

--- a/.github/workflows/update-base.yml
+++ b/.github/workflows/update-base.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       result: ${{ steps.update-base.outputs.result }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/update-base/
         id: update-base
         with:
@@ -23,12 +23,12 @@ jobs:
     if: ${{ needs.update.outputs.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       # The container image openjdk:17 doesn't have git installed
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
This removes previously deprecated NodeJS 16 actions, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ for more info.

Specifically, I validated that each of these version bumps contains no functional changes, only Node 16 -> 20 version bumps. This should remove the deprecation warnings under every actions run.

I did not update `actions/upload-artifact` from v3 to v4, as that does contain functional changes. This should maybe be investigated, however, as it does contain significant performance increases(github claims in [their v4 release post](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/) that it's a 10x increase), but it does change things and is not backwards-compatible with v3. If any tooling relies on v3 or its behavior, it would have to be adjusted.

I'd be glad to answer any questions about these changes if needed!