### PR TITLE
A lot of new classes

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -111,6 +111,7 @@ opdeop
 opped
 
 // dfu
+componentization
 datafixer
 datafixing
 renamening

--- a/mappings/net/minecraft/block/entity/OneTwentyOneBannerPatterns.mapping
+++ b/mappings/net/minecraft/block/entity/OneTwentyOneBannerPatterns.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_guijqoip net/minecraft/block/entity/OneTwentyOneBannerPatterns
+	METHOD m_zoccrwav bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/mappings/net/minecraft/client/gui/screen/BanScreenFactories.mapping
+++ b/mappings/net/minecraft/client/gui/screen/BanScreenFactories.mapping
@@ -1,0 +1,24 @@
+CLASS net/minecraft/unmapped/C_tkoofxmf net/minecraft/client/gui/screen/BanScreenFactories
+	FIELD f_nompjvqy TEMPORARY_BAN_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_okfwlrev NAME_BAN_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_ptgyazcd SKIN_BAN_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_shquzbmj PERMANENT_BAN_TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_svznhwft SKIN_BAN_DESCRIPTION Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_bkhgjebh createSkinBanScreen (Ljava/lang/Runnable;)Lnet/minecraft/unmapped/C_vpzsgabs;
+		ARG 0 callback
+	METHOD m_dmbefmvo getDescriptionText (Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 banDetails
+	METHOD m_jdcanqoh getReasonText (Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 banDetails
+	METHOD m_kkrfulue createUsernameBanScreen (Ljava/lang/String;Ljava/lang/Runnable;)Lnet/minecraft/unmapped/C_vpzsgabs;
+		ARG 1 callback
+	METHOD m_ntzfyzag getBanType (Lcom/mojang/authlib/minecraft/BanDetails;)Z
+		ARG 0 banDetails
+	METHOD m_odezxkdz createBanScreen (Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_vpzsgabs;
+		ARG 1 banDetails
+	METHOD m_pbntgobw getBannedTitle (Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 banDetails
+	METHOD m_xbymeuys getBanDuration (Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 banDetails
+	METHOD m_ycbhwjwz getBanDurationText (Lcom/mojang/authlib/minecraft/BanDetails;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 banDetails

--- a/mappings/net/minecraft/client/render/entity/BoggedEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BoggedEntityRenderer.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_ddcesbvk net/minecraft/client/render/entity/BoggedEntityRenderer
+	FIELD f_bcleisgn OVERLAY_TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_dsudahle TEXTURE Lnet/minecraft/unmapped/C_ncpywfca;

--- a/mappings/net/minecraft/client/render/entity/animation/ArmadilloEntityAnimations.mapping
+++ b/mappings/net/minecraft/client/render/entity/animation/ArmadilloEntityAnimations.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/unmapped/C_ctkzhiqu net/minecraft/client/render/entity/animation/ArmadilloEntityAnimations
+	FIELD f_avlxnhtb UNROLLING Lnet/minecraft/unmapped/C_mnzbondw;
+	FIELD f_bbyvliiy SCARED Lnet/minecraft/unmapped/C_mnzbondw;
 	FIELD f_kdacdgzm WALK Lnet/minecraft/unmapped/C_mnzbondw;
+	FIELD f_sotwqpnh ROLLING Lnet/minecraft/unmapped/C_mnzbondw;

--- a/mappings/net/minecraft/client/render/entity/animation/BatEntityAnimations.mapping
+++ b/mappings/net/minecraft/client/render/entity/animation/BatEntityAnimations.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_vdwepyje net/minecraft/client/render/entity/animation/BatEntityAnimations
+	FIELD f_ctmcosxl ROOSTING Lnet/minecraft/unmapped/C_mnzbondw;
+	FIELD f_fzrmuxfg FLYING Lnet/minecraft/unmapped/C_mnzbondw;

--- a/mappings/net/minecraft/client/render/entity/feature/SkeletonOverlayFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/SkeletonOverlayFeatureRenderer.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_lxpdzvpe net/minecraft/client/render/entity/feature/SkeletonOverlayFeatureRenderer
+	FIELD f_msekwirk model Lnet/minecraft/unmapped/C_lhqnvntm;
+	FIELD f_osomazip texture Lnet/minecraft/unmapped/C_ncpywfca;
+	METHOD <init> (Lnet/minecraft/unmapped/C_mjeyymcw;Lnet/minecraft/unmapped/C_qncyfzro;Lnet/minecraft/unmapped/C_rghfgwax;Lnet/minecraft/unmapped/C_ncpywfca;)V
+		ARG 2 modelLoader
+		ARG 3 layer
+		ARG 4 texture

--- a/mappings/net/minecraft/client/render/entity/feature/WolfArmorFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/WolfArmorFeatureRenderer.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_hznbnyph net/minecraft/client/render/entity/feature/WolfArmorFeatureRenderer
+	FIELD f_bewmfqab model Lnet/minecraft/unmapped/C_rwirtzlj;
+	FIELD f_yttlqsip TEXTURE_MAP Ljava/util/Map;

--- a/mappings/net/minecraft/client/render/entity/model/BoggedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BoggedEntityModel.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_orcllnsg net/minecraft/client/render/entity/model/BoggedEntityModel
+	FIELD f_vjlshclb mushrooms Lnet/minecraft/unmapped/C_rglqxnbw;
+	METHOD m_zvbeifvz getTexturedModelData ()Lnet/minecraft/unmapped/C_ybmhebgt;

--- a/mappings/net/minecraft/client/render/entity/model/BreezeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BreezeEntityModel.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/unmapped/C_qcaxblsy net/minecraft/client/render/entity/model/BreezeEntityModel
+	FIELD f_crfmsyyc wind Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_fbxwkrrt windBottom Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_gidaxcft head Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_lgrdvvwu root Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_rrhlhyae windMid Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_tdgznihf eyes Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_xjifswvl rods Lnet/minecraft/unmapped/C_rglqxnbw;
+	FIELD f_ziiweddz windTop Lnet/minecraft/unmapped/C_rglqxnbw;
+	METHOD <init> (Lnet/minecraft/unmapped/C_rglqxnbw;)V
+		ARG 1 root
+	METHOD m_dfjyavaz getBodyRods ()Lnet/minecraft/unmapped/C_rglqxnbw;
+	METHOD m_jfxtcafk getBodyEyes ()Lnet/minecraft/unmapped/C_rglqxnbw;
+	METHOD m_mdluoqeq getTexturedModelData (II)Lnet/minecraft/unmapped/C_ybmhebgt;
+	METHOD m_rbhceaic getBodyHead ()Lnet/minecraft/unmapped/C_rglqxnbw;
+	METHOD m_tgpjmyzq getWind ()Lnet/minecraft/unmapped/C_rglqxnbw;

--- a/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_ikhmhinf net/minecraft/client/render/entity/model
 	FIELD f_anbkwmoa SKELETON_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_bjfsnbhp ZOMBIE_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_brgczitv STRIDER_SADDLE Lnet/minecraft/unmapped/C_rghfgwax;
+	FIELD f_btvjrcbe BOGGED_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_cpmduxle MAIN Ljava/lang/String;
 	FIELD f_cujillju PIGLIN_INNER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_djzfoqmf PIGLIN_BRUTE_INNER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
@@ -39,6 +40,8 @@ CLASS net/minecraft/unmapped/C_ikhmhinf net/minecraft/client/render/entity/model
 	FIELD f_uiqzmchr ZOMBIE_VILLAGER_INNER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_urhvwxgy PIGLIN_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_uwqpsglo WITHER_SKELETON_INNER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
+	FIELD f_vfxufezl BOGGED_OUTER Lnet/minecraft/unmapped/C_rghfgwax;
+	FIELD f_vvapuulj BOGGED_INNER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_wrrxqsac LLAMA_DECOR Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_wxeqdekc TROPICAL_FISH_LARGE_PATTERN Lnet/minecraft/unmapped/C_rghfgwax;
 	FIELD f_yckzdcej WITHER_SKELETON_OUTER_ARMOR Lnet/minecraft/unmapped/C_rghfgwax;

--- a/mappings/net/minecraft/client/render/entity/model/EntityModelPartNames.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelPartNames.mapping
@@ -51,6 +51,7 @@ CLASS net/minecraft/unmapped/C_flvtdsjt net/minecraft/client/render/entity/model
 	FIELD f_rovodljg LEFT_FOOT Ljava/lang/String;
 	FIELD f_rpqxkvnu LEFT_CHEST Ljava/lang/String;
 	FIELD f_rrajhrdp RIGHT_WING Ljava/lang/String;
+	FIELD f_rxrcytbt MUSHROOMS Ljava/lang/String;
 	FIELD f_szwtcajk LEFT_MID_LEG Ljava/lang/String;
 	FIELD f_tiocpyad RIGHT_HORN Ljava/lang/String;
 	FIELD f_tqzmekau LEFT_ARM Ljava/lang/String;

--- a/mappings/net/minecraft/client/render/entity/model/SkeletonEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SkeletonEntityModel.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/unmapped/C_lhqnvntm net/minecraft/client/render/entity/model/SkeletonEntityModel
 	METHOD m_dvxjyfsj getTexturedModelData ()Lnet/minecraft/unmapped/C_ybmhebgt;
+	METHOD m_xcazdwfc addLimbs (Lnet/minecraft/unmapped/C_lacpzcxf;)V
+		ARG 0 data

--- a/mappings/net/minecraft/client/util/telemetry/logging/JsonTelemetryEventLog.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/logging/JsonTelemetryEventLog.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_wtehsvxb net/minecraft/client/util/telemetry/logg
 	METHOD <init> (Lcom/mojang/serialization/Codec;Ljava/nio/channels/FileChannel;)V
 		ARG 1 codec
 		ARG 2 channel
+	METHOD close close ()V
 	METHOD m_gtgtkpii open (Lcom/mojang/serialization/Codec;Ljava/nio/file/Path;)Lnet/minecraft/unmapped/C_wtehsvxb;
 		ARG 0 codec
 		ARG 1 path

--- a/mappings/net/minecraft/data/report/ItemListProvider.mapping
+++ b/mappings/net/minecraft/data/report/ItemListProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_pfkoukpo net/minecraft/data/report/ItemListProvider

--- a/mappings/net/minecraft/data/server/OneTwentyOneAdventureAdvancementsProvider.mapping
+++ b/mappings/net/minecraft/data/server/OneTwentyOneAdventureAdvancementsProvider.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_fhipkyzt net/minecraft/data/server/OneTwentyOneAdventureAdvancementsProvider
+	METHOD m_acridfqq create (Lnet/minecraft/unmapped/C_ugkmwocs;Ljava/util/concurrent/CompletableFuture;)Lnet/minecraft/unmapped/C_ncoihxbl;
+		ARG 0 output
+		ARG 1 lookupProvider

--- a/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneChestLootTableProvider.mapping
+++ b/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneChestLootTableProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_lnzuulfo net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneChestLootTableProvider

--- a/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneEntityLootTableProvider.mapping
+++ b/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneEntityLootTableProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_kbczphds net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneEntityLootTableProvider

--- a/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneShearingLootTableProvider.mapping
+++ b/mappings/net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneShearingLootTableProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_vvwjviqg net/minecraft/data/server/loot/one_twenty_one/OneTwentyOneShearingLootTableProvider

--- a/mappings/net/minecraft/data/server/loot_table/ShearingLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loot_table/ShearingLootTableGenerator.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_cmwiiqcn net/minecraft/data/server/loot_table/ShearingLootTableGenerator

--- a/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneBannerTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneBannerTagProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_jtuqxqpc net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneBannerTagProvider

--- a/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneDamageTypeTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneDamageTypeTagProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_qugiptdx net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneDamageTypeTagProvider

--- a/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneEntityTypeTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneEntityTypeTagProvider.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_mmcppaqq net/minecraft/data/server/tag/one_twenty_one/OneTwentyOneEntityTypeTagProvider

--- a/mappings/net/minecraft/datafixer/DataFixUtil.mapping
+++ b/mappings/net/minecraft/datafixer/DataFixUtil.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_qfhcarfn net/minecraft/datafixer/DataFixUtil
+	METHOD m_lwiilffr optionalFields ([Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/types/templates/TypeTemplate;

--- a/mappings/net/minecraft/datafixer/TypeReferences.mapping
+++ b/mappings/net/minecraft/datafixer/TypeReferences.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/unmapped/C_rodgceaz net/minecraft/datafixer/TypeReferences
 	FIELD f_dzejhezi BLOCK_STATE Lcom/mojang/datafixers/DSL$TypeReference;
 		COMMENT A type reference which refers to a block state.
 	FIELD f_eswwjwrw LEVEL Lcom/mojang/datafixers/DSL$TypeReference;
+	FIELD f_etntycyl DATA_COMPONENTS Lcom/mojang/datafixers/DSL$TypeReference;
 	FIELD f_fipiwawr CHUNK_GENERATOR_SETTINGS Lcom/mojang/datafixers/DSL$TypeReference;
 		COMMENT A type reference which refers to chunk generator settings.
 	FIELD f_gcpbrldn ENTITY Lcom/mojang/datafixers/DSL$TypeReference;

--- a/mappings/net/minecraft/datafixer/fix/AreaEffectCloudPotionFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/AreaEffectCloudPotionFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_hhpdildx net/minecraft/datafixer/fix/AreaEffectCloudPotionFix

--- a/mappings/net/minecraft/datafixer/fix/BannerPatternFormatFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BannerPatternFormatFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_dglojnba net/minecraft/datafixer/fix/BannerPatternFormatFix

--- a/mappings/net/minecraft/datafixer/fix/BeehiveFieldRenameFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BeehiveFieldRenameFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_vvigtzbk net/minecraft/datafixer/fix/BeehiveFieldRenameFix

--- a/mappings/net/minecraft/datafixer/fix/BlockNameFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BlockNameFix.mapping
@@ -7,3 +7,4 @@ CLASS net/minecraft/unmapped/C_wdyzpagx net/minecraft/datafixer/fix/BlockNameFix
 		ARG 0 oldSchema
 		ARG 1 name
 		ARG 2 rename
+	METHOD makeRule makeRule ()Lcom/mojang/datafixers/TypeRewriteRule;

--- a/mappings/net/minecraft/datafixer/fix/BlockPosFormatFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BlockPosFormatFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_lntklpwx net/minecraft/datafixer/fix/BlockPosFormatFix

--- a/mappings/net/minecraft/datafixer/fix/EmptyItemInHotbarFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/EmptyItemInHotbarFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_cgbvaywy net/minecraft/datafixer/fix/EmptyItemInHotbarFix

--- a/mappings/net/minecraft/datafixer/fix/HorseArmorFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/HorseArmorFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ozobotfj net/minecraft/datafixer/fix/HorseArmorFix

--- a/mappings/net/minecraft/datafixer/fix/HorseChestIndexingFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/HorseChestIndexingFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_avvashtl net/minecraft/datafixer/fix/HorseChestIndexingFix

--- a/mappings/net/minecraft/datafixer/fix/ItemStackComponentRemainderFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/ItemStackComponentRemainderFix.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/unmapped/C_dxmxprhk net/minecraft/datafixer/fix/ItemStackComponentRemainderFix
+	FIELD f_sfnhspmm oldComponentId Ljava/lang/String;
+	FIELD f_tsvnmqvr name Ljava/lang/String;
+	FIELD f_ytzdfflb newComponentId Ljava/lang/String;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 schema
+		ARG 2 name
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 schema
+		ARG 2 name
+		ARG 3 oldComponentId
+		ARG 4 newComponentId
+	METHOD m_ellancow fixComponent (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD makeRule makeRule ()Lcom/mojang/datafixers/TypeRewriteRule;

--- a/mappings/net/minecraft/datafixer/fix/ItemStackComponentizationFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/ItemStackComponentizationFix.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/unmapped/C_yfddtnnr net/minecraft/datafixer/fix/ItemStackComponentizationFix
+	FIELD f_bkigsjbg POTION_ITEM_IDS Ljava/util/Set;
+	FIELD f_ghmvdbpr COMMA_SPLITTER Lcom/google/common/base/Splitter;
+	FIELD f_uaodxohr ENTITY_BUCKET_ITEM_IDS Ljava/util/Set;
+	FIELD f_yzknnlmr RELEVANT_ENTITY_NBT_KEYS Ljava/util/List;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 schema
+	METHOD m_gujpxmba (Lnet/minecraft/unmapped/C_yfddtnnr$C_dhfttijx;Lcom/mojang/serialization/Dynamic;)V
+		ARG 0 stackData
+	CLASS C_dhfttijx StackData

--- a/mappings/net/minecraft/datafixer/fix/LodestoneCompassComponentFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/LodestoneCompassComponentFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_nhmdchrs net/minecraft/datafixer/fix/LodestoneCompassComponentFix

--- a/mappings/net/minecraft/datafixer/fix/MapBannerBlockPosFormatFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/MapBannerBlockPosFormatFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ozrqvrww net/minecraft/datafixer/fix/MapBannerBlockPosFormatFix

--- a/mappings/net/minecraft/datafixer/fix/PlayerHeadBlockProfileFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/PlayerHeadBlockProfileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_fstrwsah net/minecraft/datafixer/fix/PlayerHeadBlockProfileFix

--- a/mappings/net/minecraft/datafixer/fix/RenameEnchantmentFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/RenameEnchantmentFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_lpsiuxzn net/minecraft/datafixer/fix/RenameEnchantmentFix

--- a/mappings/net/minecraft/datafixer/fix/TippedArrowPotionToItemFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/TippedArrowPotionToItemFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_fqylcxas net/minecraft/datafixer/fix/TippedArrowPotionToItemFix

--- a/mappings/net/minecraft/datafixer/fix/WolfHealthFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/WolfHealthFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_hwhlokhq net/minecraft/datafixer/fix/WolfHealthFix

--- a/mappings/net/minecraft/datafixer/schema/Schema1451v5.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema1451v5.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/unmapped/C_rbdrkekw net/minecraft/datafixer/schema/Schema1451v5
+	METHOD registerBlockEntities registerBlockEntities (Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;
+		ARG 1 schema

--- a/mappings/net/minecraft/datafixer/schema/Schema3807.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3807.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_heyovgvd net/minecraft/datafixer/schema/Schema3807

--- a/mappings/net/minecraft/datafixer/schema/Schema3808.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3808.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_yecitbgf net/minecraft/datafixer/schema/Schema3808

--- a/mappings/net/minecraft/datafixer/schema/Schema3808v1.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3808v1.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_trahsecz net/minecraft/datafixer/schema/Schema3808v1

--- a/mappings/net/minecraft/datafixer/schema/Schema3816.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3816.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_dhuhcmez net/minecraft/datafixer/schema/Schema3816

--- a/mappings/net/minecraft/datafixer/schema/Schema3818.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3818.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_cvvawujf net/minecraft/datafixer/schema/Schema3818

--- a/mappings/net/minecraft/datafixer/schema/Schema3818v3.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3818v3.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_vislmlyi net/minecraft/datafixer/schema/Schema3818v3

--- a/mappings/net/minecraft/datafixer/schema/Schema3818v4.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3818v4.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_pquflbdq net/minecraft/datafixer/schema/Schema3818v4

--- a/mappings/net/minecraft/datafixer/schema/Schema3822.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema3822.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_tjddwqjd net/minecraft/datafixer/schema/Schema3822

--- a/mappings/net/minecraft/entity/ai/brain/sensor/ArmadilloScareDetectedSensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/ArmadilloScareDetectedSensor.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_pykemoio net/minecraft/entity/ai/brain/sensor/ArmadilloScareDetectedSensor

--- a/mappings/net/minecraft/entity/ai/brain/sensor/BreezeAttackEntitySensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/BreezeAttackEntitySensor.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_hmcnoqun net/minecraft/entity/ai/brain/sensor/BreezeAttackEntitySensor
+	FIELD f_ipoiopvz RANGE I

--- a/mappings/net/minecraft/entity/ai/brain/sensor/FrogAttackablesSensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/FrogAttackablesSensor.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_hxzxrfua net/minecraft/entity/ai/brain/sensor/FrogAttackablesSensor
+	FIELD f_wniwrrei RANGE F
+	METHOD m_aeyablog isTargetUnreachable (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 frog
+		ARG 2 target

--- a/mappings/net/minecraft/entity/damage/OneTwentyOneDamageTypes.mapping
+++ b/mappings/net/minecraft/entity/damage/OneTwentyOneDamageTypes.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_omkffqzw net/minecraft/entity/damage/OneTwentyOneDamageTypes
+	METHOD m_kfrxkjka bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/mappings/net/minecraft/entity/vehicle/VehicleEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/VehicleEntity.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/unmapped/C_ogoqhclb net/minecraft/entity/vehicle/VehicleEnti
 		ARG 1 source
 	METHOD m_qobhgcrb killAndDropItem (Lnet/minecraft/unmapped/C_vorddnax;)V
 	METHOD m_tqtorwvl killAndDropSelf (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
-		ARG 1 source
+		ARG 1 damageSource
 	METHOD m_ubjgxlhd setDamageWobbleTicks (I)V
 		ARG 1 ticks
 	METHOD m_votqnvdy getDamageWobbleSide ()I

--- a/mappings/net/minecraft/item/BannerPatterns.mapping
+++ b/mappings/net/minecraft/item/BannerPatterns.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/unmapped/C_lmlxpsml net/minecraft/item/BannerPatterns
 	METHOD m_gogzazvm create (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
 		ARG 0 id
+	METHOD m_iuxajiyk register (Lnet/minecraft/unmapped/C_hqoyyfco;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 0 pattern
 	METHOD m_shrfwjxe initialize (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+		ARG 0 pattern

--- a/mappings/net/minecraft/item/trim/OneTwentyOneTrimPatterns.mapping
+++ b/mappings/net/minecraft/item/trim/OneTwentyOneTrimPatterns.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_wzgeixxv net/minecraft/item/trim/OneTwentyOneTrimPatterns
+	METHOD m_rulonzyk bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/mappings/net/minecraft/loot/function/ApplyBonusLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/ApplyBonusLootFunction.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_mxqfevzh net/minecraft/loot/function/ApplyBonusLo
 	FIELD f_ojkdftuu FACTORIES Ljava/util/Map;
 	FIELD f_wsorvvwo formula Lnet/minecraft/unmapped/C_mxqfevzh$C_xgjrgsyv;
 	FIELD f_wsrpgatr enchantment Lnet/minecraft/unmapped/C_cjzoxshv;
+	FIELD f_xeglxauo CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_lngedsfm oreDrops (Lnet/minecraft/unmapped/C_jxtrubuh;)Lnet/minecraft/unmapped/C_krisseon$C_nhpzaayj;
 		ARG 0 enchantment
 	METHOD m_tghqmevs uniformBonusCount (Lnet/minecraft/unmapped/C_jxtrubuh;I)Lnet/minecraft/unmapped/C_krisseon$C_nhpzaayj;

--- a/mappings/net/minecraft/loot/function/CopyComponentsLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/CopyComponentsLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_mbgfajkg net/minecraft/loot/function/CopyComponentsLootFunction

--- a/mappings/net/minecraft/loot/function/CopyCustomDataLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/CopyCustomDataLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_hgtsxeep net/minecraft/loot/function/CopyCustomDataLootFunction

--- a/mappings/net/minecraft/loot/function/EnchantRandomlyLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/EnchantRandomlyLootFunction.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_mcyropux net/minecraft/loot/function/EnchantRandomlyLootFunction
+	FIELD f_bwriysqi CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_dtvmmsyz enchantments Ljava/util/Optional;
 	FIELD f_hmtatkky LOGGER Lorg/slf4j/Logger;
+	FIELD f_qkktzcyr ENCHANTMENT_HOLDER_CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_hgxjeanh builder ()Lnet/minecraft/unmapped/C_krisseon$C_nhpzaayj;
 	METHOD m_oylffrhc create ()Lnet/minecraft/unmapped/C_mcyropux$C_xyziffnb;
 	METHOD m_susyvyur addEnchantmentToStack (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_jxtrubuh;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_sddaxwyk;

--- a/mappings/net/minecraft/loot/function/LootFunctionTypes.mapping
+++ b/mappings/net/minecraft/loot/function/LootFunctionTypes.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_daukiiao net/minecraft/loot/function/LootFunctionTypes
 	FIELD f_cbatfjwg NOOP Ljava/util/function/BiFunction;
+	FIELD f_hcnwqyvm CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_uxadbhqb BASE_CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_dnlzaiaw (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_iakykpgh;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 stack
 		ARG 1 context

--- a/mappings/net/minecraft/loot/function/SequenceLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SequenceLootFunction.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_ndfnieah net/minecraft/loot/function/SequenceLootFunction
+	FIELD f_chvgkosj CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_kakimbcn INLINE_CODEC Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/loot/function/SetBookCoverLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetBookCoverLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_gsgjanri net/minecraft/loot/function/SetBookCoverLootFunction

--- a/mappings/net/minecraft/loot/function/SetComponentsLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetComponentsLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_dpxzhowh net/minecraft/loot/function/SetComponentsLootFunction

--- a/mappings/net/minecraft/loot/function/SetCustomDataLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetCustomDataLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_sxzxxsuj net/minecraft/loot/function/SetCustomDataLootFunction

--- a/mappings/net/minecraft/loot/function/SetFireworkExplosionLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetFireworkExplosionLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_wvihlkry net/minecraft/loot/function/SetFireworkExplosionLootFunction

--- a/mappings/net/minecraft/loot/function/SetFireworksLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetFireworksLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ldqxohxy net/minecraft/loot/function/SetFireworksLootFunction

--- a/mappings/net/minecraft/loot/function/SetStewEffectLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetStewEffectLootFunction.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_jktghael net/minecraft/loot/function/SetStewEffectLootFunction
+	FIELD f_tjmdlomo CODEC Lcom/mojang/serialization/Codec;
 	METHOD m_exrfwrvg builder ()Lnet/minecraft/unmapped/C_jktghael$C_fqobdjyc;
 	CLASS C_fqobdjyc Builder
 		METHOD m_pkcqyoae withEffect (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_iajmfyig;)Lnet/minecraft/unmapped/C_jktghael$C_fqobdjyc;

--- a/mappings/net/minecraft/loot/function/SetWritableBookPagesLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetWritableBookPagesLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_qtpcfbnm net/minecraft/loot/function/SetWritableBookPagesLootFunction

--- a/mappings/net/minecraft/loot/function/SetWrittenBookPagesLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetWrittenBookPagesLootFunction.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_kkafruck net/minecraft/loot/function/SetWrittenBookPagesLootFunction

--- a/mappings/net/minecraft/network/configuration/SynchronizeRegistriesConfigurationTask.mapping
+++ b/mappings/net/minecraft/network/configuration/SynchronizeRegistriesConfigurationTask.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_kddnzsmk net/minecraft/network/configuration/SynchronizeRegistriesConfigurationTask
+	FIELD f_fenefqnc TYPE Lnet/minecraft/unmapped/C_bztbfoyh$C_kfyphvfz;
+	FIELD f_idxromsn registryLayers Lnet/minecraft/unmapped/C_bcpxdrik;

--- a/mappings/net/minecraft/predicate/entity/LightningBoltPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LightningBoltPredicate.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_pdvqqjua net/minecraft/predicate/entity/LightningBoltPredicate

--- a/mappings/net/minecraft/registry/BootstrapContext.mapping
+++ b/mappings/net/minecraft/registry/BootstrapContext.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/unmapped/C_hqoyyfco net/minecraft/registry/BootstrapContext
+	METHOD m_cajjlsxn getRegistryLookup (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_pzdchrcy;
+	METHOD m_pymxizhb register (Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;
+		ARG 1 key
+		ARG 2 object
+	METHOD m_vbitvrmt register (Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/Object;Lcom/mojang/serialization/Lifecycle;)Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;
+		ARG 1 key
+		ARG 2 object
+		ARG 3 lifecycle

--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -69,12 +69,16 @@ CLASS net/minecraft/unmapped/C_nusqeapl net/minecraft/registry/Registries
 	FIELD f_zrzntavz BLOCK_ENTITY_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	FIELD f_zydiinmc TRUNK_PLACER_TYPE Lnet/minecraft/unmapped/C_tqxyjqsk;
 	METHOD m_fgyhnhhd freeze ()V
+	METHOD m_grgbvblx createDefaultMappedUnfrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/String;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_zogerkic;
+	METHOD m_gwxfieow createSimpleUnfrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_tqxyjqsk;
 	METHOD m_hhgwdqyg internalRegister (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_eexxncvi;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_eexxncvi;
 		ARG 1 entry
 		ARG 2 bootstrap
+	METHOD m_lzhvsneq createDefaultMappedFrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/String;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_zogerkic;
 	METHOD m_mwsegmux bootstrap ()V
 	METHOD m_sgrkhfqj validate (Lnet/minecraft/unmapped/C_tqxyjqsk;)V
 		ARG 0 registries
 	METHOD m_ybecmlwo createContents ()V
+	METHOD m_ydemdayj createSimpleFrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_tqxyjqsk;
 	CLASS C_qpkaxgeh RegistryBootstrap
 		METHOD run run (Lnet/minecraft/unmapped/C_tqxyjqsk;)Ljava/lang/Object;

--- a/mappings/net/minecraft/registry/Registry.mapping
+++ b/mappings/net/minecraft/registry/Registry.mapping
@@ -39,6 +39,8 @@ CLASS net/minecraft/unmapped/C_tqxyjqsk net/minecraft/registry/Registry
 		ARG 1 id
 		ARG 2 entry
 	METHOD m_nqoydeav getEntries ()Ljava/util/Set;
+	METHOD m_nxhthmir getHolder (Lnet/minecraft/unmapped/C_ncpywfca;)Ljava/util/Optional;
+		ARG 1 id
 	METHOD m_ojrrpohi getTagKeys ()Ljava/util/stream/Stream;
 	METHOD m_pquqhkot holderByNameCodec ()Lcom/mojang/serialization/Codec;
 	METHOD m_pvyfqcdo getCodec ()Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/registry/RegistryKeys.mapping
+++ b/mappings/net/minecraft/registry/RegistryKeys.mapping
@@ -79,6 +79,7 @@ CLASS net/minecraft/unmapped/C_msgswxvc net/minecraft/registry/RegistryKeys
 	FIELD f_vxxzjrou CONFIGURED_CARVER Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_wemnxqkx BANNER_PATTERN Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_whmqikqj FLAT_WORLD_GENERATOR_PRESET Lnet/minecraft/unmapped/C_xhhleach;
+	FIELD f_wjqbwtow WOLF_VARIANT Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_wpsxqtkb STRUCTURE_POOL_ELEMENT_TYPE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_wrkhwhtk FEATURE Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_wzpsqovi CONFIGURED_FEATURE Lnet/minecraft/unmapped/C_xhhleach;

--- a/mappings/net/minecraft/structure/OneTwentyOneStructureSets.mapping
+++ b/mappings/net/minecraft/structure/OneTwentyOneStructureSets.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_rgqlhlfp net/minecraft/structure/OneTwentyOneStructureSets
+	METHOD m_wcldnkbl bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+		ARG 0 structureSet

--- a/mappings/net/minecraft/structure/pool/OneTwentyOneStructurePools.mapping
+++ b/mappings/net/minecraft/structure/pool/OneTwentyOneStructurePools.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_lgcxeygt net/minecraft/structure/pool/OneTwentyOneStructurePools
+	METHOD m_mfefjhwc bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/mappings/net/minecraft/structure/processor/OneTwentyOneStructureProcessors.mapping
+++ b/mappings/net/minecraft/structure/processor/OneTwentyOneStructureProcessors.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_jhvluwkz net/minecraft/structure/processor/OneTwentyOneStructureProcessors
+	METHOD m_rxuycdif bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/simple_type_field_names.json5
+++ b/simple_type_field_names.json5
@@ -30,6 +30,7 @@
   "net/minecraft/unmapped/C_tqxyjqsk": "registry",
   "net/minecraft/unmapped/C_xhhleach": "registryKey",
   "net/minecraft/unmapped/C_wqxmvzdq": "registryManager", // DynamicRegistryManager
+  "net/minecraft/unmapped/C_hqoyyfco": "context", // BootstrapContext
 
   // Client
   "net/minecraft/unmapped/C_ayfeobid": "client", // MinecraftClient


### PR DESCRIPTION
Pulls a lot of datafixer classes in. I also took the chance to look through all of n/m/unmapped and map any class names that I could. This drops the number of classes in `unmapped` from 367 to 287, according to enigma's mapping stats. There's also a few other mappings I thought would be good to have in here, the main part being mapping ~92%~ of `n/m/util/profiling`.