### PR TITLE
Improved some `BoatEntity` mappings.

### DIFF
--- a/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/BoatEntity.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 	FIELD f_jgunhycm ticksUnderwater F
 	FIELD f_jpsxxmki y D
 	FIELD f_mavldovk z D
-	FIELD f_nshqodnw landFriction F
+	FIELD f_nshqodnw groundFriction F
 	FIELD f_odtguolr boatYaw D
 	FIELD f_rspsbzff fallVelocity D
 	FIELD f_sbrsivqn TIME_TO_EJECT_TICKS I
@@ -57,7 +57,7 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 	METHOD m_qktgsogx getBubbleWobbleTicks ()I
 	METHOD m_teavnubq isPaddleMoving (I)Z
 		ARG 1 paddle
-	METHOD m_tikylhyj checkBoatInWater ()Z
+	METHOD m_tikylhyj isInWater ()Z
 	METHOD m_ttullqty canCollide (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 entity
 		ARG 1 other
@@ -76,7 +76,7 @@ CLASS net/minecraft/unmapped/C_mpfuowct net/minecraft/entity/vehicle/BoatEntity
 	METHOD m_wimbgplz getSinglePassengerXOffset ()F
 	METHOD m_wovjkrir (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 entity
-	METHOD m_xwvweinm checkLocation ()Lnet/minecraft/unmapped/C_mpfuowct$C_tdpqooxn;
+	METHOD m_xwvweinm updateLocation ()Lnet/minecraft/unmapped/C_mpfuowct$C_tdpqooxn;
 	CLASS C_jyahrrif Variant
 		FIELD f_haecscok CODEC Lnet/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc;
 		FIELD f_vbzpbykb key Ljava/lang/String;


### PR DESCRIPTION
- `checkBoatInWater` -> `isInWater`; conventional and consistent with `Location.IN_WATER`
- `checkLocation` -> `updateLocation`; a bit of an odd one, `updateLandFractionAndGetLocation` would be a verbose literal name, I think `updateLocation` communicates that reasonably well
- `landFriction` -> `groundFriction`; to match `getGroundFriction`

I considered renaming all `ground` -> `land` in `BoatEntity` to be consistent with `Location.ON_LAND`, but `Entity.fall`'s `onGround` param traces back to a string, so they can't be completely reconciled, and `ground` is used more in other classes and I think is slightly better in most cases.