### PR TITLE
[1.20.6] CustomPayload.Id -> Type

### DIFF
--- a/mappings/net/minecraft/network/packet/payload/CustomPayload.mapping
+++ b/mappings/net/minecraft/network/packet/payload/CustomPayload.mapping
@@ -7,15 +7,15 @@ CLASS net/minecraft/unmapped/C_oqfbzhlw net/minecraft/network/packet/payload/Cus
 	METHOD m_vpekzbex create (Lnet/minecraft/unmapped/C_dptxqryi;Lnet/minecraft/unmapped/C_ajdohfrc;)Lnet/minecraft/unmapped/C_qsrmwluu;
 		ARG 0 encoder
 		ARG 1 decoder
-	METHOD m_xjiabzgi getId ()Lnet/minecraft/unmapped/C_oqfbzhlw$C_ioyvylwe;
+	METHOD m_xjiabzgi getType ()Lnet/minecraft/unmapped/C_oqfbzhlw$C_ioyvylwe;
 	CLASS C_idfcqkqn
 		METHOD m_bxhkmoqb write (Lnet/minecraft/unmapped/C_idfydwco;Lnet/minecraft/unmapped/C_oqfbzhlw$C_ioyvylwe;Lnet/minecraft/unmapped/C_oqfbzhlw;)V
 			ARG 1 buf
-			ARG 2 id
+			ARG 2 type
 			ARG 3 payload
 		METHOD m_lxufxfjg getPacketCodec (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_qsrmwluu;
 			ARG 1 id
-	CLASS C_ioyvylwe Id
+	CLASS C_ioyvylwe Type
 	CLASS C_jnluxmor CodecFactory
 		METHOD create create (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_qsrmwluu;
 			ARG 1 identifier


### PR DESCRIPTION
This class is not just an id, it associates an id with a specific CustomPayload class (a la EntityType).

Provided for 1.20.6 because that's what QSL is on and i'd like to use this in some api class names, but I will live without it until 1.21 if it's not possible to refactor an old version