### PR TITLE
Add `findDuplicateMappingFiles` task

### DIFF
--- a/buildSrc/src/main/java/quilt/internal/MappingsPlugin.java
+++ b/buildSrc/src/main/java/quilt/internal/MappingsPlugin.java
@@ -20,6 +20,7 @@ import quilt.internal.tasks.diff.RemapTargetMinecraftJarTask;
 import quilt.internal.tasks.jarmapping.MapNamedJarTask;
 import quilt.internal.tasks.jarmapping.MapPerVersionMappingsJarTask;
 import quilt.internal.tasks.lint.DownloadDictionaryFileTask;
+import quilt.internal.tasks.lint.FindDuplicateMappingFilesTask;
 import quilt.internal.tasks.lint.MappingLintTask;
 import quilt.internal.tasks.setup.CheckIntermediaryMappingsTask;
 import quilt.internal.tasks.setup.DownloadIntermediaryMappingsTask;
@@ -65,7 +66,11 @@ public class MappingsPlugin implements Plugin<Project> {
 
         tasks.create(GeneratePackageInfoMappingsTask.TASK_NAME, GeneratePackageInfoMappingsTask.class);
         tasks.create(DownloadDictionaryFileTask.TASK_NAME, DownloadDictionaryFileTask.class);
-        tasks.create(MappingLintTask.TASK_NAME, MappingLintTask.class);
+        final var mappingLintTask = tasks.create(MappingLintTask.TASK_NAME, MappingLintTask.class);
+        tasks.create(FindDuplicateMappingFilesTask.TASK_NAME, FindDuplicateMappingFilesTask.class, task -> {
+            task.getMappingDirectory().set(mappingLintTask.getMappingDirectory());
+            mappingLintTask.dependsOn(task);
+        });
 
         tasks.create(CheckIntermediaryMappingsTask.TASK_NAME, CheckIntermediaryMappingsTask.class);
         tasks.create(DownloadIntermediaryMappingsTask.TASK_NAME, DownloadIntermediaryMappingsTask.class);

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/DuplicateMappingFinderTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/DuplicateMappingFinderTask.java
@@ -1,0 +1,67 @@
+package quilt.internal.tasks.lint;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public abstract class DuplicateMappingFinderTask extends DefaultTask {
+    private static final Pattern CLASS_HASH_PATTERN = Pattern.compile("^CLASS net/minecraft/unmapped/C_\\w+");
+
+    @InputDirectory
+    public abstract RegularFileProperty getMappingsDir();
+
+    @TaskAction
+    public void run() {
+        final Multimap<String, File> allMappings = HashMultimap.create();
+        final Set<String> multiMappings = new HashSet<>();
+
+        try (Stream<Path> mappingPaths = Files.walk(getMappingsDir().get().getAsFile().toPath())) {
+            mappingPaths.map(Path::toFile)
+                .filter(File::isFile)
+                .forEach(mappingFile -> {
+                    try (var reader = new BufferedReader(new FileReader(mappingFile))) {
+                        final String firstLine = reader.readLine();
+                        if (firstLine != null) {
+                            final var classHashMatcher = CLASS_HASH_PATTERN.matcher(firstLine);
+                            if (classHashMatcher.find()) {
+                                final String classHash = classHashMatcher.group(0);
+                                final Collection<File> classMappings = allMappings.get(classHash);
+
+                                if (!classMappings.isEmpty()) multiMappings.add(classHash);
+
+                                classMappings.add(mappingFile);
+                            }
+                        }
+                    } catch (IOException e) {
+                        throw new GradleException("Unexpected error accessing mapping file", e);
+                    }
+                });
+        } catch (IOException e) {
+            throw new GradleException("Unexpected error accessing mappings directory", e);
+        }
+
+        if (!multiMappings.isEmpty()) {
+            final var err = new StringBuilder("Found classes mapped by multiple files!");
+            for (final String multiMapping : multiMappings) {
+                err.append('\t').append(multiMapping).append(" is mapped by:");
+
+                for (final File mappingFile : allMappings.get(multiMapping)) {
+                    err.append("\t\t").append(mappingFile);
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -21,8 +21,8 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
     public static final String TASK_NAME = "findDuplicateMappingFiles";
 
     private static final Logger LOGGER = Logging.getLogger(FindDuplicateMappingFilesTask.class);
-    private static final Pattern MINECRAFT_CLASS = Pattern.compile("^CLASS net/minecraft/(?:\\w+/)*\\w+ ");
-    private static final Pattern BLAZE_CLASS = Pattern.compile("^CLASS com/mojang/blaze3d/(?:\\w+/)*\\w+ ");
+    private static final Pattern MINECRAFT_CLASS = Pattern.compile("^CLASS net/minecraft/(?:\\w+/)*\\w+(?= )");
+    private static final Pattern BLAZE_CLASS = Pattern.compile("^CLASS com/mojang/blaze3d/(?:\\w+/)*\\w+(?= )");
 
     @InputDirectory
     public abstract DirectoryProperty getMappingDirectory();

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -52,12 +52,12 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
                                 },
                                 () -> mapNoClassFiles.add(mappingFile)
                             );
-
-                            if (!mappingFile.toString().endsWith(".mapping")) {
-                                wrongExtensionFiles.add(mappingFile);
-                            }
                         } else {
                             emptyFiles.add(mappingFile);
+                        }
+
+                        if (!mappingFile.toString().endsWith(".mapping")) {
+                            wrongExtensionFiles.add(mappingFile);
                         }
                     } catch (IOException e) {
                         throw new GradleException("Unexpected error accessing mapping file", e);
@@ -119,8 +119,8 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
             errorMessages.add(message);
 
             LOGGER.error("Found {}!", message);
-            for (final File mapNoClassFile : mapNoClassFiles) {
-                LOGGER.error("\t{}", mapNoClassFile);
+            for (final File wrongExtensionFile : wrongExtensionFiles) {
+                LOGGER.error("\t{}", wrongExtensionFile);
             }
         }
 

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -21,8 +21,8 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
     public static final String TASK_NAME = "findDuplicateMappingFiles";
 
     private static final Logger LOGGER = Logging.getLogger(FindDuplicateMappingFilesTask.class);
-    private static final Pattern MINECRAFT_CLASS = Pattern.compile("^CLASS net/minecraft/(?:\\w+/)*\\w+(?= )");
-    private static final Pattern BLAZE_CLASS = Pattern.compile("^CLASS com/mojang/blaze3d/(?:\\w+/)*\\w+(?= )");
+    private static final Pattern EXPECTED_CLASS =
+        Pattern.compile("^CLASS (?:net/minecraft|com/mojang/blaze3d)/(?:\\w+/)*\\w+(?= )");
 
     @InputDirectory
     public abstract DirectoryProperty getMappingDirectory();
@@ -146,16 +146,9 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
     }
 
     private static Optional<String> getClassMatch(String firstLine) {
-        final var minecraftClassMatcher = MINECRAFT_CLASS.matcher(firstLine);
-        if (minecraftClassMatcher.find()) {
-            return Optional.of(minecraftClassMatcher.group(0));
-        } else {
-            final var blazeClassMatcher = BLAZE_CLASS.matcher(firstLine);
-            if (blazeClassMatcher.find()) {
-                return Optional.of(blazeClassMatcher.group(0));
-            } else {
-                return Optional.empty();
-            }
-        }
+        final var expectedClassMatcher = EXPECTED_CLASS.matcher(firstLine);
+        return expectedClassMatcher.find() ?
+            Optional.of(expectedClassMatcher.group(0)) :
+            Optional.empty();
     }
 }

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -5,14 +5,14 @@ import com.google.common.collect.Multimap;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -20,7 +20,9 @@ import java.util.stream.Stream;
 public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
     public static final String TASK_NAME = "findDuplicateMappingFiles";
 
-    private static final Pattern CLASS_HASH_PATTERN = Pattern.compile("^CLASS net/minecraft/unmapped/C_\\w+");
+    private static final Logger LOGGER = Logging.getLogger(FindDuplicateMappingFilesTask.class);
+    private static final Pattern MINECRAFT_CLASS = Pattern.compile("^CLASS net/minecraft/(?:\\w+/)*\\w+ ");
+    private static final Pattern BLAZE_CLASS = Pattern.compile("^CLASS com/mojang/blaze3d/(?:\\w+/)*\\w+ ");
 
     @InputDirectory
     public abstract DirectoryProperty getMappingDirectory();
@@ -28,7 +30,10 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
     @TaskAction
     public void run() {
         final Multimap<String, File> allMappings = HashMultimap.create();
-        final Set<String> multiMappings = new HashSet<>();
+        final Set<String> duplicateMappings = new HashSet<>();
+        final List<File> emptyFiles = new ArrayList<>();
+        final List<File> mapNoClassFiles = new ArrayList<>();
+        final List<File> wrongExtensionFiles = new ArrayList<>();
 
         try (Stream<Path> mappingPaths = Files.walk(getMappingDirectory().get().getAsFile().toPath())) {
             mappingPaths.map(Path::toFile)
@@ -37,15 +42,22 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
                     try (var reader = new BufferedReader(new FileReader(mappingFile))) {
                         final String firstLine = reader.readLine();
                         if (firstLine != null) {
-                            final var classHashMatcher = CLASS_HASH_PATTERN.matcher(firstLine);
-                            if (classHashMatcher.find()) {
-                                final String classHash = classHashMatcher.group(0);
-                                final Collection<File> classMappings = allMappings.get(classHash);
+                            getClassMatch(firstLine).ifPresentOrElse(
+                                classMatch -> {
+                                    final Collection<File> classMappings = allMappings.get(classMatch);
 
-                                if (!classMappings.isEmpty()) multiMappings.add(classHash);
+                                    if (!classMappings.isEmpty()) duplicateMappings.add(classMatch);
 
-                                classMappings.add(mappingFile);
+                                    classMappings.add(mappingFile);
+                                },
+                                () -> mapNoClassFiles.add(mappingFile)
+                            );
+
+                            if (!mappingFile.toString().endsWith(".mapping")) {
+                                wrongExtensionFiles.add(mappingFile);
                             }
+                        } else {
+                            emptyFiles.add(mappingFile);
                         }
                     } catch (IOException e) {
                         throw new GradleException("Unexpected error accessing mapping file", e);
@@ -55,20 +67,95 @@ public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
             throw new GradleException("Unexpected error accessing mappings directory", e);
         }
 
-        if (!multiMappings.isEmpty()) {
-            final var err = new StringBuilder("Found classes mapped by multiple files!");
-            err.append(System.lineSeparator());
-            for (final String multiMapping : multiMappings) {
-                err.append('\t').append(multiMapping).append(" is mapped by:");
-                err.append(System.lineSeparator());
+        final List<String> errorMessages = new ArrayList<>();
+        if (!duplicateMappings.isEmpty()) {
+            final String message = "%d class%s mapped by multiple files".formatted(
+                duplicateMappings.size(),
+                duplicateMappings.size() == 1 ? "" : "es"
+            );
+            errorMessages.add(message);
 
-                for (final File mappingFile : allMappings.get(multiMapping)) {
-                    err.append("\t\t").append(mappingFile);
-                    err.append(System.lineSeparator());
+            LOGGER.error("Found {}!", message);
+            for (final String duplicateMapping : duplicateMappings) {
+                LOGGER.error("\t{} is mapped by:", duplicateMapping);
+
+                for (final File mappingFile : allMappings.get(duplicateMapping)) {
+                    LOGGER.error("\t\t{}", mappingFile);
+                }
+            }
+        }
+
+        if (!emptyFiles.isEmpty()) {
+            final String message = "%d empty file%s".formatted(
+                emptyFiles.size(),
+                emptyFiles.size() == 1 ? "" : "s"
+            );
+            errorMessages.add(message);
+
+            LOGGER.error("Found {}!", message);
+            for (final File emptyFile : emptyFiles) {
+                LOGGER.error("\t{}", emptyFile);
+            }
+        }
+
+        if (!mapNoClassFiles.isEmpty()) {
+            final String message = "%d file%s not mapping a class".formatted(
+                mapNoClassFiles.size(),
+                mapNoClassFiles.size() == 1 ? "" : "s"
+            );
+            errorMessages.add(message);
+
+            LOGGER.error("Found {}!", message);
+            for (final File mapNoClassFile : mapNoClassFiles) {
+                LOGGER.error("\t{}", mapNoClassFile);
+            }
+        }
+
+        if (!wrongExtensionFiles.isEmpty()) {
+            final String message = "%d file%s without the mapping extension".formatted(
+                wrongExtensionFiles.size(),
+                wrongExtensionFiles.size() == 1 ? "" : "s"
+            );
+            errorMessages.add(message);
+
+            LOGGER.error("Found {}!", message);
+            for (final File mapNoClassFile : mapNoClassFiles) {
+                LOGGER.error("\t{}", mapNoClassFile);
+            }
+        }
+
+        if (!errorMessages.isEmpty()) {
+            final var fullError = new StringBuilder("Found ");
+            switch (errorMessages.size()) {
+                case 1 -> { }
+                case 2 -> fullError.append(errorMessages.getFirst()).append(" and ");
+                default -> {
+                    final List<String> allButLastMessage = errorMessages.subList(0, errorMessages.size() - 1);
+                    for (final String message : allButLastMessage) {
+                        fullError.append(message).append(", ");
+                    }
+
+                    fullError.append("and ");
                 }
             }
 
-            throw new GradleException(err.toString());
+            fullError.append(errorMessages.getLast()).append("! See the log for details.");
+
+            throw new GradleException(fullError.toString());
+        }
+    }
+
+    private static Optional<String> getClassMatch(String firstLine) {
+        final var minecraftClassMatcher = MINECRAFT_CLASS.matcher(firstLine);
+        if (minecraftClassMatcher.find()) {
+            return Optional.of(minecraftClassMatcher.group(0));
+        } else {
+            final var blazeClassMatcher = BLAZE_CLASS.matcher(firstLine);
+            if (blazeClassMatcher.find()) {
+                return Optional.of(blazeClassMatcher.group(0));
+            } else {
+                return Optional.empty();
+            }
         }
     }
 }

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -17,18 +18,20 @@ import java.util.regex.Pattern;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-public abstract class DuplicateMappingFinderTask extends DefaultTask {
+public abstract class FindDuplicateMappingFilesTask extends DefaultTask {
+    public static final String TASK_NAME = "findDuplicateMappingFiles";
+
     private static final Pattern CLASS_HASH_PATTERN = Pattern.compile("^CLASS net/minecraft/unmapped/C_\\w+");
 
     @InputDirectory
-    public abstract RegularFileProperty getMappingsDir();
+    public abstract DirectoryProperty getMappingDirectory();
 
     @TaskAction
     public void run() {
         final Multimap<String, File> allMappings = HashMultimap.create();
         final Set<String> multiMappings = new HashSet<>();
 
-        try (Stream<Path> mappingPaths = Files.walk(getMappingsDir().get().getAsFile().toPath())) {
+        try (Stream<Path> mappingPaths = Files.walk(getMappingDirectory().get().getAsFile().toPath())) {
             mappingPaths.map(Path::toFile)
                 .filter(File::isFile)
                 .forEach(mappingFile -> {
@@ -55,13 +58,18 @@ public abstract class DuplicateMappingFinderTask extends DefaultTask {
 
         if (!multiMappings.isEmpty()) {
             final var err = new StringBuilder("Found classes mapped by multiple files!");
+            err.append(System.lineSeparator());
             for (final String multiMapping : multiMappings) {
                 err.append('\t').append(multiMapping).append(" is mapped by:");
+                err.append(System.lineSeparator());
 
                 for (final File mappingFile : allMappings.get(multiMapping)) {
                     err.append("\t\t").append(mappingFile);
+                    err.append(System.lineSeparator());
                 }
             }
+
+            throw new GradleException(err.toString());
         }
     }
 }

--- a/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/lint/FindDuplicateMappingFilesTask.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Multimap;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 

--- a/mappings/net/minecraft/datafixer/fix/AttributeIdFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/AttributeIdFix.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/unmapped/C_zjsuejaf net/minecraft/datafixer/fix/AttributeIdFix
+	METHOD m_jffrakte fixModifiers (Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
+	METHOD m_omvogmer fixAttribute (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD m_smnezcpi fixItemStackComponents (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD m_tuhonugx fixEntity (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixer/fix/AttributeModifierIdFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/AttributeModifierIdFix.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/unmapped/C_zjsuejaf net/minecraft/datafixer/fix/AttributeModifierIdFix
-	METHOD m_jffrakte fixModifiers (Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
-	METHOD m_omvogmer fixAttribute (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
-	METHOD m_smnezcpi fixItemStackComponents (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
-	METHOD m_tuhonugx fixEntity (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixer/fix/RemoveEmptyItemInBrushableBlockFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/RemoveEmptyItemInBrushableBlockFix.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_dxtlxcwy net/minecraft/datafixer/fix/RemoveEmptyItemInBrushableBlockFix
-	METHOD m_grqceiyr isEmptyStack (Lcom/mojang/serialization/Dynamic;)Z


### PR DESCRIPTION
Adds `findDuplicateMappingFiles` gradle task that checks for mapping files that map the same class.

Useful when merging/rebasing.
It just matches the first line of each file against ~~`"^CLASS net/minecraft/unmapped/C_\\w+"`~~ and if it finds any files with the same one it throws an exception listing them.

edit: it matches against this now:
```regex
"^CLASS (?:net/minecraft|com/mojang/blaze3d)/(?:\\w+/)*\\w+(?= )"
```

Also makes `mappingLint` depend on `findDuplicateMappingFiles`.

Edit: also removes current duplicate mapping files so the build run can complete.