### PR TITLE
enable same-name proposal on non hashed mappings

### DIFF
--- a/enigma_profile.json
+++ b/enigma_profile.json
@@ -5,7 +5,10 @@
                 "id": "enigma:specialized_method_name_proposer"
             },
             {
-                "id": "quiltmc:name_proposal"
+                "id": "quiltmc:name_proposal",
+                "args": {
+                    "disable_map_non_hashed": "false"
+                }
             }
         ],
         "jar_indexer": {

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -1,108 +1,98 @@
-CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlStateManager
-	FIELD BLEND BLEND Lcom/mojang/blaze3d/platform/GlStateManager$C_ylrgzzji;
-	FIELD COLOR_LOGIC COLOR_LOGIC Lcom/mojang/blaze3d/platform/GlStateManager$C_vfgqorge;
-	FIELD COLOR_MASK COLOR_MASK Lcom/mojang/blaze3d/platform/GlStateManager$C_rjgxucxb;
-	FIELD CULL CULL Lcom/mojang/blaze3d/platform/GlStateManager$C_kjkfvpuw;
-	FIELD DEPTH DEPTH Lcom/mojang/blaze3d/platform/GlStateManager$C_jwjvoryv;
-	FIELD ON_LINUX ON_LINUX Z
-	FIELD POLY_OFFSET POLY_OFFSET Lcom/mojang/blaze3d/platform/GlStateManager$C_ugvwtbhw;
-	FIELD SCISSOR SCISSOR Lcom/mojang/blaze3d/platform/GlStateManager$C_ujpcnblf;
-	FIELD STENCIL STENCIL Lcom/mojang/blaze3d/platform/GlStateManager$C_roxsdpvm;
-	FIELD TEXTURES TEXTURES [Lcom/mojang/blaze3d/platform/GlStateManager$C_vgejkzlz;
-	FIELD TEXTURE_COUNT TEXTURE_COUNT I
-	FIELD activeTexture activeTexture I
-	METHOD _activeTexture _activeTexture (I)V
+CLASS com/mojang/blaze3d/platform/GlStateManager
+	FIELD activeTexture I
+	METHOD _activeTexture (I)V
 		ARG 0 texture
-	METHOD _bindTexture _bindTexture (I)V
+	METHOD _bindTexture (I)V
 		ARG 0 texture
-	METHOD _blendEquation _blendEquation (I)V
+	METHOD _blendEquation (I)V
 		ARG 0 mode
-	METHOD _blendFunc _blendFunc (II)V
+	METHOD _blendFunc (II)V
 		ARG 0 srcFactor
 		ARG 1 dstFactor
-	METHOD _blendFuncSeparate _blendFuncSeparate (IIII)V
+	METHOD _blendFuncSeparate (IIII)V
 		ARG 0 srcFactorRGB
 		ARG 1 dstFactorRGB
 		ARG 2 srcFactorAlpha
 		ARG 3 dstFactorAlpha
-	METHOD _clearColor _clearColor (FFFF)V
-		ARG 0 red
-		ARG 1 green
-		ARG 2 blue
-		ARG 3 alpha
-	METHOD _clearDepth _clearDepth (D)V
-		ARG 0 depth
-	METHOD _clearStencil _clearStencil (I)V
-		ARG 0 stencil
-	METHOD _colorMask _colorMask (ZZZZ)V
-		ARG 0 red
-		ARG 1 green
-		ARG 2 blue
-		ARG 3 alpha
-	METHOD _deleteTexture _deleteTexture (I)V
-		ARG 0 texture
-	METHOD _deleteTextures _deleteTextures ([I)V
-		ARG 0 ids
-	METHOD _depthFunc _depthFunc (I)V
-		ARG 0 func
-	METHOD _depthMask _depthMask (Z)V
+	METHOD _clear (I)V
 		ARG 0 mask
-	METHOD _disableBlend _disableBlend ()V
-	METHOD _disableColorLogicOp _disableColorLogicOp ()V
-	METHOD _disableCull _disableCull ()V
-	METHOD _disableDepthTest _disableDepthTest ()V
-	METHOD _disablePolygonOffset _disablePolygonOffset ()V
-	METHOD _disableScissorTest _disableScissorTest ()V
-	METHOD _disableVertexAttribArray _disableVertexAttribArray (I)V
+	METHOD _clearColor (FFFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD _clearDepth (D)V
+		ARG 0 depth
+	METHOD _clearStencil (I)V
+		ARG 0 stencil
+	METHOD _colorMask (ZZZZ)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD _deleteTexture (I)V
+		ARG 0 texture
+	METHOD _deleteTextures ([I)V
+		ARG 0 ids
+	METHOD _depthFunc (I)V
+		ARG 0 func
+	METHOD _depthMask (Z)V
+		ARG 0 mask
+	METHOD _disableBlend ()V
+	METHOD _disableColorLogicOp ()V
+	METHOD _disableCull ()V
+	METHOD _disableDepthTest ()V
+	METHOD _disablePolygonOffset ()V
+	METHOD _disableVertexAttribArray (I)V
 		ARG 0 index
-	METHOD _drawElements _drawElements (IIIJ)V
+	METHOD _drawElements (IIIJ)V
 		ARG 0 mode
 		ARG 1 count
 		ARG 2 type
 		ARG 3 indices
-	METHOD _enableBlend _enableBlend ()V
-	METHOD _enableColorLogicOp _enableColorLogicOp ()V
-	METHOD _enableCull _enableCull ()V
-	METHOD _enableDepthTest _enableDepthTest ()V
-	METHOD _enablePolygonOffset _enablePolygonOffset ()V
-	METHOD _enableScissorTest _enableScissorTest ()V
-	METHOD _enableVertexAttribArray _enableVertexAttribArray (I)V
+	METHOD _enableBlend ()V
+	METHOD _enableColorLogicOp ()V
+	METHOD _enableCull ()V
+	METHOD _enableDepthTest ()V
+	METHOD _enablePolygonOffset ()V
+	METHOD _enableScissorTest ()V
+	METHOD _enableVertexAttribArray (I)V
 		ARG 0 index
-	METHOD _genTexture _genTexture ()I
-	METHOD _genTextures _genTextures ([I)V
+	METHOD _genTexture ()I
+	METHOD _genTextures ([I)V
 		ARG 0 ids
-	METHOD _getActiveTexture _getActiveTexture ()I
-	METHOD _getError _getError ()I
-	METHOD _getInteger _getInteger (I)I
+	METHOD _getActiveTexture ()I
+	METHOD _getError ()I
+	METHOD _getInteger (I)I
 		ARG 0 pname
-	METHOD _getString _getString (I)Ljava/lang/String;
+	METHOD _getString (I)Ljava/lang/String;
 		ARG 0 name
-	METHOD _getTexImage _getTexImage (IIIIJ)V
+	METHOD _getTexImage (IIIIJ)V
 		ARG 0 target
 		ARG 1 level
 		ARG 2 format
 		ARG 3 type
 		ARG 4 pixels
-	METHOD _getTexLevelParameter _getTexLevelParameter (III)I
+	METHOD _getTexLevelParameter (III)I
 		ARG 0 target
 		ARG 1 level
 		ARG 2 pname
-	METHOD _glBindAttribLocation _glBindAttribLocation (IILjava/lang/CharSequence;)V
+	METHOD _glBindAttribLocation (IILjava/lang/CharSequence;)V
 		ARG 0 program
 		ARG 1 index
 		ARG 2 name
-	METHOD _glBindBuffer _glBindBuffer (II)V
+	METHOD _glBindBuffer (II)V
 		ARG 0 target
 		ARG 1 buffer
-	METHOD _glBindFramebuffer _glBindFramebuffer (II)V
+	METHOD _glBindFramebuffer (II)V
 		ARG 0 target
 		ARG 1 framebuffer
-	METHOD _glBindRenderbuffer _glBindRenderbuffer (II)V
+	METHOD _glBindRenderbuffer (II)V
 		ARG 0 target
 		ARG 1 renderbuffer
-	METHOD _glBindVertexArray _glBindVertexArray (I)V
+	METHOD _glBindVertexArray (I)V
 		ARG 0 array
-	METHOD _glBlitFrameBuffer _glBlitFrameBuffer (IIIIIIIIII)V
+	METHOD _glBlitFrameBuffer (IIIIIIIIII)V
 		ARG 0 srcX0
 		ARG 1 srcY0
 		ARG 2 srcX1
@@ -113,15 +103,15 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 7 dstY1
 		ARG 8 mask
 		ARG 9 filter
-	METHOD _glBufferData _glBufferData (IJI)V
+	METHOD _glBufferData (IJI)V
 		ARG 0 target
 		ARG 1 size
 		ARG 3 usage
-	METHOD _glBufferData _glBufferData (ILjava/nio/ByteBuffer;I)V
+	METHOD _glBufferData (ILjava/nio/ByteBuffer;I)V
 		ARG 0 target
 		ARG 1 data
 		ARG 2 usage
-	METHOD _glCopyTexSubImage2D _glCopyTexSubImage2D (IIIIIIII)V
+	METHOD _glCopyTexSubImage2D (IIIIIIII)V
 		ARG 0 target
 		ARG 1 level
 		ARG 2 xoffset
@@ -130,102 +120,102 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 5 y
 		ARG 6 width
 		ARG 7 height
-	METHOD _glDeleteBuffers _glDeleteBuffers (I)V
+	METHOD _glDeleteBuffers (I)V
 		ARG 0 buffer
-	METHOD _glDeleteFramebuffers _glDeleteFramebuffers (I)V
+	METHOD _glDeleteFramebuffers (I)V
 		ARG 0 framebuffer
-	METHOD _glDeleteRenderbuffers _glDeleteRenderbuffers (I)V
+	METHOD _glDeleteRenderbuffers (I)V
 		ARG 0 buffer
-	METHOD _glDeleteVertexArrays _glDeleteVertexArrays (I)V
+	METHOD _glDeleteVertexArrays (I)V
 		ARG 0 array
-	METHOD _glDrawPixels _glDrawPixels (IIIIJ)V
+	METHOD _glDrawPixels (IIIIJ)V
 		ARG 0 width
 		ARG 1 height
 		ARG 2 format
 		ARG 3 type
 		ARG 4 pixels
-	METHOD _glFramebufferRenderbuffer _glFramebufferRenderbuffer (IIII)V
+	METHOD _glFramebufferRenderbuffer (IIII)V
 		ARG 0 target
 		ARG 1 attachment
 		ARG 2 renderbufferTarget
 		ARG 3 renderbuffer
-	METHOD _glFramebufferTexture2D _glFramebufferTexture2D (IIIII)V
+	METHOD _glFramebufferTexture2D (IIIII)V
 		ARG 0 target
 		ARG 1 attachment
 		ARG 2 textureTarget
 		ARG 3 texture
 		ARG 4 level
-	METHOD _glGenBuffers _glGenBuffers ()I
-	METHOD _glGenVertexArrays _glGenVertexArrays ()I
-	METHOD _glGetAttribLocation _glGetAttribLocation (ILjava/lang/CharSequence;)I
+	METHOD _glGenBuffers ()I
+	METHOD _glGenVertexArrays ()I
+	METHOD _glGetAttribLocation (ILjava/lang/CharSequence;)I
 		ARG 0 program
 		ARG 1 name
-	METHOD _glGetUniformLocation _glGetUniformLocation (ILjava/lang/CharSequence;)I
+	METHOD _glGetUniformLocation (ILjava/lang/CharSequence;)I
 		ARG 0 program
 		ARG 1 name
-	METHOD _glMapBuffer _glMapBuffer (II)Ljava/nio/ByteBuffer;
+	METHOD _glMapBuffer (II)Ljava/nio/ByteBuffer;
 		ARG 0 target
 		ARG 1 access
-	METHOD _glRenderbufferStorage _glRenderbufferStorage (IIII)V
+	METHOD _glRenderbufferStorage (IIII)V
 		ARG 0 target
 		ARG 1 internalFormat
 		ARG 2 width
 		ARG 3 height
-	METHOD _glUniform1 _glUniform1 (ILjava/nio/FloatBuffer;)V
+	METHOD _glUniform1 (ILjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform1 _glUniform1 (ILjava/nio/IntBuffer;)V
+	METHOD _glUniform1 (ILjava/nio/IntBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform1i _glUniform1i (II)V
+	METHOD _glUniform1i (II)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform2 _glUniform2 (ILjava/nio/FloatBuffer;)V
+	METHOD _glUniform2 (ILjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform2 _glUniform2 (ILjava/nio/IntBuffer;)V
+	METHOD _glUniform2 (ILjava/nio/IntBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform3 _glUniform3 (ILjava/nio/FloatBuffer;)V
+	METHOD _glUniform3 (ILjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform3 _glUniform3 (ILjava/nio/IntBuffer;)V
+	METHOD _glUniform3 (ILjava/nio/IntBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform4 _glUniform4 (ILjava/nio/FloatBuffer;)V
+	METHOD _glUniform4 (ILjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniform4 _glUniform4 (ILjava/nio/IntBuffer;)V
+	METHOD _glUniform4 (ILjava/nio/IntBuffer;)V
 		ARG 0 location
 		ARG 1 value
-	METHOD _glUniformMatrix2 _glUniformMatrix2 (IZLjava/nio/FloatBuffer;)V
+	METHOD _glUniformMatrix2 (IZLjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 transpose
 		ARG 2 value
-	METHOD _glUniformMatrix3 _glUniformMatrix3 (IZLjava/nio/FloatBuffer;)V
+	METHOD _glUniformMatrix3 (IZLjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 transpose
 		ARG 2 value
-	METHOD _glUniformMatrix4 _glUniformMatrix4 (IZLjava/nio/FloatBuffer;)V
+	METHOD _glUniformMatrix4 (IZLjava/nio/FloatBuffer;)V
 		ARG 0 location
 		ARG 1 transpose
 		ARG 2 value
-	METHOD _glUnmapBuffer _glUnmapBuffer (I)V
+	METHOD _glUnmapBuffer (I)V
 		ARG 0 target
-	METHOD _glUseProgram _glUseProgram (I)V
+	METHOD _glUseProgram (I)V
 		ARG 0 program
-	METHOD _logicOp _logicOp (I)V
+	METHOD _logicOp (I)V
 		ARG 0 op
-	METHOD _pixelStore _pixelStore (II)V
+	METHOD _pixelStore (II)V
 		ARG 0 pname
 		ARG 1 param
-	METHOD _polygonMode _polygonMode (II)V
+	METHOD _polygonMode (II)V
 		ARG 0 face
 		ARG 1 mode
-	METHOD _polygonOffset _polygonOffset (FF)V
+	METHOD _polygonOffset (FF)V
 		ARG 0 factor
 		ARG 1 units
-	METHOD _readPixels _readPixels (IIIIIIJ)V
+	METHOD _readPixels (IIIIIIJ)V
 		ARG 0 x
 		ARG 1 y
 		ARG 2 width
@@ -233,7 +223,7 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 4 format
 		ARG 5 type
 		ARG 6 pixels
-	METHOD _readPixels _readPixels (IIIIIILjava/nio/ByteBuffer;)V
+	METHOD _readPixels (IIIIIILjava/nio/ByteBuffer;)V
 		ARG 0 x
 		ARG 1 y
 		ARG 2 width
@@ -241,22 +231,22 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 4 format
 		ARG 5 type
 		ARG 6 pixels
-	METHOD _scissorBox _scissorBox (IIII)V
+	METHOD _scissorBox (IIII)V
 		ARG 0 x
 		ARG 1 y
-		ARG 2 width
-		ARG 3 height
-	METHOD _stencilFunc _stencilFunc (III)V
+		ARG 2 height
+		ARG 3 width
+	METHOD _stencilFunc (III)V
 		ARG 0 func
 		ARG 1 ref
 		ARG 2 mask
-	METHOD _stencilMask _stencilMask (I)V
+	METHOD _stencilMask (I)V
 		ARG 0 mask
-	METHOD _stencilOp _stencilOp (III)V
+	METHOD _stencilOp (III)V
 		ARG 0 sfail
 		ARG 1 dpfail
 		ARG 2 dppass
-	METHOD _texImage2D _texImage2D (IIIIIIIILjava/nio/IntBuffer;)V
+	METHOD _texImage2D (IIIIIIIILjava/nio/IntBuffer;)V
 		ARG 0 target
 		ARG 1 level
 		ARG 2 internalFormat
@@ -266,15 +256,15 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 6 format
 		ARG 7 type
 		ARG 8 pixels
-	METHOD _texParameter _texParameter (IIF)V
+	METHOD _texParameter (IIF)V
 		ARG 0 target
 		ARG 1 pname
 		ARG 2 param
-	METHOD _texParameter _texParameter (III)V
+	METHOD _texParameter (III)V
 		ARG 0 target
 		ARG 1 pname
 		ARG 2 param
-	METHOD _texSubImage2D _texSubImage2D (IIIIIIIIJ)V
+	METHOD _texSubImage2D (IIIIIIIIJ)V
 		ARG 0 target
 		ARG 1 level
 		ARG 2 offsetX
@@ -293,78 +283,74 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		ARG 5 format
 		ARG 6 pixels
 		ARG 7 pixelConsumer
-	METHOD _vertexAttribIPointer _vertexAttribIPointer (IIIIJ)V
+	METHOD _vertexAttribIPointer (IIIIJ)V
 		ARG 0 index
 		ARG 1 size
 		ARG 2 type
 		ARG 3 stride
 		ARG 4 pointer
-	METHOD _vertexAttribPointer _vertexAttribPointer (IIIZIJ)V
+	METHOD _vertexAttribPointer (IIIZIJ)V
 		ARG 0 index
 		ARG 1 size
 		ARG 2 type
 		ARG 3 normalized
 		ARG 4 stride
 		ARG 5 pointer
-	METHOD _viewport _viewport (IIII)V
+	METHOD _viewport (IIII)V
 		ARG 0 x
 		ARG 1 y
 		ARG 2 width
 		ARG 3 height
-	METHOD getBoundFramebuffer getBoundFramebuffer ()I
-	METHOD glActiveTexture glActiveTexture (I)V
+	METHOD glActiveTexture (I)V
 		ARG 0 texture
-	METHOD glAttachShader glAttachShader (II)V
+	METHOD glAttachShader (II)V
 		ARG 0 program
 		ARG 1 shader
-	METHOD glBlendFuncSeparate glBlendFuncSeparate (IIII)V
+	METHOD glBlendFuncSeparate (IIII)V
 		ARG 0 srcFactorRGB
 		ARG 1 dstFactorRGB
 		ARG 2 srcFactorAlpha
 		ARG 3 dstFactorAlpha
-	METHOD glCheckFramebufferStatus glCheckFramebufferStatus (I)I
+	METHOD glCheckFramebufferStatus (I)I
 		ARG 0 target
-	METHOD glCompileShader glCompileShader (I)V
+	METHOD glCompileShader (I)V
 		ARG 0 shader
-	METHOD glCreateProgram glCreateProgram ()I
-	METHOD glCreateShader glCreateShader (I)I
+	METHOD glCreateShader (I)I
 		ARG 0 type
-	METHOD glDeleteProgram glDeleteProgram (I)V
+	METHOD glDeleteProgram (I)V
 		ARG 0 program
-	METHOD glDeleteShader glDeleteShader (I)V
+	METHOD glDeleteShader (I)V
 		ARG 0 shader
-	METHOD glGenFramebuffers glGenFramebuffers ()I
-	METHOD glGenRenderbuffers glGenRenderbuffers ()I
-	METHOD glGetProgramInfoLog glGetProgramInfoLog (II)Ljava/lang/String;
+	METHOD glGetProgramInfoLog (II)Ljava/lang/String;
 		ARG 0 program
 		ARG 1 maxLength
-	METHOD glGetProgrami glGetProgrami (II)I
+	METHOD glGetProgrami (II)I
 		ARG 0 program
 		ARG 1 pname
-	METHOD glGetShaderInfoLog glGetShaderInfoLog (II)Ljava/lang/String;
+	METHOD glGetShaderInfoLog (II)Ljava/lang/String;
 		ARG 0 shader
 		ARG 1 maxLength
-	METHOD glGetShaderi glGetShaderi (II)I
+	METHOD glGetShaderi (II)I
 		ARG 0 shader
 		ARG 1 pname
-	METHOD glLinkProgram glLinkProgram (I)V
+	METHOD glLinkProgram (I)V
 		ARG 0 program
-	METHOD glShaderSource glShaderSource (ILjava/util/List;)V
+	METHOD glShaderSource (ILjava/util/List;)V
 		ARG 0 shader
 		ARG 1 strings
 	METHOD lambda$static$0 (I)Lcom/mojang/blaze3d/platform/GlStateManager$C_vgejkzlz;
 		ARG 0 id
-	METHOD setupGui3DDiffuseLighting setupGui3DDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
+	METHOD setupGui3DDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
 		ARG 0 light0
 		ARG 1 light1
-	METHOD setupGuiFlatDiffuseLighting setupGuiFlatDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
+	METHOD setupGuiFlatDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
 		ARG 0 light0
 		ARG 1 light1
-	METHOD setupLevelDiffuseLighting setupWorldDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;Lorg/joml/Matrix4f;)V
+	METHOD setupLevelDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;Lorg/joml/Matrix4f;)V
 		ARG 0 light0
 		ARG 1 light1
 		ARG 2 modelMatrix
-	METHOD upload upload (IIIIILnet/minecraft/unmapped/C_ayikuhxa$C_pfzicqtf;Ljava/nio/IntBuffer;Ljava/util/function/Consumer;)V
+	METHOD upload (IIIIILnet/minecraft/unmapped/C_ayikuhxa$C_pfzicqtf;Ljava/nio/IntBuffer;Ljava/util/function/Consumer;)V
 		ARG 0 mipLevels
 		ARG 1 xOffset
 		ARG 2 yOffset
@@ -377,6 +363,10 @@ CLASS com/mojang/blaze3d/platform/GlStateManager com/mojang/blaze3d/platform/GlS
 		FIELD f_yldbwizx value I
 		METHOD <init> (Ljava/lang/String;II)V
 			ARG 3 value
+	CLASS C_hjoiptsm FramebufferState
+		FIELD f_wipywpki binding I
+		METHOD m_rwmcpbbg update (I)Z
+			ARG 1 binding
 	CLASS C_jwjvoryv DepthTestState
 		FIELD f_ibvgpdgq capState Lcom/mojang/blaze3d/platform/GlStateManager$C_rfswymsl;
 		FIELD f_rxshfals func I

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -232,10 +232,6 @@ CLASS com/mojang/blaze3d/platform/GlStateManager
 		ARG 5 type
 		ARG 6 pixels
 	METHOD _scissorBox (IIII)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 height
-		ARG 3 width
 	METHOD _stencilFunc (III)V
 		ARG 0 func
 		ARG 1 ref
@@ -346,7 +342,7 @@ CLASS com/mojang/blaze3d/platform/GlStateManager
 	METHOD setupGuiFlatDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
 		ARG 0 light0
 		ARG 1 light1
-	METHOD setupLevelDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;Lorg/joml/Matrix4f;)V
+	METHOD setupLevelDiffuseLighting setupWorldDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;Lorg/joml/Matrix4f;)V
 		ARG 0 light0
 		ARG 1 light1
 		ARG 2 modelMatrix

--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -1,5 +1,4 @@
-CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderSystem
-	FIELD LOGGER LOGGER Lorg/slf4j/Logger;
+CLASS com/mojang/blaze3d/systems/RenderSystem
 	FIELD MAX_SUPPORTED_TEXTURE_SIZE maxSupportedTextureSize I
 	FIELD MINIMUM_ATLAS_TEXTURE_SIZE MINIMUM_ATLAS_TEXTURE_SIZE I
 	FIELD RENDER_THREAD_TESSELATOR RENDER_THREAD_TESSELLATOR Lnet/minecraft/unmapped/C_hiiunyvh;
@@ -28,8 +27,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 	FIELD vertexSorting vertexSorting Lnet/minecraft/unmapped/C_onfzhami;
 	METHOD activeTexture activeTexture (I)V
 		ARG 0 texture
-	METHOD assertOnRenderThread assertOnRenderThread ()V
-	METHOD assertOnRenderThreadOrInit assertOnRenderThreadOrInit ()V
 	METHOD backupProjectionMatrix backupProjectionMatrix ()V
 	METHOD beginInitialization beginInitialization ()V
 	METHOD bindTexture bindTexture (I)V
@@ -68,7 +65,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 		ARG 1 green
 		ARG 2 blue
 		ARG 3 alpha
-	METHOD constructThreadException constructThreadException ()Ljava/lang/IllegalStateException;
 	METHOD defaultBlendFunc defaultBlendFunc ()V
 	METHOD deleteTexture deleteTexture (I)V
 		ARG 0 texture
@@ -79,7 +75,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 	METHOD disableBlend disableBlend ()V
 	METHOD disableColorLogicOp disableColorLogicOp ()V
 	METHOD disableCull disableCull ()V
-	METHOD disableDepthTest disableDepthTest ()V
 	METHOD disablePolygonOffset disablePolygonOffset ()V
 	METHOD disableScissor disableScissor ()V
 	METHOD drawElements drawElements (III)V
@@ -89,9 +84,8 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 	METHOD enableBlend enableBlend ()V
 	METHOD enableColorLogicOp enableColorLogicOp ()V
 	METHOD enableCull enableCull ()V
-	METHOD enableDepthTest enableDepthTest ()V
 	METHOD enablePolygonOffset enablePolygonOffset ()V
-	METHOD enableScissor enableScissor (IIII)V
+	METHOD enableScissor (IIII)V
 		ARG 0 x
 		ARG 1 y
 		ARG 2 width
@@ -173,9 +167,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 	METHOD initRenderer initRenderer (IZ)V
 		ARG 0 debugVerbosity
 		ARG 1 debugSync
-	METHOD isFrozenAtPollEvents isFrozenAtPollEvents ()Z
-	METHOD isOnRenderThread isOnRenderThread ()Z
-	METHOD isOnRenderThreadOrInit isOnRenderThreadOrInit ()Z
 	METHOD lambda$static$0 (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
 		ARG 0 indexBuilder
 		ARG 1 primitiveId
@@ -192,7 +183,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 	METHOD pixelStore pixelStore (II)V
 		ARG 0 pname
 		ARG 1 param
-	METHOD pollEvents pollEvents ()V
 	METHOD polygonMode polygonMode (II)V
 		ARG 0 face
 		ARG 1 mode
@@ -207,7 +197,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem com/mojang/blaze3d/systems/RenderS
 		ARG 4 format
 		ARG 5 type
 		ARG 6 pixels
-	METHOD recordRenderCall recordRenderCall (Lnet/minecraft/unmapped/C_ycxumudt;)V
+	METHOD recordRenderCall (Lnet/minecraft/unmapped/C_ycxumudt;)V
 		ARG 0 renderCall
 	METHOD renderCrosshair renderCrosshair (I)V
 		ARG 0 size

--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -86,10 +86,6 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 	METHOD enableCull enableCull ()V
 	METHOD enablePolygonOffset enablePolygonOffset ()V
 	METHOD enableScissor (IIII)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 width
-		ARG 3 height
 	METHOD finishInitialization finishInitialization ()V
 	METHOD flipFrame flipFrame (J)V
 		ARG 0 window
@@ -248,7 +244,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 	METHOD setupGuiFlatDiffuseLighting setupGuiFlatDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
 		ARG 0 light0
 		ARG 1 light1
-	METHOD setupLevelDiffuseLighting setupLevelDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
+	METHOD setupLevelDiffuseLighting setupWorldDiffuseLighting (Lorg/joml/Vector3f;Lorg/joml/Vector3f;)V
 	METHOD setupOverlayColor setupOverlayColor (II)V
 		ARG 1 color
 	METHOD setupShaderLights setupShaderLights (Lnet/minecraft/unmapped/C_alllhitb;)V


### PR DESCRIPTION
and delete a lot of "mark as deobf" mappings. i built this feature ages ago so we'd stop doing that and never turned it on
- removes "file not mapping a class" error. it's a good idea, but doesn't support name proposal