### PR TITLE
Map OggAudioStream and some related stuff

### DIFF
--- a/mappings/net/minecraft/client/sound/BufferedAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/BufferedAudioStream.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_sotxsrbb net/minecraft/client/sound/BufferedAudioStream
+	FIELD f_iciccron EXPECTED_MAX_FRAME_SIZE I
+	METHOD m_oxmnkscz readFrame (Lit/unimi/dsi/fastutil/floats/FloatConsumer;)Z
+		ARG 1 output

--- a/mappings/net/minecraft/client/sound/ChannelList.mapping
+++ b/mappings/net/minecraft/client/sound/ChannelList.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/unmapped/C_hwtbkxpz net/minecraft/client/sound/ChannelList
+	FIELD f_bfvadbcu currentBufferSize I
+	FIELD f_bztfudnt buffers Ljava/util/List;
+	FIELD f_nadhdvvb buffer Ljava/nio/ByteBuffer;
+	FIELD f_yoooifrn size I
+	METHOD <init> (I)V
+		ARG 1 bufferSize
+	METHOD accept addChannel (F)V
+		ARG 1 data
+	METHOD m_tbwtswjb getBuffer ()Ljava/nio/ByteBuffer;
+	METHOD m_vcsjohlh getCurrentBufferSize ()I

--- a/mappings/net/minecraft/client/sound/FiniteAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/FiniteAudioStream.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_sxqhbpzn net/minecraft/client/sound/FiniteAudioStream
+	METHOD m_lmmmaoqk getBuffer ()Ljava/nio/ByteBuffer;

--- a/mappings/net/minecraft/client/sound/OggAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/OggAudioStream.mapping
@@ -1,0 +1,43 @@
+CLASS net/minecraft/unmapped/C_osybdcpo net/minecraft/client/sound/OggAudioStream
+	FIELD f_bnzdhjzq EXPECTED_MAX_FRAME_SIZE I
+	FIELD f_ctqdwixq MAX_SAMPLES J
+	FIELD f_dgqtinlj state Lcom/jcraft/jogg/StreamState;
+	FIELD f_djhpehah soundProcessor Lcom/jcraft/jorbis/DspState;
+	FIELD f_ejavwrtw inputStream Ljava/io/InputStream;
+	FIELD f_euzzfoxr samplesWritten J
+	FIELD f_mdavmxfj syncState Lcom/jcraft/jogg/SyncState;
+	FIELD f_pilmrhpz frame Lcom/jcraft/jogg/Page;
+	FIELD f_qlbmiuko rawAudioFrame Lcom/jcraft/jogg/Packet;
+	FIELD f_qtbdzokq processedAudioFrame Lcom/jcraft/jorbis/Block;
+	FIELD f_vzbyyvhw format Ljavax/sound/sampled/AudioFormat;
+	FIELD f_wahodjuq properties Lcom/jcraft/jorbis/Info;
+	METHOD <init> (Ljava/io/InputStream;)V
+		ARG 1 inputStream
+	METHOD close close ()V
+	METHOD m_asdsaorv readAllChannels ([[FI[IJLit/unimi/dsi/fastutil/floats/FloatConsumer;)V
+		ARG 0 channelBuffers
+		ARG 1 channelCount
+		ARG 2 startIndexes
+		ARG 3 samplesToWrite
+		ARG 5 output
+	METHOD m_bimljqtb readPage ()Lcom/jcraft/jogg/Page;
+	METHOD m_bywsuebv getSampleToWrite (I)J
+		ARG 1 samples
+	METHOD m_bzwaelxt getRawAudio ()Lcom/jcraft/jogg/Packet;
+	METHOD m_eeeoajbz readMono ([FIJLit/unimi/dsi/fastutil/floats/FloatConsumer;)V
+		ARG 0 buf
+		ARG 1 startIndex
+		ARG 2 samplesToWrite
+		ARG 4 output
+	METHOD m_izjvnksj readStereo ([FI[FIJLit/unimi/dsi/fastutil/floats/FloatConsumer;)V
+		ARG 0 leftBuf
+		ARG 1 leftStartIndex
+		ARG 2 rightBuf
+		ARG 3 rightStartIndex
+		ARG 4 samplesToWrite
+		ARG 6 output
+	METHOD m_nceiwgbq isInvalid (I)Z
+		ARG 0 state
+	METHOD m_sszxrscr isFinished ()Z
+	METHOD m_vdfmjcwj getPacket (Lcom/jcraft/jogg/Page;)Lcom/jcraft/jogg/Packet;
+		ARG 1 page

--- a/mappings/net/minecraft/client/sound/OggAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/OggAudioStream.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/unmapped/C_osybdcpo net/minecraft/client/sound/OggAudioStream
 	FIELD f_bnzdhjzq EXPECTED_MAX_FRAME_SIZE I
-	FIELD f_ctqdwixq MAX_SAMPLES J
+	FIELD f_ctqdwixq totalSamplesInStream J
 	FIELD f_dgqtinlj state Lcom/jcraft/jogg/StreamState;
 	FIELD f_djhpehah soundProcessor Lcom/jcraft/jorbis/DspState;
 	FIELD f_ejavwrtw inputStream Ljava/io/InputStream;


### PR DESCRIPTION
Somehow it’s mapping got lost when Mojang rewrote it in 1.20.5-pre1. I’ve stuck to the old (before 1.20.5-pre1) names as far as possible, and for the rest I cross-referenced them with Parchment, the old QuiltMappings file for it and Mojmap. Let me know if something is off.