### PR TITLE
fix method conflict in `RegistrySetBuilder`

### DIFF
--- a/mappings/net/minecraft/registry/RegistrySetBuilder.mapping
+++ b/mappings/net/minecraft/registry/RegistrySetBuilder.mapping
@@ -89,7 +89,7 @@ CLASS net/minecraft/unmapped/C_tncydixy net/minecraft/registry/RegistrySetBuilde
 		METHOD <init> (Lnet/minecraft/unmapped/C_hkebgttw;Lnet/minecraft/unmapped/C_vtbxyypo$C_drwjtlvl;)V
 			ARG 1 owner
 	CLASS C_vcrasote
-		METHOD m_bpnnoeac get (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/Optional;
+		METHOD m_bpnnoeac getEntry (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/Optional;
 			ARG 1 registry
 	CLASS C_vmdfhvom LazyHolder
 		FIELD f_rekjfnjh supplier Ljava/util/function/Supplier;


### PR DESCRIPTION
the private method `get` in the anonymous class defined in `RegistrySetBuilder#buildProvider` conflicted with the method `get` in an implemented interface `HolderProvider.Provider`. this changes the name to `getEntry` (from mojmap).