### PR TITLE
add a test to make sure broken unpick definitions error

### DIFF
--- a/buildSrc/src/test/java/quilt/internal/TasksTest.java
+++ b/buildSrc/src/test/java/quilt/internal/TasksTest.java
@@ -1,5 +1,6 @@
 package quilt.internal;
 
+import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
 import net.fabricmc.mappingio.tree.MappingTree;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -48,6 +49,7 @@ public class TasksTest {
     private static Path mappingsDir;
     private static Path profilePath;
     private static Path unpickDefinitions;
+    private static Path brokenUnpickDefinitions;
 
     private static Path perVersionMappingsJar;
     private static Path outputsDir;
@@ -91,6 +93,7 @@ public class TasksTest {
         mappingsDir = testProjectDir.resolve("mappings/");
         profilePath = testProjectDir.resolve("enigma_profile.json");
         unpickDefinitions = testProjectDir.resolve("unpick-definitions/");
+        brokenUnpickDefinitions = testProjectDir.resolve("broken-unpick-definitions/");
 
         perVersionMappings = getResource("/test-intermediate.tiny");
         perVersionMappingsJar = testProjectDir.resolve("test-hashed.jar");
@@ -261,6 +264,13 @@ public class TasksTest {
         assertTrue(file.isSimpleConstantGroup("g_type"));
         assertEquals("g_type", file.getParameterConstantGroup("com/example/GClass", "fromType", "(I)Ljava/lang/String;", 0));
         assertEquals("g_type", file.getReturnConstantGroup("com/example/GClass", "toType", "(Ljava/lang/String;)I"));
+    }
+
+    @Test
+    public void testCombineBrokenUnpickDefinitions() {
+        Path output = outputsDir.resolve("broken-combined-definitions.unpick");
+        Collection<File> input = List.of(brokenUnpickDefinitions.toFile().listFiles());
+        assertThrows(UnpickSyntaxException.class, () -> CombineUnpickDefinitionsTask.combineUnpickDefinitions(input, output));
     }
 
     @Test

--- a/buildSrc/src/test/java/quilt/internal/TestUtil.java
+++ b/buildSrc/src/test/java/quilt/internal/TestUtil.java
@@ -42,19 +42,19 @@ public class TestUtil {
     }
 
     public static MemoryMappingTree readTinyV2(Path path) throws IOException {
-        return readTree(path, MappingFormat.TINY_2);
+        return readTree(path, MappingFormat.TINY_2_FILE);
     }
 
     public static void writeTinyV2(Path path, MappingTree tree) throws IOException {
-        writeTree(path, tree, MappingFormat.TINY_2);
+        writeTree(path, tree, MappingFormat.TINY_2_FILE);
     }
 
     public static MemoryMappingTree readEnigma(Path path) throws IOException {
-        return readTree(path, MappingFormat.ENIGMA);
+        return readTree(path, MappingFormat.ENIGMA_DIR);
     }
 
     public static void writeEnigma(Path path, MappingTree tree) throws IOException {
-        writeTree(path, tree, MappingFormat.ENIGMA);
+        writeTree(path, tree, MappingFormat.ENIGMA_DIR);
     }
 
     public static UnpickFile readUnpickFile(Path path, Path jar) throws Exception {

--- a/buildSrc/src/test/resources/testProject/broken-unpick-definitions/no_header.unpick
+++ b/buildSrc/src/test/resources/testProject/broken-unpick-definitions/no_header.unpick
@@ -1,0 +1,5 @@
+flag f_flags com/example/FEnum FLAG_LEFT
+flag f_flags com/example/FEnum FLAG_RIGHT
+
+target_method com/example/FEnum <init> (Ljava/lang/String;II)V
+	param 0 f_flags

--- a/buildSrc/src/test/resources/testProject/broken-unpick-definitions/working.unpick
+++ b/buildSrc/src/test/resources/testProject/broken-unpick-definitions/working.unpick
@@ -1,0 +1,10 @@
+v2
+
+flag e_flags com/example/EClass FLAG_A
+flag e_flags com/example/EClass FLAG_B
+flag e_flags com/example/EClass FLAG_C
+flag e_flags com/example/EClass FLAG_D
+
+# Test comment
+target_method com/example/EClass m1 (I)V
+	param 0 e_flags

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ enigma = "2.5.0"
 enigma_plugin = "2.2.3"
 tiny_remapper = "0.7.2"
 stitch = "0.6.1"
-unpick = "3.0.9"
+unpick = "3.0.10"
 mapping_io = "0.6.1"
 javadoc_draftsman = "1.2.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ enigma = "2.5.0"
 enigma_plugin = "2.2.3"
 tiny_remapper = "0.7.2"
 stitch = "0.6.1"
-unpick = "3.0.8+local"
+unpick = "3.0.9"
 mapping_io = "0.6.1"
 javadoc_draftsman = "1.2.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ enigma = "2.5.0"
 enigma_plugin = "2.2.3"
 tiny_remapper = "0.7.2"
 stitch = "0.6.1"
-unpick = "3.0.8"
+unpick = "3.0.8+local"
 mapping_io = "0.6.1"
 javadoc_draftsman = "1.2.3"
 


### PR DESCRIPTION
goes along with quiltmc/unpick#3

makes sure that if unpick files are broken `combineUnpickDefinitions` will fail. also fixes the buildscript tests being broken to MIO updates