### PR TITLE
fix 'overrides final method' error

### DIFF
--- a/mappings/net/minecraft/entity/InteractionEntity.mapping
+++ b/mappings/net/minecraft/entity/InteractionEntity.mapping
@@ -9,15 +9,15 @@ CLASS net/minecraft/unmapped/C_hvnhlgso net/minecraft/entity/InteractionEntity
 	FIELD f_xnjxidmy ATTACK_KEY Ljava/lang/String;
 	FIELD f_ygkdbibs HEIGHT_KEY Ljava/lang/String;
 	FIELD f_ztmqbiqd RESPONSE_KEY Ljava/lang/String;
-	METHOD m_acettnna getDimensions ()Lnet/minecraft/unmapped/C_sszpscpo;
-	METHOD m_dyvbaohz getHeight ()F
-	METHOD m_mcajgzfg getWidth ()F
+	METHOD m_acettnna getInteractionDimensions ()Lnet/minecraft/unmapped/C_sszpscpo;
+	METHOD m_dyvbaohz getInteractionHeight ()F
+	METHOD m_mcajgzfg getInteractionWidth ()F
 	METHOD m_oeurfxnz setResponse (Z)V
 		ARG 1 response
 	METHOD m_stegizgr getResponse ()Z
-	METHOD m_uesbqavb setWidth (F)V
+	METHOD m_uesbqavb setInteractionWidth (F)V
 		ARG 1 width
-	METHOD m_yvnkyldm setHeight (F)V
+	METHOD m_yvnkyldm setInteractionHeight (F)V
 		ARG 1 height
 	CLASS C_nzivpjdf Interaction
 		FIELD f_dckrisox CODEC Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/entity/InteractionEntity.mapping
+++ b/mappings/net/minecraft/entity/InteractionEntity.mapping
@@ -2,8 +2,8 @@ CLASS net/minecraft/unmapped/C_hvnhlgso net/minecraft/entity/InteractionEntity
 	FIELD f_ckdsvier WIDTH_KEY Ljava/lang/String;
 	FIELD f_ctyumtqt interaction Lnet/minecraft/unmapped/C_hvnhlgso$C_nzivpjdf;
 	FIELD f_jzdfpkpp attack Lnet/minecraft/unmapped/C_hvnhlgso$C_nzivpjdf;
-	FIELD f_luxekrhz HEIGHT Lnet/minecraft/unmapped/C_rinmcaxy;
-	FIELD f_rmbogufh WIDTH Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_luxekrhz INTERACTION_HEIGHT Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_rmbogufh INTERACTION_WIDTH Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_vvmxstjr INTERACTION_KEY Ljava/lang/String;
 	FIELD f_vxdufukm RESPONSE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_xnjxidmy ATTACK_KEY Ljava/lang/String;


### PR DESCRIPTION
Fixes this error which occurs on launch when using 1.21.4-build.1:
```
java.lang.IncompatibleClassChangeError: class net.minecraft.entity.InteractionEntity overrides final method net.minecraft.entity.Entity.getHeight()F
```