### PR TITLE
add mappings for Rarity

### DIFF
--- a/mappings/net/minecraft/util/Rarity.mapping
+++ b/mappings/net/minecraft/util/Rarity.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/unmapped/C_mqmixksm net/minecraft/util/Rarity
 	FIELD f_efjldeaw formatting Lnet/minecraft/unmapped/C_tnezalvh;
+	FIELD f_gahweovi name Ljava/lang/String;
+	METHOD m_waqdxpfx getFormatting ()Lnet/minecraft/unmapped/C_tnezalvh;


### PR DESCRIPTION
Add mappings to the `net.minecraft.util.Rarity` class for its `name` field and its `formatting` getter method. The name for the String field comes from other implementations of `StringIdentifiable` such as `DyeColor`, `Direction`, and `LiquidSettings` where they all have a matching field named `name`. The formatting getter was named following the convention for non-boolean getters as `getFormatting`.

I'm glad to find a way I can help contribute back to quilt! 