### PR TITLE
add missing CommonColor constants

### DIFF
--- a/mappings/net/minecraft/util/CommonColors.mapping
+++ b/mappings/net/minecraft/util/CommonColors.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/unmapped/C_oauvuath net/minecraft/util/CommonColors
 	FIELD f_bcspjcwq LIGHT_GRAY I
 	FIELD f_fdbmklve LIGHT_YELLOW I
 	FIELD f_hxnrjiec BLACK I
-	FIELD f_mbpvtspr ALTERNATE_WHITE I
+	FIELD f_mbpvtspr LIGHTER_GRAY I
 	FIELD f_ocmjathi BLUE I
 	FIELD f_qlmrjxqb WHITE I
 	FIELD f_qzyevrxu LIGHT_RED I

--- a/mappings/net/minecraft/util/CommonColors.mapping
+++ b/mappings/net/minecraft/util/CommonColors.mapping
@@ -5,6 +5,9 @@ CLASS net/minecraft/unmapped/C_oauvuath net/minecraft/util/CommonColors
 	FIELD f_bcspjcwq LIGHT_GRAY I
 	FIELD f_fdbmklve LIGHT_YELLOW I
 	FIELD f_hxnrjiec BLACK I
+	FIELD f_mbpvtspr ALTERNATE_WHITE I
+	FIELD f_ocmjathi BLUE I
 	FIELD f_qlmrjxqb WHITE I
 	FIELD f_qzyevrxu LIGHT_RED I
+	FIELD f_tqdlcziy GREEN I
 	FIELD f_vzujugkt GRAY I


### PR DESCRIPTION
Add missing constant names in `CommonColors`. `BLUE`, `GREEN`, and `ALTERNATE_WHITE` were unmapped. Names for blue and green are self explanatory, `ALTERNATE_WHITE` comes from yarn.