### PR TITLE
add mappings for LocationPredicate.Builder fields and setter methods

### DIFF
--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -40,6 +40,8 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 		METHOD m_diuvndpc light (Lnet/minecraft/unmapped/C_ammgthmo$C_kadjxsdu;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 builder
 		METHOD m_dkdenbmq structures (Lnet/minecraft/unmapped/C_odfnijdo;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+			ARG 1 structures
+
 		METHOD m_dsbslmxh z (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 z
 		METHOD m_dxvijcur fluid (Lnet/minecraft/unmapped/C_fjarvlro$C_ahtnwewe;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;

--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -54,6 +54,7 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 			ARG 1 builder
 		METHOD m_idydmjlz create ()Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_jklecett structure (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+			ARG 0 structure
 		METHOD m_lsutwusu biome (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_mkgxbhcm canSeeSky (Z)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_onghaezr dimension (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;

--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -56,6 +56,7 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 		METHOD m_jklecett structure (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 0 structure
 		METHOD m_lsutwusu biome (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+			ARG 0 biome
 		METHOD m_mkgxbhcm canSeeSky (Z)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_onghaezr dimension (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 dimension

--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -58,6 +58,7 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 		METHOD m_lsutwusu biome (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 0 biome
 		METHOD m_mkgxbhcm canSeeSky (Z)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+			ARG 1 canSeeSky
 		METHOD m_onghaezr dimension (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 dimension
 		METHOD m_qkyrpclg createWithY (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;

--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -9,7 +9,11 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
+	METHOD m_yciuynsr (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
 	CLASS C_gcijxrat PositionRange
+		METHOD m_bhbuulsr (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
 		METHOD m_gjufjxkq z ()Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;
 		METHOD m_msjfphrw test (DDD)Z
 			ARG 1 x
@@ -22,16 +26,20 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 			ARG 2 z
 		METHOD m_zitylnny x ()Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;
 	CLASS C_okutxubz Builder
+		FIELD f_botkjajr structures Ljava/util/Optional;
 		FIELD f_dnpxvyqk fluid Ljava/util/Optional;
 		FIELD f_dsialmis block Ljava/util/Optional;
 		FIELD f_fhwlhfkz z Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;
+		FIELD f_hgqqelqt biomes Ljava/util/Optional;
 		FIELD f_hyqkkafq x Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;
+		FIELD f_pdhpiijj canSeeSky Ljava/util/Optional;
 		FIELD f_qasujtxj dimension Ljava/util/Optional;
 		FIELD f_vgpejppz y Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;
 		FIELD f_xezgeelf light Ljava/util/Optional;
 		FIELD f_yijrvruc smokey Ljava/util/Optional;
 		METHOD m_diuvndpc light (Lnet/minecraft/unmapped/C_ammgthmo$C_kadjxsdu;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 builder
+		METHOD m_dkdenbmq structures (Lnet/minecraft/unmapped/C_odfnijdo;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_dsbslmxh z (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 z
 		METHOD m_dxvijcur fluid (Lnet/minecraft/unmapped/C_fjarvlro$C_ahtnwewe;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
@@ -43,9 +51,13 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 		METHOD m_hibprzfm block (Lnet/minecraft/unmapped/C_uuwlfkxz$C_nlqurblw;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 builder
 		METHOD m_idydmjlz create ()Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+		METHOD m_jklecett structure (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+		METHOD m_lsutwusu biome (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+		METHOD m_mkgxbhcm canSeeSky (Z)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_onghaezr dimension (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 dimension
 		METHOD m_qkyrpclg createWithY (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+		METHOD m_sizzovtm biomes (Lnet/minecraft/unmapped/C_odfnijdo;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_umdksspn x (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 x
 		METHOD m_xrknskqs createWithWorld (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;

--- a/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/LocationPredicate.mapping
@@ -63,6 +63,7 @@ CLASS net/minecraft/unmapped/C_ypvebgnl net/minecraft/predicate/entity/LocationP
 			ARG 1 dimension
 		METHOD m_qkyrpclg createWithY (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 		METHOD m_sizzovtm biomes (Lnet/minecraft/unmapped/C_odfnijdo;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
+			ARG 1 biomes
 		METHOD m_umdksspn x (Lnet/minecraft/unmapped/C_nihhkamy$C_qatgyzfn;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;
 			ARG 1 x
 		METHOD m_xrknskqs createWithWorld (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_ypvebgnl$C_okutxubz;


### PR DESCRIPTION
map builder methods (and fields) for `LocationPredicate.Builder`. Names are to match with those already in `LocationPredicate`, just not in its builder.