### PR TITLE
Block restoration

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -261,6 +261,7 @@ seagrass
 shroomlight
 terracotta
 torchflower
+eyeblossom
 
 // pot patterns
 guster

--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -239,6 +239,7 @@ blockpredicate
 blockstate
 infiniburn
 stateprovider
+multiface
 
 // blocks
 blackstone

--- a/enigma/simple_type_field_names.json5
+++ b/enigma/simple_type_field_names.json5
@@ -118,6 +118,11 @@
       "blockSettings"
     ]
   },
+  "net/minecraft/unmapped/C_kvegafmh": { // BlockEntity
+    local_name: "blockEntity",
+    exclusive: true,
+    inherit: true
+  },
 
   // Item
   "net/minecraft/unmapped/C_sddaxwyk": "stack", // ItemStack

--- a/mappings/net/minecraft/SpreadingMultifaceBlock.mapping
+++ b/mappings/net/minecraft/SpreadingMultifaceBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_kxpovstt net/minecraft/SpreadingMultifaceBlock
+	METHOD m_uuxipekm getSpreadBehavior ()Lnet/minecraft/unmapped/C_twpgwpwn;

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	FIELD f_eagudpej slipperiness F
 	FIELD f_gtipwtfw requiredFlags Lnet/minecraft/unmapped/C_czxxrbcp;
 	FIELD f_hcgxjldr jumpVelocityMultiplier F
-	FIELD f_hflsieep lootTableId Ljava/util/Optional;
+	FIELD f_hflsieep lootTable Ljava/util/Optional;
 	FIELD f_hpfrgdhl velocityMultiplier F
 	FIELD f_hskzbzfq settings Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 	FIELD f_lyvgdypq soundGroup Lnet/minecraft/unmapped/C_aevintex;
@@ -93,6 +93,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 entity
+		ARG 5 effectManager
 	METHOD m_mfmohedo hasSidedTransparency (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
 	METHOD m_mjglzdvu getRenderType (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_obvqhpgv;
@@ -111,7 +112,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 2 stateFrom
 		ARG 3 direction
 	METHOD m_orfjlsuz getPickStack (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Z)Lnet/minecraft/unmapped/C_sddaxwyk;
-		ARG 4 withComponents
+		ARG 4 includeComponents
 	METHOD m_pguoxmgn onUse (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_jdakttms;)Lnet/minecraft/unmapped/C_ozuepbyj;
 		ARG 4 entity
 		ARG 5 hitResult
@@ -139,7 +140,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 3 pos
 		ARG 4 stack
 		ARG 5 dropExperience
-	METHOD m_qodrklgm getLootTableId ()Ljava/util/Optional;
+	METHOD m_qodrklgm getLootTable ()Ljava/util/Optional;
 	METHOD m_qzmkwuwe canReplace (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_aiootljq;)Z
 		ARG 1 state
 		ARG 2 context
@@ -165,6 +166,8 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		ARG 4 block
 		ARG 5 orientation
 		ARG 6 notify
+	METHOD m_twpfvvna onReplaced (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Z)V
+		ARG 4 suppressUpdates
 	METHOD m_umbsjste rotate (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_mboglirk;)Lnet/minecraft/unmapped/C_txtbiemp;
 		COMMENT Applies a block rotation to a block state.
 		COMMENT
@@ -309,6 +312,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			COMMENT Gets the possibly updated block state of this block when a neighboring block is updated.
 			COMMENT
 			COMMENT @return the new state of this block
+			ARG 2 tickAccess
 			ARG 3 pos
 				COMMENT the position of this block
 			ARG 4 direction
@@ -344,6 +348,8 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 2 pos
 		METHOD m_iaogtews getRenderingSeed (Lnet/minecraft/unmapped/C_hynzadkk;)J
 			ARG 1 pos
+		METHOD m_ibhctugj getPickStack (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Z)Lnet/minecraft/unmapped/C_sddaxwyk;
+			ARG 3 includeComponents
 		METHOD m_ikryvqun isSolid ()Z
 		METHOD m_iqyhrmls materialReplaceable ()Z
 		METHOD m_iznnuukl canPathfindThrough (Lnet/minecraft/unmapped/C_kjwlgpfr;)Z
@@ -450,6 +456,9 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 1 world
 			ARG 2 pos
 			ARG 3 entity
+			ARG 4 effectManager
+		METHOD m_umphpklk onReplaced (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Z)V
+			ARG 3 suppressUpdates
 		METHOD m_umxslqzf isIn (Lnet/minecraft/unmapped/C_ednuhnnn;)Z
 			COMMENT {@return whether this block is in the specified tag}
 			ARG 1 tag
@@ -538,6 +547,8 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 	CLASS C_hqjgaunn OffsetType
 	CLASS C_izsedryc ContextPredicate
 	CLASS C_knnwryez TypedContextPredicate
+		METHOD test (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/lang/Object;)Z
+			ARG 4 type
 	CLASS C_mlfsdncu OffsetFunction
 	CLASS C_xnkxsdfy Settings
 		FIELD f_bhzlstcj postProcessPredicate Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
@@ -549,6 +560,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		FIELD f_eioycbda key Lnet/minecraft/unmapped/C_xhhleach;
 		FIELD f_gepbjyhg nonSolid Z
 		FIELD f_gljcimhm emissiveLightingPredicate Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
+		FIELD f_gxswpnob translationKey Lnet/minecraft/unmapped/C_jquyxssk;
 		FIELD f_hgzeyqby randomTicks Z
 		FIELD f_hzpexiar mapColorGetter Ljava/util/function/Function;
 		FIELD f_ivzlotoq replaceable Z
@@ -563,7 +575,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		FIELD f_obppjqdx opaque Z
 		FIELD f_pgktgiev offsetFunction Lnet/minecraft/unmapped/C_triydqro$C_mlfsdncu;
 		FIELD f_piwzbwkw suffocationPredicate Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
-		FIELD f_pxqjcqnw lootTableId Lnet/minecraft/unmapped/C_jquyxssk;
+		FIELD f_pxqjcqnw lootTable Lnet/minecraft/unmapped/C_jquyxssk;
 		FIELD f_stojhpmj solid Z
 		FIELD f_vgbjitlh spawnsDustParticles Z
 		FIELD f_vncuqezy luminance Ljava/util/function/ToIntFunction;
@@ -575,6 +587,7 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		METHOD m_bcasjlrn variantOf (Lnet/minecraft/unmapped/C_triydqro;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			ARG 0 block
 		METHOD m_bwwgnswz solid ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		METHOD m_bybxvckr getLootTable ()Ljava/util/Optional;
 		METHOD m_bzhfzklk emissiveLighting (Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			ARG 1 predicate
 		METHOD m_cfcitqhx requiredFlags ([Lnet/minecraft/unmapped/C_kksdgidr;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
@@ -608,12 +621,21 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 		METHOD m_ixvdwzpv ticksRandomly ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 		METHOD m_jjsywpzh slipperiness (F)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			ARG 1 slipperiness
+		METHOD m_jzrlfqyp (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/lang/String;
+			ARG 0 key
 		METHOD m_ksnsduxl create ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 		METHOD m_lzknvbog hardness (F)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			ARG 1 hardness
 		METHOD m_mkgblwbl nonSolid ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 		METHOD m_mkiacirn air ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 		METHOD m_mylnzrvw mapColor (Lnet/minecraft/unmapped/C_vhpmxtfv;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+			ARG 1 color
+		METHOD m_nbpsnvhc lootTable (Ljava/util/Optional;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+			COMMENT Sets the block's loot table.
+			COMMENT <p>
+			COMMENT If not set explicitly via this method, the loot table will be derived from
+			COMMENT the block's {@linkplain #key(RegistryKey) registry key} with the form
+			COMMENT {@code <namespace>:blocks/<path>}.
 		METHOD m_nfvnphha allowsSpawning (Lnet/minecraft/unmapped/C_triydqro$C_knnwryez;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			COMMENT Specifies logic that calculates whether an entity can spawn on a block.
 			ARG 1 predicate
@@ -627,6 +649,15 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			COMMENT Specifies the light level emitted by a block.
 			ARG 1 luminance
 				COMMENT a per block state light level, with values between 0 and 15
+		METHOD m_oileiccy translationKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+			COMMENT Sets the block's translation key.
+			COMMENT <p>
+			COMMENT If not set explicitly via this method, the translation key will be derived from
+			COMMENT the block's {@linkplain #key(RegistryKey) registry key} with the form
+			COMMENT {@code block.<namespace>.<path>}.<br>
+			COMMENT Any {@code /} characters in the {@code <path>} will be replaced with
+			COMMENT {@code .} characters.
+			ARG 1 translationKey
 		METHOD m_pbfkvwez strength (F)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 			ARG 1 strength
 		METHOD m_riwmybec instrument (Lnet/minecraft/unmapped/C_onjtjtsi;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
@@ -639,7 +670,9 @@ CLASS net/minecraft/unmapped/C_triydqro net/minecraft/block/AbstractBlock
 			ARG 0 state
 			ARG 1 world
 			ARG 2 pos
+			ARG 3 type
 		METHOD m_shyyftwz toolRequired ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		METHOD m_telcghnd getTranslationKey ()Ljava/lang/String;
 		METHOD m_tzpskyoo (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 			ARG 0 state
 			ARG 1 world

--- a/mappings/net/minecraft/block/AbstractChestBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractChestBlock.mapping
@@ -4,3 +4,4 @@ CLASS net/minecraft/unmapped/C_mzhguxyu net/minecraft/block/AbstractChestBlock
 		ARG 1 settings
 		ARG 2 entityTypeSupplier
 	METHOD m_uywfrlmd getBlockEntitySource (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Z)Lnet/minecraft/unmapped/C_empmxbdt$C_rsioyjyt;
+		ARG 4 ignoreBlocked

--- a/mappings/net/minecraft/block/AbstractFireBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractFireBlock.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/unmapped/C_sluvsuoh net/minecraft/block/AbstractFireBlock
 	FIELD f_cbwcpwpk SET_ON_FIRE_SECONDS I
+	FIELD f_gsdnrrxi MAX_FIRE_TICK_INCREMENT I
 	FIELD f_kfbtyhkw damage F
+	FIELD f_orvmpxjl MIN_FIRE_TICK_INCREMENT I
+	FIELD f_yhbgdpbx SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;F)V
 		ARG 1 settings
 		ARG 2 damage
@@ -17,4 +20,5 @@ CLASS net/minecraft/unmapped/C_sluvsuoh net/minecraft/block/AbstractFireBlock
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 direction
+	METHOD m_vrlnhjwy ignite (Lnet/minecraft/unmapped/C_astfners;)V
 	METHOD m_vsetrugb isFlammable (Lnet/minecraft/unmapped/C_txtbiemp;)Z

--- a/mappings/net/minecraft/block/AbstractLeavesBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractLeavesBlock.mapping
@@ -1,0 +1,26 @@
+CLASS net/minecraft/unmapped/C_vpbrfrld net/minecraft/block/AbstractLeavesBlock
+	FIELD f_idpcqsbq DISTANCE Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_jfxclwgr particleChance F
+	FIELD f_kefxatay PERSISTENT Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_rjjksefw TICK_DELAY I
+	FIELD f_vpbxbcme WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_wlukwelu MAX_DISTANCE I
+	METHOD m_gpxzhkzd getDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;)I
+		ARG 0 state
+	METHOD m_hhmrqbor canDecay (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+		ARG 1 state
+	METHOD m_huyvbgdx getOptionalDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/OptionalInt;
+		ARG 0 state
+	METHOD m_jglawzkf spawnLeafParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)V
+	METHOD m_llppeccb trySpawnDripParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 1 pos
+		ARG 3 stateBelow
+		ARG 4 below
+	METHOD m_nadmcbtn trySpawnLeafParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 2 pos
+		ARG 4 stateBelow
+		ARG 5 below
+	METHOD m_qbhqdinb updateDistanceFromLogs (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 0 state
+		ARG 1 world
+		ARG 2 pos

--- a/mappings/net/minecraft/block/AbstractLeavesBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractLeavesBlock.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/unmapped/C_vpbrfrld net/minecraft/block/AbstractLeavesBlock
 		ARG 0 state
 	METHOD m_hhmrqbor canDecay (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
-	METHOD m_huyvbgdx getOptionalDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/OptionalInt;
+	METHOD m_huyvbgdx getDistanceFromLogOrEmpty (Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/OptionalInt;
 		ARG 0 state
 	METHOD m_jglawzkf spawnLeafParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)V
 	METHOD m_llppeccb trySpawnDripParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;)V
@@ -20,7 +20,7 @@ CLASS net/minecraft/unmapped/C_vpbrfrld net/minecraft/block/AbstractLeavesBlock
 		ARG 2 pos
 		ARG 4 stateBelow
 		ARG 5 below
-	METHOD m_qbhqdinb updateDistanceFromLogs (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_qbhqdinb updateDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/AbstractPlantBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPlantBlock.mapping
@@ -1,1 +1,2 @@
-CLASS net/minecraft/unmapped/C_bgdokvym net/minecraft/block/AbstractPlantBlock
+CLASS net/minecraft/unmapped/C_yqpevhlg net/minecraft/block/AbstractPlantBlock
+	METHOD m_fajehlrs canGrowOn (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z

--- a/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_lgaafbhj net/minecraft/block/AbstractPressurePlateBlock
 	FIELD f_dyltpxtf blockSetType Lnet/minecraft/unmapped/C_hgpogkhy;
 	FIELD f_hejzuhsz BOX Lnet/minecraft/unmapped/C_hbcjzgoe;
+	FIELD f_scjffrzn DEFAULT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_sfdrrxbe PRESSED_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;Lnet/minecraft/unmapped/C_hgpogkhy;)V
 		ARG 1 settings
 		ARG 2 blockSetType
@@ -19,6 +21,7 @@ CLASS net/minecraft/unmapped/C_lgaafbhj net/minecraft/block/AbstractPressurePlat
 		ARG 2 pos
 	METHOD m_uqcpydqj getRedstoneOutput (Lnet/minecraft/unmapped/C_txtbiemp;)I
 	METHOD m_vhzntwmq setRedstoneOutput (Lnet/minecraft/unmapped/C_txtbiemp;I)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 2 power
 	METHOD m_ylkjmojd getEntityCount (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hbcjzgoe;Ljava/lang/Class;)I
 		ARG 0 world
 		ARG 1 box

--- a/mappings/net/minecraft/block/AbstractRailBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractRailBlock.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_mgkftsgg net/minecraft/block/AbstractRailBlock
 	FIELD f_afdevxyp uncurvable Z
 	FIELD f_hugfgcne WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_wxacikuu ASCENDING_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_wyagalyy DEFAULT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	METHOD <init> (ZLnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 uncurvable
 		ARG 2 settings

--- a/mappings/net/minecraft/block/AbstractTorchBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractTorchBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/unmapped/C_teovrngh net/minecraft/block/AbstractTorchBlock
+	FIELD f_eknpnkow SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/AmethystClusterBlock.mapping
+++ b/mappings/net/minecraft/block/AmethystClusterBlock.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/unmapped/C_sdtaqcut net/minecraft/block/AmethystClusterBlock
 	FIELD f_fabgpzfk CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_ieqcygge shapes Ljava/util/Map;
 	FIELD f_rsuosfjc FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_ztvojeln WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD <init> (FFLnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 3 settings
+	METHOD m_pkgyyicw (Lnet/minecraft/unmapped/C_sdtaqcut;)Ljava/lang/Float;
+		ARG 0 cluster
+	METHOD m_ymivlgkm (Lnet/minecraft/unmapped/C_sdtaqcut;)Ljava/lang/Float;
+		ARG 0 cluster

--- a/mappings/net/minecraft/block/AttachedStemBlock.mapping
+++ b/mappings/net/minecraft/block/AttachedStemBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_khgfyxfg net/minecraft/block/AttachedStemBlock
+	FIELD f_bsloaiks SHAPES Ljava/util/Map;
 	FIELD f_hgeorsxr FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_lcjxatqe CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_zxdligzi gourdBlock Lnet/minecraft/unmapped/C_xhhleach;
@@ -6,3 +7,9 @@ CLASS net/minecraft/unmapped/C_khgfyxfg net/minecraft/block/AttachedStemBlock
 		ARG 4 settings
 	METHOD m_bzrxpycp (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 stemBlock
+	METHOD m_gstlwgsg (Lnet/minecraft/unmapped/C_khgfyxfg;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 attachedStem
+	METHOD m_lgbjgzkv (Lnet/minecraft/unmapped/C_khgfyxfg;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 attachedStem
+	METHOD m_ssmjjcny (Lnet/minecraft/unmapped/C_khgfyxfg;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 attachedStem

--- a/mappings/net/minecraft/block/BambooBlock.mapping
+++ b/mappings/net/minecraft/block/BambooBlock.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/unmapped/C_romdhvev net/minecraft/block/BambooBlock
+	FIELD f_bijgoqoy BASE_COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_bqiavdzz AGE Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_cfvguqhh BASE_LARGE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_pcsjnror LEAVES Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_qfjlhxny CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_qyevrnrf AGE_THIN I
+	FIELD f_tmfgieyw BASE_SMALL_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_uhfnqpld STAGE_GROWING_FINISHED I
 	FIELD f_uiimfyxj STAGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_vszltbyw STAGE_GROWING I

--- a/mappings/net/minecraft/block/BambooSaplingBlock.mapping
+++ b/mappings/net/minecraft/block/BambooSaplingBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_zdpkyqwn net/minecraft/block/BambooSaplingBlock
+	FIELD f_dtetwgst BASE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_eaceacnw CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_llzxqaxu grow (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 world

--- a/mappings/net/minecraft/block/BeetrootsBlock.mapping
+++ b/mappings/net/minecraft/block/BeetrootsBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/unmapped/C_nixkqwvu net/minecraft/block/BeetrootsBlock
 	FIELD f_dedfsbiq AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_eyrftkxb CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_vftzyzzu SHAPES_BY_AGE [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ybicbsei MAX_AGE I
+	METHOD m_cbqbfnop (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 age

--- a/mappings/net/minecraft/block/BellBlock.mapping
+++ b/mappings/net/minecraft/block/BellBlock.mapping
@@ -1,10 +1,14 @@
 CLASS net/minecraft/unmapped/C_kvzqooxs net/minecraft/block/BellBlock
 	FIELD f_cmsmkpgi BELL_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_cokbmaex CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_gsacngar SINGLE_WALL_SHAPES Ljava/util/Map;
+	FIELD f_ibttblfa CEILING_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_pcaujdgr FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_sgxlmllz DOUBLE_WALL_SHAPES Ljava/util/Map;
 	FIELD f_sohaussh BELL_RING_EVENT I
 	FIELD f_tngpgqaf ATTACHMENT Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_xxnshmjp POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_yokoiywa FLOOR_SHAPES Ljava/util/Map;
 	METHOD m_dyllwhvv ring (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/BigDripleafBlock.mapping
+++ b/mappings/net/minecraft/block/BigDripleafBlock.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/unmapped/C_gpceuifm net/minecraft/block/BigDripleafBlock
+	FIELD f_aiyvdant LEAF_SHAPES Ljava/util/Map;
 	FIELD f_avdjnjcb WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_eiogboye ENTITY_MIN_DETECTION_Y I
 	FIELD f_gqsqxipt TILT Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_knmseybn shapeGetter Ljava/util/function/Function;
 	FIELD f_pfircekx MAX_GEN_HEIGHT I
 	FIELD f_ruqpfxnt NO_TICK I
 	FIELD f_rutwxmew NEXT_TILT_DELAYS Lit/unimi/dsi/fastutil/objects/Object2IntMap;
@@ -47,3 +49,4 @@ CLASS net/minecraft/unmapped/C_gpceuifm net/minecraft/block/BigDripleafBlock
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 soundEvent
+	METHOD m_ylhnnppw createShapeGetter ()Ljava/util/function/Function;

--- a/mappings/net/minecraft/block/BigDripleafStemBlock.mapping
+++ b/mappings/net/minecraft/block/BigDripleafStemBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_geikjobf net/minecraft/block/BigDripleafStemBlock
 	FIELD f_fjqhezyo WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_iulegwwr SHAPES Ljava/util/Map;
 	FIELD f_xmowzvej CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_qzzihvfg placeStemAt (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 world

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 	FIELD f_ngtlhrdq FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
 	FIELD f_okywtldq STATE_IDS Lnet/minecraft/unmapped/C_lwiadjvw;
 	FIELD f_pelzkawq SKIP_UPDATE_BLOCK_ENTITY_SIDEEFFECTS I
-	FIELD f_rnbszkxo UPDATE_SKIP_ALL_SIDEEFFECTS I
+	FIELD f_rnbszkxo SKIP_ALL_UPDATE_SIDEEFFECTS I
 	FIELD f_sqfncgqq LOGGER Lorg/slf4j/Logger;
 	FIELD f_utymbzpn REDRAW_ON_MAIN_THREAD I
 		COMMENT Forces a synchronous redraw on clients.

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -38,8 +38,8 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 	FIELD f_nexeeilp stateManager Lnet/minecraft/unmapped/C_ezfeikaq;
 	FIELD f_ngtlhrdq FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
 	FIELD f_okywtldq STATE_IDS Lnet/minecraft/unmapped/C_lwiadjvw;
-	FIELD f_pelzkawq SKIP_UPDATE_BLOCK_ENTITY_SIDEEFFECTS I
-	FIELD f_rnbszkxo SKIP_ALL_UPDATE_SIDEEFFECTS I
+	FIELD f_pelzkawq SKIP_UPDATE_BLOCK_ENTITY_SIDE_EFFECTS I
+	FIELD f_rnbszkxo SKIP_ALL_UPDATE_SIDE_EFFECTS I
 	FIELD f_sqfncgqq LOGGER Lorg/slf4j/Logger;
 	FIELD f_utymbzpn REDRAW_ON_MAIN_THREAD I
 		COMMENT Forces a synchronous redraw on clients.

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -27,6 +27,7 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		COMMENT The default setBlockState behavior. Same as {@code NOTIFY_NEIGHBORS | NOTIFY_LISTENERS}.
 	FIELD f_fmkkgoft MOVED I
 		COMMENT Signals that the current block is being moved to a different location, usually because of a piston.
+	FIELD f_grnanfzp UPDATE_SKIP_ON_PLACE I
 	FIELD f_hncvzxyf defaultState Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_hyfvlkab FORCE_STATE I
 		COMMENT Bypass virtual block state changes and forces the passed state to be stored as-is.
@@ -37,6 +38,8 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 	FIELD f_nexeeilp stateManager Lnet/minecraft/unmapped/C_ezfeikaq;
 	FIELD f_ngtlhrdq FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
 	FIELD f_okywtldq STATE_IDS Lnet/minecraft/unmapped/C_lwiadjvw;
+	FIELD f_pelzkawq UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS I
+	FIELD f_rnbszkxo UPDATE_SKIP_ALL_SIDEEFFECTS I
 	FIELD f_sqfncgqq LOGGER Lorg/slf4j/Logger;
 	FIELD f_utymbzpn REDRAW_ON_MAIN_THREAD I
 		COMMENT Forces a synchronous redraw on clients.
@@ -73,8 +76,13 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 3 blockEntity
 	METHOD m_cbjpaznf getBlockFromItem (Lnet/minecraft/unmapped/C_vorddnax;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 		ARG 0 item
+	METHOD m_cixqwdon createXYCenteredCuboid (DDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 xySize
 	METHOD m_cwuunnrc cannotConnect (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
+	METHOD m_dtmmhfqw createXZCenteredCuboid (DDDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 xSize
+		ARG 2 zSize
 	METHOD m_dvztrwyo getStateFromRawId (I)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 0 stateId
 	METHOD m_eapglecc precipitationTick (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_orlkpefs$C_xwlyzxea;)V
@@ -91,6 +99,10 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 5 stack
 	METHOD m_eslctrgs (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 2 stack
+	METHOD m_ewgcevbe (Lnet/minecraft/unmapped/C_vzlztuyw;)Ljava/lang/Object;
+		ARG 0 property
+	METHOD m_ewwwkauf (Lnet/minecraft/unmapped/C_vzlztuyw;)Lnet/minecraft/unmapped/C_vzlztuyw;
+		ARG 0 property
 	METHOD m_fgtteebr hasDynamicBounds ()Z
 	METHOD m_fuvqealb onPlaced (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 world
@@ -98,6 +110,8 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 3 state
 		ARG 4 placer
 		ARG 5 itemStack
+	METHOD m_fvtdilcl createXYCenteredCuboid (DDDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 2 ySize
 	METHOD m_goutaqfi shouldDropItemsOnExplosion (Lnet/minecraft/unmapped/C_aahhrzpf;)Z
 		ARG 1 explosion
 	METHOD m_grdgsfjs postProcessState (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
@@ -105,6 +119,9 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 	METHOD m_gsgxvzbp getName ()Lnet/minecraft/unmapped/C_npqneive;
+	METHOD m_gvapgzox stateWith (Lnet/minecraft/unmapped/C_jccsnmmo;Lnet/minecraft/unmapped/C_vzlztuyw;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_jccsnmmo;
+		ARG 0 state
+		ARG 2 value
 	METHOD m_gzevdpnp getBlastResistance ()F
 	METHOD m_hittbukc canMobSpawnInside (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
@@ -112,7 +129,7 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		COMMENT Called when this block is destroyed by an explosion.
 		ARG 2 pos
 		ARG 3 explosion
-	METHOD m_iipllqny createCuboidShape (DDDDDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+	METHOD m_iipllqny createCuboid (DDDDDD)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 0 minX
 		ARG 2 minY
 		ARG 4 minZ
@@ -120,18 +137,25 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 8 maxY
 		ARG 10 maxZ
 	METHOD m_iwedynhy getPlacementState (Lnet/minecraft/unmapped/C_aiootljq;)Lnet/minecraft/unmapped/C_txtbiemp;
-		ARG 1 ctx
+		ARG 1 context
 	METHOD m_jajpdzzy sideCoversSmallSquare (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 side
 	METHOD m_jeqzqmog (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 2 stack
+	METHOD m_jmmkoich createXZCenteredCuboid (DDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 xzSize
 	METHOD m_jweqgtyb onLandedUpon (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;D)V
 		ARG 1 world
 		ARG 2 state
 		ARG 3 pos
 		ARG 4 entity
+	METHOD m_kchifbxg createShapeGetter (Ljava/util/function/Function;)Ljava/util/function/Function;
+		ARG 1 getShapeForState
+	METHOD m_kismeqwe createShapeArray (ILjava/util/function/IntFunction;)[Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 size
+		ARG 1 getShape
 	METHOD m_ksyzaetw dropStacks (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 0 state
 		ARG 1 world
@@ -212,6 +236,8 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 random
+	METHOD m_qmkndjvo createCenteredCube (D)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 size
 	METHOD m_qnwpfxhz getVelocityMultiplier ()F
 	METHOD m_rvydtzjt getDroppedStacks (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_kvegafmh;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sddaxwyk;)Ljava/util/List;
 		ARG 0 state
@@ -225,11 +251,15 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 1 to
 		ARG 2 world
 		ARG 3 pos
+	METHOD m_smollgqm createXCenteredCuboid (DDDDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 xSize
 	METHOD m_sslzkkcf dropStacks (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_kvegafmh;)V
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 blockEntity
+	METHOD m_swedjjpo (Lnet/minecraft/unmapped/C_txtbiemp;Ljava/util/Map$Entry;)Z
+		ARG 1 entry
 	METHOD m_thiabdjl getDefaultState ()Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_tjijvtpb onBreak (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_jzrpycqo;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 1 world
@@ -257,8 +287,19 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 stack
+	METHOD m_zfmftrtj createShapeGetter (Ljava/util/function/Function;[Lnet/minecraft/unmapped/C_vzlztuyw;)Ljava/util/function/Function;
+		ARG 1 getShapeForSate
+		ARG 2 ignoredProperties
+	METHOD m_zhkrlkwq createCenteredCuboid (DDD)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 2 ySize
 	METHOD m_zpnlglhs shouldDrawSide (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 state
 		ARG 1 sideState
 		ARG 2 side
 	CLASS C_epynadow ShapePair
+	CLASS C_miiagdeq
+		METHOD load (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 key
+	CLASS C_znvnetlf
+		METHOD rehash (I)V
+			ARG 1 newN

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -21,13 +21,13 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 	FIELD f_bjwoutju NOTIFY_LISTENERS I
 		COMMENT Notifies listeners and clients who need to react when the block changes.
 	FIELD f_bqorapkz UPDATE_LIMIT I
-	FIELD f_egxohwli UPDATE_NONE I
+	FIELD f_egxohwli SKIP_UPDATES I
 	FIELD f_etbvyypx FACE_CULL_MAP Ljava/lang/ThreadLocal;
 	FIELD f_fdbmuaky NOTIFY_ALL I
 		COMMENT The default setBlockState behavior. Same as {@code NOTIFY_NEIGHBORS | NOTIFY_LISTENERS}.
 	FIELD f_fmkkgoft MOVED I
 		COMMENT Signals that the current block is being moved to a different location, usually because of a piston.
-	FIELD f_grnanfzp UPDATE_SKIP_ON_PLACE I
+	FIELD f_grnanfzp SKIP_UPDATE_ON_PLACE I
 	FIELD f_hncvzxyf defaultState Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_hyfvlkab FORCE_STATE I
 		COMMENT Bypass virtual block state changes and forces the passed state to be stored as-is.
@@ -38,7 +38,7 @@ CLASS net/minecraft/unmapped/C_mmxmpdoq net/minecraft/block/Block
 	FIELD f_nexeeilp stateManager Lnet/minecraft/unmapped/C_ezfeikaq;
 	FIELD f_ngtlhrdq FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
 	FIELD f_okywtldq STATE_IDS Lnet/minecraft/unmapped/C_lwiadjvw;
-	FIELD f_pelzkawq UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS I
+	FIELD f_pelzkawq SKIP_UPDATE_BLOCK_ENTITY_SIDEEFFECTS I
 	FIELD f_rnbszkxo UPDATE_SKIP_ALL_SIDEEFFECTS I
 	FIELD f_sqfncgqq LOGGER Lorg/slf4j/Logger;
 	FIELD f_utymbzpn REDRAW_ON_MAIN_THREAD I

--- a/mappings/net/minecraft/block/Blocks.mapping
+++ b/mappings/net/minecraft/block/Blocks.mapping
@@ -1,17 +1,50 @@
 CLASS net/minecraft/unmapped/C_jricjyva net/minecraft/block/Blocks
 	FIELD f_bqfkdntj PISTON_NOT_EXTENDED_PREDICATE Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
 	FIELD f_lfmqbeqz SHULKER_BOX_SUFFOCATES_PREDICATE Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
+	METHOD m_asxurasr createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
+	METHOD m_cbneopvk createButtonSettings ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
 	METHOD m_cptpfson register (Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 		ARG 0 key
+		ARG 1 factory
+	METHOD m_esefldin createCandleSettings (Lnet/minecraft/unmapped/C_vhpmxtfv;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 0 mapColor
+	METHOD m_hscknoqa createFlowerPotSettings ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+	METHOD m_jbcmxapk createPistonSettings ()Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+	METHOD m_kbjlngha registerCopiedStairs (Ljava/lang/String;Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD m_knkwxiyx solid (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	METHOD m_lvemnici registerStainedGlass (Ljava/lang/String;Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+	METHOD m_mzckqran (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Z
+		ARG 3 entityType
+	METHOD m_nedgkuwe createLeavesSettings (Lnet/minecraft/unmapped/C_aevintex;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 0 sounds
 	METHOD m_nmstzpxh spawnable (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Ljava/lang/Boolean;
 		ARG 3 entityType
+	METHOD m_olnmucit createShulkerBoxSettings (Lnet/minecraft/unmapped/C_vhpmxtfv;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 0 mapColor
+	METHOD m_pddyceds register (Ljava/lang/String;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD m_pelkwenc luminanceOf (I)Ljava/util/function/ToIntFunction;
 		ARG 0 lightLevel
+	METHOD m_pmthclel registerBed (Ljava/lang/String;Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+		ARG 1 color
 	METHOD m_qpxyruwi nonSpawnable (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Ljava/lang/Boolean;
 		ARG 3 entityType
 	METHOD m_rzfpgupq allowOcelotsAndParrots (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Ljava/lang/Boolean;
 		ARG 3 entityType
+	METHOD m_sfaglezr register (Ljava/lang/String;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+	METHOD m_sttguhre createSettingsFromProperties (Lnet/minecraft/unmapped/C_mmxmpdoq;Z)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 1 includeTranslationKey
+	METHOD m_tcuuejax (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Z
+		ARG 3 entityType
 	METHOD m_tobwsgju waterlogMapColor (Lnet/minecraft/unmapped/C_vhpmxtfv;)Ljava/util/function/Function;
+		ARG 0 color
+	METHOD m_uglmuloe (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ogavsvbr;)Z
+		ARG 3 entityType
 	METHOD m_vfpzuwtj register (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD m_wjfyifdb nonSolid (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	METHOD m_ynkzrfld registerVariantStairs (Ljava/lang/String;Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+	METHOD m_ytybowqx createNetherStemSettings (Lnet/minecraft/unmapped/C_vhpmxtfv;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 0 mapColor
+	METHOD m_zclwojlu createLogSettings (Lnet/minecraft/unmapped/C_vhpmxtfv;Lnet/minecraft/unmapped/C_vhpmxtfv;Lnet/minecraft/unmapped/C_aevintex;)Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;
+		ARG 0 verticalMapColor
+		ARG 1 horizontalMapColor
+		ARG 2 sounds

--- a/mappings/net/minecraft/block/Blocks.mapping
+++ b/mappings/net/minecraft/block/Blocks.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_jricjyva net/minecraft/block/Blocks
+	FIELD f_bqfkdntj PISTON_NOT_EXTENDED_PREDICATE Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
 	FIELD f_lfmqbeqz SHULKER_BOX_SUFFOCATES_PREDICATE Lnet/minecraft/unmapped/C_triydqro$C_izsedryc;
 	METHOD m_cptpfson register (Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 		ARG 0 key

--- a/mappings/net/minecraft/block/BushBlock.mapping
+++ b/mappings/net/minecraft/block/BushBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_bgdokvym net/minecraft/block/BushBlock
+	FIELD f_nlvsrwnj SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/ButtonBlock.mapping
+++ b/mappings/net/minecraft/block/ButtonBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_mvguptux net/minecraft/block/ButtonBlock
 	FIELD f_eexsojfl CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_oodobmpj onTicks I
+	FIELD f_ordwnpqd shapeGetter Ljava/util/function/Function;
 	FIELD f_plcwtqai blockSetType Lnet/minecraft/unmapped/C_hgpogkhy;
 	FIELD f_pzyrfksa POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_hgpogkhy;ILnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
@@ -9,6 +10,7 @@ CLASS net/minecraft/unmapped/C_mvguptux net/minecraft/block/ButtonBlock
 		ARG 0 block
 	METHOD m_smnwtisx getClickSound (Z)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 1 powered
+	METHOD m_snirxovx createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_sspxzrop (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 button
 	METHOD m_vkkuhzwv updateNeighbors (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/unmapped/C_yvojkeai net/minecraft/block/CactusBlock
+	FIELD f_blemeugo FLOWER_GROWTH_AGE I
 	FIELD f_bzzmigqf CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_lxxqvyhb SHORT_CACTUS_FLOWER_GROWTH_CHANCE D
 	FIELD f_nrlwhltn AGE Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_pmtnzytd COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_roqygzxw TALL_CACTUS_FLOWER_GROWTH_CHANCE D
+	FIELD f_rsmbfvfa MAX_GROWTH_HEIGHT I
 	FIELD f_wbvmqqbb MAX_AGE I
+	FIELD f_xwkwaxpm OUTLINE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/CactusFlowerBlock.mapping
+++ b/mappings/net/minecraft/block/CactusFlowerBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_oxvdzzub net/minecraft/block/CactusFlowerBlock
+	FIELD f_jqjeamzy SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_tldtxelx net/minecraft/block/CakeBlock
 	FIELD f_faclvvif DEFAULT_COMPARATOR_OUTPUT I
 	FIELD f_gmlywhqj MAX_BITES I
+	FIELD f_isbsguet SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_jviguqpi BITES Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_ueezsnwh CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_fesliehb getComparatorOutput (I)I
@@ -10,3 +11,5 @@ CLASS net/minecraft/unmapped/C_tldtxelx net/minecraft/block/CakeBlock
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 player
+	METHOD m_uwolqmup (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/CampfireBlock.mapping
+++ b/mappings/net/minecraft/block/CampfireBlock.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_gcjouocd net/minecraft/block/CampfireBlock
 	FIELD f_jmwlfywl LIT Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_mfjbfakw fireDamage I
 	FIELD f_ofxalugw SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_qjwccciu LIT_CAMPFIRE_SEARCH_AREA Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_xczudktw SMOKE_RENDER_DISTANCE I
 	FIELD f_xiocftdj emitsParticles Z
 	FIELD f_ygukbhme SIGNAL_FIRE Lnet/minecraft/unmapped/C_xhwijdsd;
@@ -23,6 +24,8 @@ CLASS net/minecraft/unmapped/C_gcjouocd net/minecraft/block/CampfireBlock
 		ARG 0 state
 	METHOD m_hjatvryy (Lnet/minecraft/unmapped/C_gcjouocd;)Ljava/lang/Boolean;
 		ARG 0 block
+	METHOD m_itqdyxix (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hjseusrb$C_bvtkxdyi;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_wmubauif;)V
+		ARG 2 tickerWorld
 	METHOD m_lhwkhjgy isLitCampfire (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_llezjudc spawnSmokeParticle (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;ZZ)V
@@ -37,3 +40,5 @@ CLASS net/minecraft/unmapped/C_gcjouocd net/minecraft/block/CampfireBlock
 	METHOD m_vehfpozy isLitCampfireInRange (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 world
 		ARG 1 pos
+	METHOD m_wvykeluc (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
+		ARG 0 campfireState

--- a/mappings/net/minecraft/block/CandleBlock.mapping
+++ b/mappings/net/minecraft/block/CandleBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_rrwcrbzt net/minecraft/block/CandleBlock
 	FIELD f_egpozybp MIN_CANDLES I
+	FIELD f_eknnmilz SHAPES_BY_CANDLES_INDEX [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ewjclegu STATE_TO_LUMINANCE Ljava/util/function/ToIntFunction;
 	FIELD f_ffzcvmxh CANDLES_TO_PARTICLE_OFFSETS Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD f_jzngyics CANDLES Lnet/minecraft/unmapped/C_vltzvhxi;
@@ -13,3 +14,5 @@ CLASS net/minecraft/unmapped/C_rrwcrbzt net/minecraft/block/CandleBlock
 		ARG 0 state
 	METHOD m_loylnbda (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
 		ARG 0 state
+	METHOD m_wmsplhaj (Lit/unimi/dsi/fastutil/ints/Int2ObjectOpenHashMap;)V
+		ARG 0 candlesToParticleOffsets

--- a/mappings/net/minecraft/block/CarrotsBlock.mapping
+++ b/mappings/net/minecraft/block/CarrotsBlock.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/unmapped/C_fuflxzxg net/minecraft/block/CarrotsBlock
+	FIELD f_rqxuljys SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zutuwukn CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD m_rkhfdmpc (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/ChainBlock.mapping
+++ b/mappings/net/minecraft/block/ChainBlock.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/unmapped/C_tcsihbdu net/minecraft/block/ChainBlock
+	FIELD f_jqdkhfhc SHAPES Ljava/util/Map;
 	FIELD f_jxfyjtxt WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_yqbcbtck CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/unmapped/C_kscsbeif net/minecraft/block/ChestBlock
 	FIELD f_bfpteavl CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_ehunughp CHEST_TYPE Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_hawtdftr FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_qspgdgge CONNECTED_SHAPES Ljava/util/Map;
+	FIELD f_roumjjjq SINGLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_xlpqsxfi NAME_RETRIEVER Lnet/minecraft/unmapped/C_empmxbdt$C_jsopmqcu;
 	FIELD f_xwudvaxp INVENTORY_RETRIEVER Lnet/minecraft/unmapped/C_empmxbdt$C_jsopmqcu;
 	FIELD f_ytdpygkd EVENT_SET_OPEN_COUNT I
@@ -34,3 +36,9 @@ CLASS net/minecraft/unmapped/C_kscsbeif net/minecraft/block/ChestBlock
 	METHOD m_zcrwwdxl hasBlockOnTop (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 world
 		ARG 1 pos
+	CLASS C_lkukcafk
+		METHOD m_uawgibgj (Lnet/minecraft/unmapped/C_idrrrnej;Lnet/minecraft/unmapped/C_idrrrnej;F)F
+			ARG 2 delta
+	CLASS C_nbseopnd
+		METHOD m_kgqdsgyx (Lnet/minecraft/unmapped/C_idrrrnej;)Ljava/util/Optional;
+			ARG 1 blockEntity

--- a/mappings/net/minecraft/block/ChorusFlowerBlock.mapping
+++ b/mappings/net/minecraft/block/ChorusFlowerBlock.mapping
@@ -2,9 +2,12 @@ CLASS net/minecraft/unmapped/C_knlkybdi net/minecraft/block/ChorusFlowerBlock
 	FIELD f_dszhovmh AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_kyvpntsg MAX_AGE I
 	FIELD f_paxddqay plantBlock Lnet/minecraft/unmapped/C_mmxmpdoq;
+	FIELD f_sltgupzc SIDES_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ynugwbrw CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD <init> (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 2 settings
+	METHOD m_akswwkjz (Lnet/minecraft/unmapped/C_knlkybdi;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+		ARG 0 flower
 	METHOD m_cnvppyfs grow (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;I)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/CocoaBlock.mapping
+++ b/mappings/net/minecraft/block/CocoaBlock.mapping
@@ -2,3 +2,6 @@ CLASS net/minecraft/unmapped/C_voaxbqpr net/minecraft/block/CocoaBlock
 	FIELD f_bppqotqe CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_cetcjzod MAX_AGE I
 	FIELD f_mqzxnevk AGE Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_qdperhnw SHAPES_BY_FACING_BY_AGE Ljava/util/List;
+	METHOD m_cvgukcvn (I)Ljava/util/Map;
+		ARG 0 age

--- a/mappings/net/minecraft/block/ComposterBlock.mapping
+++ b/mappings/net/minecraft/block/ComposterBlock.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_cbvdmcmj net/minecraft/block/ComposterBlock
 	FIELD f_lhovhpys MIN_LEVEL I
 	FIELD f_mfhgdtry ITEM_TO_LEVEL_INCREASE_CHANCE Lit/unimi/dsi/fastutil/objects/Object2FloatMap;
 	FIELD f_qsdeocap LEVEL_TO_COLLISION_SHAPE [Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_zuoqbthz INNER_WIDTH I
 	FIELD f_zvsjlxgd LEVEL Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD m_epngjhfs emptyFullComposter (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 0 entity
@@ -21,6 +22,8 @@ CLASS net/minecraft/unmapped/C_cbvdmcmj net/minecraft/block/ComposterBlock
 		ARG 2 world
 		ARG 3 pos
 	METHOD m_nvzvzqwg registerDefaultCompostableItems ()V
+	METHOD m_nxfkxivw (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index
 	METHOD m_padinrof registerCompostableItem (FLnet/minecraft/unmapped/C_gmbqjnle;)V
 		ARG 0 levelIncreaseChance
 		ARG 1 item

--- a/mappings/net/minecraft/block/ConnectingBlock.mapping
+++ b/mappings/net/minecraft/block/ConnectingBlock.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_bgglkyxh net/minecraft/block/ConnectingBlock
 	FIELD f_apbfdepp DOWN Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_dyywfaux WEST Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_hmtlidkh SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_msmhprqm shapeGetter Ljava/util/function/Function;
 	FIELD f_sliyoepc UP Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_svnizrma NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_svqnynza FACING_PROPERTIES Ljava/util/Map;
@@ -9,5 +10,5 @@ CLASS net/minecraft/unmapped/C_bgglkyxh net/minecraft/block/ConnectingBlock
 	METHOD <init> (FLnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 radius
 		ARG 2 settings
-	METHOD m_rhbbmqca generateFacingsToShapeMap (F)Ljava/util/function/Function;
+	METHOD m_rhbbmqca createShapeGetter (F)Ljava/util/function/Function;
 		ARG 1 radius

--- a/mappings/net/minecraft/block/CoralParentBlock.mapping
+++ b/mappings/net/minecraft/block/CoralParentBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_hxblpphu net/minecraft/block/CoralParentBlock
+	FIELD f_erdincnj SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_jdiyfdif WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD m_crdjrjge isInWater (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 state
@@ -6,4 +7,5 @@ CLASS net/minecraft/unmapped/C_hxblpphu net/minecraft/block/CoralParentBlock
 		ARG 2 pos
 	METHOD m_eeufklii checkLivingConditions (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_adoatlrf;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 state
+		ARG 3 tickAccess
 		ARG 5 pos

--- a/mappings/net/minecraft/block/CreakingHeartBlock.mapping
+++ b/mappings/net/minecraft/block/CreakingHeartBlock.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/unmapped/C_qnrzjsej net/minecraft/block/CreakingHeartBlock
+	FIELD f_lifcvzus STATE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_vviisyvu NATURAL Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_xnzagghe AXIS Lnet/minecraft/unmapped/C_cgckxfsw;
+	METHOD m_mvbdslwi isRooted (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	METHOD m_ptedtpgq updateState (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_tyxaudjp isWakeTime (Lnet/minecraft/unmapped/C_cdctfzbn;)Z
+	METHOD m_wwugepdj isEnclosedInPaleOak (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		ARG 0 world
+	METHOD m_xdisthyh tryDropExperience (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V

--- a/mappings/net/minecraft/block/CropBlock.mapping
+++ b/mappings/net/minecraft/block/CropBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_rhzoiqkd net/minecraft/block/CropBlock
 	FIELD f_cnumgyii MAX_AGE I
 	FIELD f_mwwdlpaw CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_npoxhjyv SHAPES_BY_AGE [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_oitmwsoi AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD m_alupcouq getSeedsItem ()Lnet/minecraft/unmapped/C_gmbqjnle;
 	METHOD m_gpssfeqb getAge (Lnet/minecraft/unmapped/C_txtbiemp;)I
@@ -8,6 +9,8 @@ CLASS net/minecraft/unmapped/C_rhzoiqkd net/minecraft/block/CropBlock
 	METHOD m_hzwbhnfv withAge (I)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 1 age
 	METHOD m_ijrdwbxi getMaxAge ()I
+	METHOD m_jrrcystv (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 age
 	METHOD m_lkntfvxg getAgeProperty ()Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD m_roapqwua getGrowthAmount (Lnet/minecraft/unmapped/C_cdctfzbn;)I
 		ARG 1 world

--- a/mappings/net/minecraft/block/DeadCoralFanBlock.mapping
+++ b/mappings/net/minecraft/block/DeadCoralFanBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_ncrxqukt net/minecraft/block/DeadCoralFanBlock
 	FIELD f_akizfbjj CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_pcyznkqj SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/DecoratedPotBlock.mapping
+++ b/mappings/net/minecraft/block/DecoratedPotBlock.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/unmapped/C_bnspifpc net/minecraft/block/DecoratedPotBlock
+	FIELD f_bgudsqqp SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_cjrquyuv CRACKED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_egywafcb WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_fehlkmmz FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_gpbhosxr CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_tohwohru SHERDS Lnet/minecraft/unmapped/C_ncpywfca;
+	METHOD m_saxfcody (Lnet/minecraft/unmapped/C_snnddtnv;Ljava/util/function/Consumer;)V
+		ARG 1 lootProcessor

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_dfkdtnby net/minecraft/block/DoorBlock
 	FIELD f_itolrcbh HINGE Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_pgtypdwz FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_rkamnhzi HALF Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_rrltvcvo SHAPES Ljava/util/Map;
 	FIELD f_vqiotyjw blockSetType Lnet/minecraft/unmapped/C_hgpogkhy;
 	FIELD f_wlmdlqkf OPEN Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_xylcrlvu POWERED Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/block/DoubleBlockProperties.mapping
+++ b/mappings/net/minecraft/block/DoubleBlockProperties.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_empmxbdt net/minecraft/block/DoubleBlockPropertie
 		ARG 0 blockEntityType
 		ARG 1 typeMapper
 		ARG 2 posOffsetGetter
+		ARG 3 facing
 		ARG 4 state
 		ARG 5 world
 		ARG 6 pos
@@ -10,9 +11,14 @@ CLASS net/minecraft/unmapped/C_empmxbdt net/minecraft/block/DoubleBlockPropertie
 	CLASS C_jsopmqcu PropertyRetriever
 		METHOD m_kepatcde getFallback ()Ljava/lang/Object;
 		METHOD m_plbseukp getFrom (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 blockEntity
 		METHOD m_spcgicas getFromBoth (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 first
+			ARG 2 second
 	CLASS C_plunhppa Type
 	CLASS C_rsioyjyt PropertySource
+		METHOD apply (Lnet/minecraft/unmapped/C_empmxbdt$C_jsopmqcu;)Ljava/lang/Object;
+			ARG 1 retriever
 		CLASS C_oxpytkct Single
 			FIELD f_nzrwlfwr single Ljava/lang/Object;
 			METHOD <init> (Ljava/lang/Object;)V

--- a/mappings/net/minecraft/block/DryPlantBlock.mapping
+++ b/mappings/net/minecraft/block/DryPlantBlock.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_evtamfwe net/minecraft/block/DryPlantBlock
+	FIELD f_gccszzbi INVERSE_SOUND_CHANCE I
+	FIELD f_xfgiwwaw SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_xkvdmvko BADLANDS_SOUND_CHANCE_PENALTY I

--- a/mappings/net/minecraft/block/EnchantingTableBlock.mapping
+++ b/mappings/net/minecraft/block/EnchantingTableBlock.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/unmapped/C_dicxqeuf net/minecraft/block/EnchantingTableBlock
+	FIELD f_hcsybajr POWER_SEARCH_OFFSETS Ljava/util/List;
+	FIELD f_sjpoihos SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	METHOD m_bknecqvl powerProvidedFrom (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		ARG 1 tablePos
+		ARG 2 offset
+	METHOD m_isrfmwma (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_sxzqocrm;Lnet/minecraft/unmapped/C_jzrpycqo;)Lnet/minecraft/unmapped/C_mkrkudpa;
+		ARG 2 syncId
+		ARG 3 playerInventory

--- a/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
+++ b/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_ebtjecda net/minecraft/block/EndPortalFrameBlock
+	FIELD f_dyzuetto FILLED_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_pmrtdejw EMPTY_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_qdtcqgst CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_qzsffewp EYE Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_rutyheku completedFrame Lnet/minecraft/unmapped/C_cgooxnaq;

--- a/mappings/net/minecraft/block/EntityCollisionEffect.mapping
+++ b/mappings/net/minecraft/block/EntityCollisionEffect.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_uiwpahut net/minecraft/block/EntityCollisionEffect
+	FIELD f_toblxyvf applicator Ljava/util/function/Consumer;
+	METHOD m_ijsnxxxb getApplicator ()Ljava/util/function/Consumer;

--- a/mappings/net/minecraft/block/EntityCollisionEffectManager.mapping
+++ b/mappings/net/minecraft/block/EntityCollisionEffectManager.mapping
@@ -1,0 +1,26 @@
+CLASS net/minecraft/unmapped/C_bummdtgu net/minecraft/block/EntityCollisionEffectManager
+	FIELD f_fbyaeooc DUMMY Lnet/minecraft/unmapped/C_bummdtgu;
+	METHOD m_dqkpaxpv addEffect (Lnet/minecraft/unmapped/C_uiwpahut;)V
+		ARG 1 effect
+	METHOD m_qtuabsvy addPreEffectCallback (Lnet/minecraft/unmapped/C_uiwpahut;Ljava/util/function/Consumer;)V
+		ARG 1 effect
+		ARG 2 callback
+	METHOD m_ykzysfgr addPostEffectCallback (Lnet/minecraft/unmapped/C_uiwpahut;Ljava/util/function/Consumer;)V
+		ARG 1 effect
+		ARG 2 callback
+	CLASS C_ybqvbnjz Iterating
+		FIELD f_cxxevkzi postCallbacks Ljava/util/Map;
+		FIELD f_dyxadgsy iteration I
+		FIELD f_ewgtrnrm preCallbacks Ljava/util/Map;
+		FIELD f_ghzdfkvx ALL_EFFECTS [Lnet/minecraft/unmapped/C_uiwpahut;
+		FIELD f_oaxnftyg actionQueue Ljava/util/List;
+		FIELD f_tygevlkf pendingEffects Ljava/util/Set;
+		FIELD f_yywclgma NO_ITERATION I
+		METHOD m_etngwutk tryIterate (I)V
+			ARG 1 iteration
+		METHOD m_mhxoixol applyEffects (Lnet/minecraft/unmapped/C_astfners;)V
+		METHOD m_oefhssez (Lnet/minecraft/unmapped/C_uiwpahut;)Ljava/util/List;
+			ARG 0 ignored
+		METHOD m_vprobcnu queueActions ()V
+		METHOD m_xzzwlstb (Lnet/minecraft/unmapped/C_uiwpahut;)Ljava/util/List;
+			ARG 0 ignored

--- a/mappings/net/minecraft/block/EntityShapeContext.mapping
+++ b/mappings/net/minecraft/block/EntityShapeContext.mapping
@@ -2,9 +2,13 @@ CLASS net/minecraft/unmapped/C_qyrslpru net/minecraft/block/EntityShapeContext
 	FIELD f_agssfwgd descending Z
 	FIELD f_brrhsxlq ABSENT Lnet/minecraft/unmapped/C_pbfjvesm;
 	FIELD f_dqzmjrcu minY D
+	FIELD f_poengnrn placement Z
 	FIELD f_sqzftxsg entity Lnet/minecraft/unmapped/C_astfners;
 	FIELD f_ulnpxoti heldItem Lnet/minecraft/unmapped/C_sddaxwyk;
 	FIELD f_wsgxxalk walkOnFluidPredicate Ljava/util/function/Predicate;
+	METHOD <init> (Lnet/minecraft/unmapped/C_astfners;ZZ)V
+		ARG 2 collidesWithFluid
+		ARG 3 placement
 	METHOD m_cgfxeuct getEntity ()Lnet/minecraft/unmapped/C_astfners;
 	METHOD m_dgjqzash (Lnet/minecraft/unmapped/C_xqketiuf;)Z
 		ARG 0 fluidState

--- a/mappings/net/minecraft/block/EyeBlossomBlock.mapping
+++ b/mappings/net/minecraft/block/EyeBlossomBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_bwtojyjm net/minecraft/block/EyeBlossomBlock
+CLASS net/minecraft/unmapped/C_bwtojyjm net/minecraft/block/EyeblossomBlock
 	FIELD f_jpmpisag type Lnet/minecraft/unmapped/C_bwtojyjm$C_hiadigjk;
 	FIELD f_ntaxtxyf HORIZONTAL_PROPAGATION_RANGE I
 	FIELD f_oqzugvyg VERTICAL_PROPAGATION_RANGE I

--- a/mappings/net/minecraft/block/EyeBlossomBlock.mapping
+++ b/mappings/net/minecraft/block/EyeBlossomBlock.mapping
@@ -1,0 +1,24 @@
+CLASS net/minecraft/unmapped/C_bwtojyjm net/minecraft/block/EyeBlossomBlock
+	FIELD f_jpmpisag type Lnet/minecraft/unmapped/C_bwtojyjm$C_hiadigjk;
+	FIELD f_ntaxtxyf HORIZONTAL_PROPAGATION_RANGE I
+	FIELD f_oqzugvyg VERTICAL_PROPAGATION_RANGE I
+	METHOD m_nfprbovw (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 4 propagationPos
+	METHOD m_wfycsybx (Lnet/minecraft/unmapped/C_bwtojyjm;)Ljava/lang/Boolean;
+		ARG 0 blossom
+	METHOD m_yvwryuju tryToggle (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
+	CLASS C_hiadigjk Type
+		FIELD f_eqxxbxcp duration F
+		FIELD f_lsnovadi effect Lnet/minecraft/unmapped/C_cjzoxshv;
+		FIELD f_phbvavuw open Z
+		FIELD f_rgyxcjpb particleColor I
+		FIELD f_upqlpyon longToggleSound Lnet/minecraft/unmapped/C_avavozay;
+		FIELD f_vwclgkvt shortToggleSound Lnet/minecraft/unmapped/C_avavozay;
+		METHOD m_dvsjrdtw getDefaultState ()Lnet/minecraft/unmapped/C_txtbiemp;
+		METHOD m_kvlbpqfm spawnParticle (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)V
+		METHOD m_mmzxmudi getLongToggleSound ()Lnet/minecraft/unmapped/C_avavozay;
+		METHOD m_nipdmsuw isOpen ()Z
+		METHOD m_swagnavs getBlock ()Lnet/minecraft/unmapped/C_mmxmpdoq;
+		METHOD m_xjafiyhc of (Z)Lnet/minecraft/unmapped/C_bwtojyjm$C_hiadigjk;
+			ARG 0 open
+		METHOD m_xojwnmqx toggle ()Lnet/minecraft/unmapped/C_bwtojyjm$C_hiadigjk;

--- a/mappings/net/minecraft/block/FallingBlock.mapping
+++ b/mappings/net/minecraft/block/FallingBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/unmapped/C_lzbaysmw net/minecraft/block/FallingBlock
-	METHOD m_dpxrfjcv getColor (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)I
+	METHOD m_dpxrfjcv getFallingDustColor (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_vhbyklfu net/minecraft/block/FenceBlock
 	FIELD f_mlyyeinh CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_pahmggww cullingShapes Ljava/util/function/Function;
 	METHOD m_gywiugbf canConnect (Lnet/minecraft/unmapped/C_txtbiemp;ZLnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 state
 		ARG 2 neighborIsFullSquare

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -1,15 +1,25 @@
 CLASS net/minecraft/unmapped/C_nfehypbw net/minecraft/block/FenceGateBlock
 	FIELD f_dxajkrni CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_ewlswtam IN_WALL Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_fgoxobzj CLOSED_SIDE_SHAPES Ljava/util/Map;
+	FIELD f_fhodctjk DEFAULT_OUTLINE_SHAPES Ljava/util/Map;
+	FIELD f_fyhsvuqs IN_WALL_OUTLINE_SHAPES Ljava/util/Map;
 	FIELD f_miphehdo OPEN Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_mkwhokiw CLOSED_COLLISION_SHAPES Ljava/util/Map;
 	FIELD f_whecgsjr signType Lnet/minecraft/unmapped/C_xlaykyai;
 	FIELD f_xlluklyn POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_xvxtdtac IN_WALL_CULLING_SHAPES Ljava/util/Map;
+	FIELD f_yrdjvdum DEFAULT_CULLING_SHAPES Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/unmapped/C_xlaykyai;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 2 settings
+	METHOD m_cwmtcazv (Lnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 cullingShape
 	METHOD m_evukuidt canWallConnect (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 state
 		ARG 1 side
 	METHOD m_hhkaskkq isWall (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state
+	METHOD m_wszzegxk (Lnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 defaultShape
 	METHOD m_xjturete (Lnet/minecraft/unmapped/C_nfehypbw;)Lnet/minecraft/unmapped/C_xlaykyai;
 		ARG 0 block

--- a/mappings/net/minecraft/block/Fertilizable.mapping
+++ b/mappings/net/minecraft/block/Fertilizable.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/unmapped/C_svvihwsq net/minecraft/block/Fertilizable
+	METHOD m_bfjvhfyh findSpreadPos (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/Optional;
+	METHOD m_euscwagd findSpreadPosImpl (Ljava/util/List;Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/Optional;
+		ARG 0 directions
+	METHOD m_kjnbsawk canSpread (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 	METHOD m_lprnjghr getParticlePos (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_lqjmmujl isFertilizable (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 	METHOD m_mxdrxjjx canFertilize (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z

--- a/mappings/net/minecraft/block/FireBlock.mapping
+++ b/mappings/net/minecraft/block/FireBlock.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/unmapped/C_dwizkkyd net/minecraft/block/FireBlock
 	FIELD f_iqiemzab IGNITE_HARD I
 	FIELD f_jtmytify BURN_HARD I
 	FIELD f_jwxrxajt WEST Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_kabhoriw shapeGetter Ljava/util/function/Function;
 	FIELD f_lkjukwrn burnChances Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	FIELD f_mwpvhcwj NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_ooajyaij IGNITE_EASY I
@@ -32,6 +33,7 @@ CLASS net/minecraft/unmapped/C_dwizkkyd net/minecraft/block/FireBlock
 		ARG 3 age
 	METHOD m_mvglfnpv getSpreadChance (Lnet/minecraft/unmapped/C_txtbiemp;)I
 		ARG 1 state
+	METHOD m_nkbvpypl createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_ocnocwfu trySpreadingFire (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_rlomrsco;I)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/FireFlyBushBlock.mapping
+++ b/mappings/net/minecraft/block/FireFlyBushBlock.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/unmapped/C_qdmklpvw net/minecraft/block/FireFlyBushBlock
+	FIELD f_khgevxxa UPWARD_PARTICLE_SPREAD D
+	FIELD f_pgixjpfw MAX_LIGHT_FOR_PARTICLE_SPAWN I
+	FIELD f_rzgapzda INVERSE_SOUND_CHANCE I
+	FIELD f_taglidxa HORIZONTAL_PARTICLE_SPREAD D
+	FIELD f_xujddalo PARTICLE_CHANCE D

--- a/mappings/net/minecraft/block/FireFlyBushBlock.mapping
+++ b/mappings/net/minecraft/block/FireFlyBushBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_qdmklpvw net/minecraft/block/FireFlyBushBlock
+CLASS net/minecraft/unmapped/C_qdmklpvw net/minecraft/block/FireflyBushBlock
 	FIELD f_khgevxxa UPWARD_PARTICLE_SPREAD D
 	FIELD f_pgixjpfw MAX_LIGHT_FOR_PARTICLE_SPAWN I
 	FIELD f_rzgapzda INVERSE_SOUND_CHANCE I

--- a/mappings/net/minecraft/block/FlowerBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerBlock.mapping
@@ -6,3 +6,4 @@ CLASS net/minecraft/unmapped/C_zhojkkij net/minecraft/block/FlowerBlock
 	METHOD m_eohzikrf getEffects (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lnet/minecraft/unmapped/C_ceasgpks;
 		ARG 0 effect
 		ARG 1 duration
+	METHOD m_twdcrcyq getCollisionEffect ()Lnet/minecraft/unmapped/C_wpfizwve;

--- a/mappings/net/minecraft/block/FlowerPotBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerPotBlock.mapping
@@ -8,3 +8,6 @@ CLASS net/minecraft/unmapped/C_urzerdak net/minecraft/block/FlowerPotBlock
 		ARG 2 settings
 	METHOD m_ckgcbvvg getPotted ()Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD m_opkmcbyy isEmpty ()Z
+	METHOD m_recxibpy (Lnet/minecraft/unmapped/C_urzerdak;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+		ARG 0 pot
+	METHOD m_xozbfbts tryToggleEyeBlossom (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/FlowerPotBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerPotBlock.mapping
@@ -10,4 +10,4 @@ CLASS net/minecraft/unmapped/C_urzerdak net/minecraft/block/FlowerPotBlock
 	METHOD m_opkmcbyy isEmpty ()Z
 	METHOD m_recxibpy (Lnet/minecraft/unmapped/C_urzerdak;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 		ARG 0 pot
-	METHOD m_xozbfbts tryToggleEyeBlossom (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_xozbfbts tryToggleEyeblossom (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/FluidBlock.mapping
+++ b/mappings/net/minecraft/block/FluidBlock.mapping
@@ -4,10 +4,13 @@ CLASS net/minecraft/unmapped/C_vxkgppzz net/minecraft/block/FluidBlock
 	FIELD f_llasnfwf CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_pbeellxw fluid Lnet/minecraft/unmapped/C_vneqepda;
 	FIELD f_udqymsuo LEVEL Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_xhreluuv WALKABLE_COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zzgryjzt statesByLevel Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/unmapped/C_vneqepda;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 fluid
 		ARG 2 settings
+	METHOD m_dfqjxyjk (Lnet/minecraft/unmapped/C_rxhyurmy;)Lcom/mojang/serialization/DataResult;
+		ARG 0 fluid
 	METHOD m_jbmcokcl receiveNeighborFluids (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 world
 		ARG 2 pos
@@ -15,3 +18,7 @@ CLASS net/minecraft/unmapped/C_vxkgppzz net/minecraft/block/FluidBlock
 	METHOD m_mmjvfxne playExtinguishSound (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 world
 		ARG 2 pos
+	METHOD m_upoqxfov (Lnet/minecraft/unmapped/C_vneqepda;)Lnet/minecraft/unmapped/C_rxhyurmy;
+		ARG 0 flowableFluid
+	METHOD m_yzvqiina (Lnet/minecraft/unmapped/C_vxkgppzz;)Lnet/minecraft/unmapped/C_vneqepda;
+		ARG 0 fluidBlock

--- a/mappings/net/minecraft/block/FluidFillable.mapping
+++ b/mappings/net/minecraft/block/FluidFillable.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/unmapped/C_gvnflrne net/minecraft/block/FluidFillable
 	METHOD m_wguzozcn canFillWithFluid (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_rxhyurmy;)Z
+		ARG 5 fluid
 	METHOD m_ymsxgqxp tryFillWithFluid (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xqketiuf;)Z
+		ARG 1 world

--- a/mappings/net/minecraft/block/GrindstoneBlock.mapping
+++ b/mappings/net/minecraft/block/GrindstoneBlock.mapping
@@ -1,5 +1,10 @@
 CLASS net/minecraft/unmapped/C_lyfxnajv net/minecraft/block/GrindstoneBlock
 	FIELD f_fdpreiim CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_lusjjfxe shapeGetter Ljava/util/function/Function;
 	FIELD f_qqapvvnr TITLE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_pfgzsicd createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_sizmzwww getShape (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 state
+	METHOD m_uboniiog (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_sxzqocrm;Lnet/minecraft/unmapped/C_jzrpycqo;)Lnet/minecraft/unmapped/C_mkrkudpa;
+		ARG 2 syncId
+		ARG 3 playerInventory

--- a/mappings/net/minecraft/block/GrowingPlantPartBlock.mapping
+++ b/mappings/net/minecraft/block/GrowingPlantPartBlock.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/unmapped/C_nplyatkk net/minecraft/block/GrowingPlantPartBloc
 		ARG 3 outlineShape
 		ARG 4 tickWater
 	METHOD m_inibvmov getStem ()Lnet/minecraft/unmapped/C_blxdfgoo;
+	METHOD m_jtvptvwl randomizeAge (Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_oydhwfwm getPlant ()Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD m_whyfcbgc canAttachTo (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 state

--- a/mappings/net/minecraft/block/HopperBlock.mapping
+++ b/mappings/net/minecraft/block/HopperBlock.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_sooxppjc net/minecraft/block/HopperBlock
 	FIELD f_cbeksrsg ENABLED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_irnfmflv raycastShapes Ljava/util/Map;
+	FIELD f_symmlzhj outlineShapeGetter Ljava/util/function/Function;
 	FIELD f_tbukched FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_zghtzfcu CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD m_khtgbdmj createOutlineShapeGetter (Lnet/minecraft/unmapped/C_zscvhwbd;)Ljava/util/function/Function;
+		ARG 1 innerShape
 	METHOD m_ppqouxhc updateEnabled (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/HorizontalConnectingBlock.mapping
+++ b/mappings/net/minecraft/block/HorizontalConnectingBlock.mapping
@@ -1,22 +1,22 @@
 CLASS net/minecraft/unmapped/C_mxklsuxa net/minecraft/block/HorizontalConnectingBlock
 	FIELD f_dqtdhico FACING_PROPERTIES Ljava/util/Map;
+	FIELD f_eomipsfm outlineShapeGetter Ljava/util/function/Function;
+	FIELD f_ikamsyvl collisionShapeGetter Ljava/util/function/Function;
 	FIELD f_qplzfudz NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_stvhajyd SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_vrpnplcn WEST Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_vtrtmhfv WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_xesnlgip EAST Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD <init> (FFFFFLnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
-		ARG 1 radius1
-		ARG 2 radius2
-		ARG 3 boundingHeight1
-		ARG 4 boundingHeight2
+		ARG 2 outlinePostHeight
+		ARG 4 outlineConnectionHeight
 		ARG 5 collisionHeight
 		ARG 6 settings
 	METHOD m_erafjzrz (Ljava/util/Map$Entry;)Z
 		ARG 0 entry
-	METHOD m_oekhoibr createShapes (FFFFF)Ljava/util/function/Function;
-		ARG 1 radius1
-		ARG 2 radius2
-		ARG 3 height1
-		ARG 4 offset2
-		ARG 5 height2
+	METHOD m_oekhoibr createShapeGetter (FFFFF)Ljava/util/function/Function;
+		ARG 1 postWidth
+		ARG 2 postHeight
+		ARG 3 connectionThickness
+		ARG 4 connectionMinY
+		ARG 5 connectionMaxY

--- a/mappings/net/minecraft/block/InventoryProvider.mapping
+++ b/mappings/net/minecraft/block/InventoryProvider.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_iyzflmjd net/minecraft/block/InventoryProvider
 	METHOD m_vwnlbxaz getInventory (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_dqieilpc;
+		ARG 2 world

--- a/mappings/net/minecraft/block/JigsawBlock.mapping
+++ b/mappings/net/minecraft/block/JigsawBlock.mapping
@@ -6,3 +6,5 @@ CLASS net/minecraft/unmapped/C_yxkpprxn net/minecraft/block/JigsawBlock
 	METHOD m_rszfhdiw getRotation (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_xpuuihxf;
 		ARG 0 state
 	METHOD m_tdoreqwf attachmentMatches (Lnet/minecraft/unmapped/C_abvlwuej$C_awytwwja;Lnet/minecraft/unmapped/C_abvlwuej$C_awytwwja;)Z
+		ARG 0 leftInfo
+		ARG 1 rightInfo

--- a/mappings/net/minecraft/block/LadderBlock.mapping
+++ b/mappings/net/minecraft/block/LadderBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_zltezrwu net/minecraft/block/LadderBlock
+	FIELD f_aopdiikd SHAPES Ljava/util/Map;
 	FIELD f_otohkpbg CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_vvjmchry FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_yqyzpxky WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/block/LanternBlock.mapping
+++ b/mappings/net/minecraft/block/LanternBlock.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_iydozliz net/minecraft/block/LanternBlock
 	FIELD f_anqotfie HANGING Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_bptueolr WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_lwvqpscw HANGING_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_urbjexkd CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_wbvjlfpw DEFAULT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	METHOD m_vaahqdnn attachedDirection (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_xpuuihxf;
 		ARG 0 state

--- a/mappings/net/minecraft/block/LeafLitterBlock.mapping
+++ b/mappings/net/minecraft/block/LeafLitterBlock.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_yxjatvwq net/minecraft/block/LeafLitterBlock
+	FIELD f_nqyuhrfg shapeGetter Ljava/util/function/Function;
+	FIELD f_tvxgsyuf FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	METHOD m_akijixow createShapeGetter ()Ljava/util/function/Function;

--- a/mappings/net/minecraft/block/LeavesBlock.mapping
+++ b/mappings/net/minecraft/block/LeavesBlock.mapping
@@ -1,16 +1,5 @@
-CLASS net/minecraft/unmapped/C_vpbrfrld net/minecraft/block/LeavesBlock
-	FIELD f_idpcqsbq DISTANCE Lnet/minecraft/unmapped/C_vltzvhxi;
-	FIELD f_kefxatay PERSISTENT Lnet/minecraft/unmapped/C_xhwijdsd;
-	FIELD f_rjjksefw TICK_DELAY I
-	FIELD f_vpbxbcme WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
-	FIELD f_wlukwelu MAX_DISTANCE I
-	METHOD m_gpxzhkzd getDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;)I
-		ARG 0 state
-	METHOD m_hhmrqbor canDecay (Lnet/minecraft/unmapped/C_txtbiemp;)Z
-		ARG 1 state
-	METHOD m_huyvbgdx getOptionalDistanceFromLog (Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/OptionalInt;
-		ARG 0 state
-	METHOD m_qbhqdinb updateDistanceFromLogs (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
-		ARG 0 state
-		ARG 1 world
-		ARG 2 pos
+CLASS net/minecraft/unmapped/C_skmvaljl net/minecraft/block/LeavesBlock
+	METHOD m_ibcihabl (Lnet/minecraft/unmapped/C_skmvaljl;)Ljava/lang/Float;
+		ARG 0 leaves
+	METHOD m_tpfciadp (Lnet/minecraft/unmapped/C_skmvaljl;)Lnet/minecraft/unmapped/C_nqucohct;
+		ARG 0 leaves

--- a/mappings/net/minecraft/block/LecternBlock.mapping
+++ b/mappings/net/minecraft/block/LecternBlock.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_ksjrzgfh net/minecraft/block/LecternBlock
 	FIELD f_skgkzcxn POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_wkugapry COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_xjamdfmq SCHEDULED_TICK_DELAY I
+	FIELD f_zvmpljkm OUTLINE_SHAPE Ljava/util/Map;
 	METHOD m_kkgqosaq putBookIfAbsent (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 0 entity
 		ARG 1 world

--- a/mappings/net/minecraft/block/LeverBlock.mapping
+++ b/mappings/net/minecraft/block/LeverBlock.mapping
@@ -1,12 +1,14 @@
 CLASS net/minecraft/unmapped/C_hcykfprw net/minecraft/block/LeverBlock
 	FIELD f_eehxwxgv CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_tyacqxtk POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_wqejvzey shapeGetter Ljava/util/function/Function;
 	METHOD m_cilpunoe playToggleSound (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 	METHOD m_frzaiydw updateNeighbors (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
+	METHOD m_kosbrcps createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_qafqjimt spawnParticles (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;F)V
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/LilyPadBlock.mapping
+++ b/mappings/net/minecraft/block/LilyPadBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_scakpyla net/minecraft/block/LilyPadBlock
+	FIELD f_rcomfyqp SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_yffmmnzf CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/MangrovePropaguleBlock.mapping
+++ b/mappings/net/minecraft/block/MangrovePropaguleBlock.mapping
@@ -1,10 +1,13 @@
 CLASS net/minecraft/unmapped/C_txfkypkg net/minecraft/block/MangrovePropaguleBlock
 	FIELD f_arajxszx CODEC Lcom/mojang/serialization/MapCodec;
-	FIELD f_fkllsupi SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_eewxvrlb MIN_Z_BY_AGE [I
+	FIELD f_fkllsupi SHAPES_BY_AGE [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_jjebyzyy AGE_4 Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_tnqcrctm MAX_AGE I
 	FIELD f_wwgigpdl HANGING Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_zrwbtgyz WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	METHOD m_hfjwqmvj (Lnet/minecraft/unmapped/C_txfkypkg;)Lnet/minecraft/unmapped/C_hupbiznx;
+		ARG 0 propagule
 	METHOD m_jhecokjt getHangingState (I)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 0 age
 	METHOD m_jvsnxoxr isHanging (Lnet/minecraft/unmapped/C_txtbiemp;)Z
@@ -12,3 +15,5 @@ CLASS net/minecraft/unmapped/C_txfkypkg net/minecraft/block/MangrovePropaguleBlo
 	METHOD m_kqsrbwkr isFullyGrown (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state
 	METHOD m_wckhwxxr getHangingState ()Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_zoqmcxyn (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 age

--- a/mappings/net/minecraft/block/MossBlock.mapping
+++ b/mappings/net/minecraft/block/MossBlock.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_fqlszbaq net/minecraft/block/MossBlock
+	METHOD m_flsonvjb (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)V
+		ARG 3 feature
+	METHOD m_zhzltnwb (Lnet/minecraft/unmapped/C_fqlszbaq;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 moss

--- a/mappings/net/minecraft/block/MultifaceBlock.mapping
+++ b/mappings/net/minecraft/block/MultifaceBlock.mapping
@@ -1,6 +1,8 @@
-CLASS net/minecraft/unmapped/C_qpwigkki net/minecraft/block/AbstractLichenBlock
+CLASS net/minecraft/unmapped/C_qpwigkki net/minecraft/block/MultifaceBlock
 	FIELD f_edhhkowj DIRECTIONS [Lnet/minecraft/unmapped/C_xpuuihxf;
 	FIELD f_esqfyeak canMirrorZ Z
+	FIELD f_ltmosbqm shapeGetter Ljava/util/function/Function;
+	FIELD f_sveyxyvg WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_uccvsbbr FACING_PROPERTIES Ljava/util/Map;
 	FIELD f_xphtjnjg hasAllHorizontalDirections Z
 	FIELD f_znvlgwkn canMirrorX Z
@@ -17,6 +19,7 @@ CLASS net/minecraft/unmapped/C_qpwigkki net/minecraft/block/AbstractLichenBlock
 	METHOD m_hzdoqmsn hasDirection (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 0 state
 		ARG 1 direction
+	METHOD m_ikgvevnz createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_jaqpamhc canHaveDirection (Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 direction
 	METHOD m_khvcoyem getOpenFaces (Lnet/minecraft/unmapped/C_txtbiemp;)Ljava/util/Set;
@@ -30,6 +33,7 @@ CLASS net/minecraft/unmapped/C_qpwigkki net/minecraft/block/AbstractLichenBlock
 		ARG 4 dir
 	METHOD m_pqscucoi unpackDirections (B)Ljava/util/Set;
 		ARG 0 packed
+	METHOD m_qrhnfhaj canAttachTo (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 	METHOD m_scdkefrx getProperty (Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_xhwijdsd;
 		ARG 0 direction
 	METHOD m_wcjiwopm mirror (Lnet/minecraft/unmapped/C_txtbiemp;Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_txtbiemp;
@@ -37,6 +41,7 @@ CLASS net/minecraft/unmapped/C_qpwigkki net/minecraft/block/AbstractLichenBlock
 		ARG 2 mirror
 	METHOD m_yrphhzpz withAllDirections (Lnet/minecraft/unmapped/C_ezfeikaq;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 0 stateManager
+	METHOD m_zbdoyaiq canAttachAt (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 	METHOD m_zlkvzjhz (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 4 direction
 	METHOD m_zpjxxmlc hasAnyDirection (Lnet/minecraft/unmapped/C_txtbiemp;)Z

--- a/mappings/net/minecraft/block/NetherPortalBlock.mapping
+++ b/mappings/net/minecraft/block/NetherPortalBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_zpsdinym net/minecraft/block/NetherPortalBlock
+	FIELD f_jqsktyee SHAPES Ljava/util/Map;
 	FIELD f_murlvzvr CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_pdbgmnkv AXIS Lnet/minecraft/unmapped/C_cgckxfsw;
 	METHOD m_cuetenod tryCreateTransition (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_hynzadkk;ZLnet/minecraft/unmapped/C_pneibfez;)Lnet/minecraft/unmapped/C_sqhjwpkh;
@@ -12,9 +13,11 @@ CLASS net/minecraft/unmapped/C_zpsdinym net/minecraft/block/NetherPortalBlock
 		ARG 2 startAxis
 		ARG 3 offset
 		ARG 4 entity
+		ARG 5 transition
 	METHOD m_kvaymgqu createTransition (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_wauhtoaq$C_tqypnjit;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sqhjwpkh$C_saosxlyx;)Lnet/minecraft/unmapped/C_sqhjwpkh;
 		ARG 0 entity
 		ARG 2 portalRectangle
+		ARG 4 transition
 	METHOD m_lcmdheru (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 pos2
 	METHOD m_qziuriys (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;)Z

--- a/mappings/net/minecraft/block/NetherWartBlock.mapping
+++ b/mappings/net/minecraft/block/NetherWartBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/unmapped/C_xwlxakin net/minecraft/block/NetherWartBlock
+	FIELD f_apjiesud SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_cralmgby MAX_AGE I
 	FIELD f_wbpmrwbs AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_wmdhcpor CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD m_znbxfbpl (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/ObserverBlock.mapping
+++ b/mappings/net/minecraft/block/ObserverBlock.mapping
@@ -6,4 +6,5 @@ CLASS net/minecraft/unmapped/C_vyejtyga net/minecraft/block/ObserverBlock
 		ARG 2 pos
 		ARG 3 state
 	METHOD m_zpwqujyv scheduleTick (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_adoatlrf;Lnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 2 tickAccess
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PaleHangingMossBlock.mapping
+++ b/mappings/net/minecraft/block/PaleHangingMossBlock.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_ujcipsff net/minecraft/block/PaleHangingMossBlock
+	FIELD f_iglqfkym TIP Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_mgushzaa TIP_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_wnmsdzah BASE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	METHOD m_bdddddgr canGrowInto (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_flwsbonc findLowest (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_twxkrpfg canAttachAbove (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z

--- a/mappings/net/minecraft/block/PaleMossCarpetBlock.mapping
+++ b/mappings/net/minecraft/block/PaleMossCarpetBlock.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/unmapped/C_dgjnmbkq net/minecraft/block/PaleMossCarpetBlock
-	FIELD f_avkomfyj WALL_SHAPES Ljava/util/Map;
-	FIELD f_cdsbxnjo SOUTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_avkomfyj CONNECTION_PROPERTIES Ljava/util/Map;
+	FIELD f_cdsbxnjo SOUTH Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_ckiimgnw BOTTOM Lnet/minecraft/unmapped/C_xhwijdsd;
-	FIELD f_dxquavhi NORTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
-	FIELD f_pygcgezd EAST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
-	FIELD f_rfahglcq WEST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_dxquavhi NORTH Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_pygcgezd EAST Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_rfahglcq WEST Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_uljyaikg shapeGetter Ljava/util/function/Function;
 	METHOD m_bwonrrkl canAttachAt (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 	METHOD m_bwwwepzk getTopState (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/function/BooleanSupplier;)Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/PaleMossCarpetBlock.mapping
+++ b/mappings/net/minecraft/block/PaleMossCarpetBlock.mapping
@@ -1,0 +1,19 @@
+CLASS net/minecraft/unmapped/C_dgjnmbkq net/minecraft/block/PaleMossCarpetBlock
+	FIELD f_avkomfyj WALL_SHAPES Ljava/util/Map;
+	FIELD f_cdsbxnjo SOUTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_ckiimgnw BOTTOM Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_dxquavhi NORTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_pygcgezd EAST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_rfahglcq WEST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_uljyaikg shapeGetter Ljava/util/function/Function;
+	METHOD m_bwonrrkl canAttachAt (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
+	METHOD m_bwwwepzk getTopState (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/function/BooleanSupplier;)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 2 allowSide
+	METHOD m_dcutulrw place (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;I)V
+		ARG 0 world
+		ARG 3 flags
+	METHOD m_dwpfvnkk getWallShape (Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_cgckxfsw;
+	METHOD m_gwzkualz createShapeGetter ()Ljava/util/function/Function;
+	METHOD m_osflvwub hasFaces (Lnet/minecraft/unmapped/C_txtbiemp;)Z
+	METHOD m_wbditfid updateState (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Z)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 3 low

--- a/mappings/net/minecraft/block/PiglinWallHeadBlock.mapping
+++ b/mappings/net/minecraft/block/PiglinWallHeadBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_hpdbnucu net/minecraft/block/PiglinWallHeadBlock
+	FIELD f_hfhupbch SHAPES Ljava/util/Map;
 	FIELD f_zxyfafzz CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/PinkPetalsBlock.mapping
+++ b/mappings/net/minecraft/block/PinkPetalsBlock.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_mrovvmos net/minecraft/block/PinkPetalsBlock
+	FIELD f_netvoosq FLOWER_AMOUNT Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_rvpzhcln shapeGetter Ljava/util/function/Function;
+	FIELD f_vefdjcbs FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	METHOD m_mkimpfzk createShapeGetter ()Ljava/util/function/Function;

--- a/mappings/net/minecraft/block/PitcherCropBlock.mapping
+++ b/mappings/net/minecraft/block/PitcherCropBlock.mapping
@@ -1,8 +1,12 @@
 CLASS net/minecraft/unmapped/C_fntbpikr net/minecraft/block/PitcherCropBlock
+	FIELD f_azfinfxx AGE_0_COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_fnokzkbm BONE_MEAL_AGE_INCREASE I
 	FIELD f_hfwwcmcn SIZE_INCREASE_AGE I
+	FIELD f_ilvqpehn HALF Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_sfooqodv outlineShapeGetter Ljava/util/function/Function;
 	FIELD f_tomgjyza MAX_AGE I
 	FIELD f_wuvsofas CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_xxqijxdf DEFAULT_COLLISION_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zixwbbhv AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD m_comeruhy isDoubleTallAtAge (I)Z
 		ARG 0 age
@@ -30,6 +34,7 @@ CLASS net/minecraft/unmapped/C_fntbpikr net/minecraft/block/PitcherCropBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+	METHOD m_wnhlvoyq createOutlineShaperGetter ()Ljava/util/function/Function;
 	CLASS C_jrcoboha LowerHalfInfo
 		FIELD f_bathctbu pos Lnet/minecraft/unmapped/C_hynzadkk;
 		FIELD f_zoszfvcj state Lnet/minecraft/unmapped/C_txtbiemp;

--- a/mappings/net/minecraft/block/PotatoesBlock.mapping
+++ b/mappings/net/minecraft/block/PotatoesBlock.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/unmapped/C_zfuvuhrn net/minecraft/block/PotatoesBlock
+	FIELD f_fckbvqge SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_groahegb CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD m_pgsfimzl (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/PressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/PressurePlateBlock.mapping
@@ -4,3 +4,5 @@ CLASS net/minecraft/unmapped/C_dzitlvcv net/minecraft/block/PressurePlateBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_hgpogkhy;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 blockSetType
 		ARG 2 settings
+	METHOD m_liwndlth (Lnet/minecraft/unmapped/C_dzitlvcv;)Lnet/minecraft/unmapped/C_hgpogkhy;
+		ARG 0 pressurePlate

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -1,9 +1,10 @@
 CLASS net/minecraft/unmapped/C_hbdlqish net/minecraft/block/RedstoneWireBlock
 	FIELD f_bcvuxzmx POWER Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_fyjjmxtv WIRE_CONNECTION_SOUTH Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_hilvmyql shapeGetter Ljava/util/function/Function;
 	FIELD f_isurntyc WIRE_CONNECTION_NORTH Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_jjwmffoj DIRECTION_TO_WIRE_CONNECTION_PROPERTY Ljava/util/Map;
-	FIELD f_laswtpnf COLORS [I
+	FIELD f_laswtpnf COLORS_BY_POWER [I
 	FIELD f_lhkdefum WIRE_CONNECTION_WEST Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_ooedtwdp dotState Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_psbskmvz CODEC Lcom/mojang/serialization/MapCodec;
@@ -11,6 +12,8 @@ CLASS net/minecraft/unmapped/C_hbdlqish net/minecraft/block/RedstoneWireBlock
 	FIELD f_qomovzle WIRE_CONNECTION_EAST Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_quuiddba wiresGivePower Z
 	FIELD f_qwcrdmpx controller Lnet/minecraft/unmapped/C_lakkobyv;
+	METHOD m_ahfsctfo ([I)V
+		ARG 0 colorsByPower
 	METHOD m_brufkqwu updateNeighbors (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 world
 		ARG 2 pos
@@ -30,7 +33,8 @@ CLASS net/minecraft/unmapped/C_hbdlqish net/minecraft/block/RedstoneWireBlock
 		ARG 3 oldState
 		ARG 4 newState
 	METHOD m_kofgxicj getWireColor (I)I
-		ARG 0 powerLevel
+		ARG 0 power
+	METHOD m_mgogczbz createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_nmxjtrcu addPoweredParticles (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;ILnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_xpuuihxf;FF)V
 		ARG 0 world
 		ARG 1 random

--- a/mappings/net/minecraft/block/RodBlock.mapping
+++ b/mappings/net/minecraft/block/RodBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/unmapped/C_wvtzqngj net/minecraft/block/RodBlock
+	FIELD f_cgufbqhr SHAPES Ljava/util/Map;

--- a/mappings/net/minecraft/block/SandBlock.mapping
+++ b/mappings/net/minecraft/block/SandBlock.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_hdfyaaty net/minecraft/block/SandBlock
+	METHOD m_ynoexjjt (Lnet/minecraft/unmapped/C_hdfyaaty;)Lnet/minecraft/unmapped/C_cibvoqed;
+		ARG 0 sand

--- a/mappings/net/minecraft/block/ScaffoldingBlock.mapping
+++ b/mappings/net/minecraft/block/ScaffoldingBlock.mapping
@@ -1,9 +1,13 @@
 CLASS net/minecraft/unmapped/C_gtgfyrcn net/minecraft/block/ScaffoldingBlock
 	FIELD f_fnuvwstn CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_funabfyp TICK_DELAY I
+	FIELD f_huefzifl CUBE_BELOW Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_ifsdymrq DEFAULT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_joqpkqpr BOTTOM Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_kbnzjaip DISTANCE Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_lcztkxcb BOTTOM_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ngmcspig MAX_DISTANCE I
+	FIELD f_nzbloiqz OUTLINE_SHAPE_WITH_BOTTOM Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_uiqqtthz WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD m_spwwnuqp calculateDistance (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)I
 		ARG 0 world

--- a/mappings/net/minecraft/block/SeaPickleBlock.mapping
+++ b/mappings/net/minecraft/block/SeaPickleBlock.mapping
@@ -2,6 +2,10 @@ CLASS net/minecraft/unmapped/C_yvwvhmsg net/minecraft/block/SeaPickleBlock
 	FIELD f_jdmptisp MAX_PICKLES I
 	FIELD f_pbgrbldt WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_sgnqovsp CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_udfrnhdq SINGLE_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_vpiwgxvx TRI_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_vsvkxkgh BI_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_xbvvsedm QUAD_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_yjzuvuwd PICKLES Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD m_xldeseup isDry (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 0 state

--- a/mappings/net/minecraft/block/SeaPickleBlock.mapping
+++ b/mappings/net/minecraft/block/SeaPickleBlock.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/unmapped/C_yvwvhmsg net/minecraft/block/SeaPickleBlock
 	FIELD f_jdmptisp MAX_PICKLES I
 	FIELD f_pbgrbldt WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_sgnqovsp CODEC Lcom/mojang/serialization/MapCodec;
-	FIELD f_udfrnhdq SINGLE_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_udfrnhdq MONO_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_vpiwgxvx TRI_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_vsvkxkgh BI_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_xbvvsedm QUAD_PICKLE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/Segmented.mapping
+++ b/mappings/net/minecraft/block/Segmented.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/unmapped/C_lskgiwlp net/minecraft/block/Segmented
+	FIELD f_emvxkmna SEGMENT_AMOUNT Lnet/minecraft/unmapped/C_vltzvhxi;
+	FIELD f_gvcnlpah MIN_SEGMENTS I
+	FIELD f_thvihzrz MAX_SEGMENTS I
+	METHOD m_ahusxvkw getHeight ()D
+	METHOD m_huodadyt createShapeGetter (Lnet/minecraft/unmapped/C_cgckxfsw;Lnet/minecraft/unmapped/C_vltzvhxi;)Ljava/util/function/Function;
+		ARG 1 facing
+		ARG 2 segmentAmount
+	METHOD m_isqxbnjj getPlacementState (Lnet/minecraft/unmapped/C_aiootljq;Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_vltzvhxi;Lnet/minecraft/unmapped/C_cgckxfsw;)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 1 context
+		ARG 3 segmentAmount
+		ARG 4 facing
+	METHOD m_kncxzfqb canAddSegment (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_aiootljq;Lnet/minecraft/unmapped/C_vltzvhxi;)Z
+		ARG 2 context
+		ARG 3 segmentAmount
+	METHOD m_xvuwnktr getSegmentAmount ()Lnet/minecraft/unmapped/C_vltzvhxi;

--- a/mappings/net/minecraft/block/ShapeContext.mapping
+++ b/mappings/net/minecraft/block/ShapeContext.mapping
@@ -1,10 +1,17 @@
 CLASS net/minecraft/unmapped/C_pbfjvesm net/minecraft/block/ShapeContext
 	METHOD m_daqtnaqm isAbove (Lnet/minecraft/unmapped/C_zscvhwbd;Lnet/minecraft/unmapped/C_hynzadkk;Z)Z
+		ARG 1 shape
+		ARG 3 defaultValue
 	METHOD m_ffgvonpe canWalkOnFluid (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_xqketiuf;)Z
+		ARG 1 stateAbove
+		ARG 2 stateBelow
 	METHOD m_fuhloafm of (Lnet/minecraft/unmapped/C_astfners;Z)Lnet/minecraft/unmapped/C_pbfjvesm;
+	METHOD m_gbtkffux createPlacement (Lnet/minecraft/unmapped/C_astfners;)Lnet/minecraft/unmapped/C_pbfjvesm;
 	METHOD m_hussiivc isDescending ()Z
 	METHOD m_jwyjjkqk getCollisionShape (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zscvhwbd;
+	METHOD m_vmhjwqgh isPlacement ()Z
 	METHOD m_wristroz absent ()Lnet/minecraft/unmapped/C_pbfjvesm;
 	METHOD m_xvebqowz of (Lnet/minecraft/unmapped/C_astfners;)Lnet/minecraft/unmapped/C_pbfjvesm;
 		ARG 0 entity
 	METHOD m_yktbztwe isHolding (Lnet/minecraft/unmapped/C_vorddnax;)Z
+		ARG 1 item

--- a/mappings/net/minecraft/block/ShortDryGrassBlock.mapping
+++ b/mappings/net/minecraft/block/ShortDryGrassBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_gcgpzxaz net/minecraft/block/ShortDryGrassBlock
+	FIELD f_ogrfphmk SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/ShulkerBoxBlock.mapping
+++ b/mappings/net/minecraft/block/ShulkerBoxBlock.mapping
@@ -3,9 +3,12 @@ CLASS net/minecraft/unmapped/C_buvdtidq net/minecraft/block/ShulkerBoxBlock
 	FIELD f_lkgtjife CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_tdgqhkue color Lnet/minecraft/unmapped/C_arllgqae;
 	FIELD f_wkcidmzm FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_xtsphndr OPEN_SIDES_SHAPES Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/unmapped/C_arllgqae;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 color
 		ARG 2 settings
+	METHOD m_bvrautpr (Lnet/minecraft/unmapped/C_buvdtidq;)Ljava/util/Optional;
+		ARG 0 shulkerBox
 	METHOD m_ebdznmod get (Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_mmxmpdoq;
 		ARG 0 dyeColor
 	METHOD m_ikgriolf getColor ()Lnet/minecraft/unmapped/C_arllgqae;
@@ -14,5 +17,9 @@ CLASS net/minecraft/unmapped/C_buvdtidq net/minecraft/block/ShulkerBoxBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 entity
+	METHOD m_mogwlsyy (Ljava/util/Optional;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)Lnet/minecraft/unmapped/C_buvdtidq;
+		ARG 0 color
+	METHOD m_oqjczujq (Lnet/minecraft/unmapped/C_gauehqwp;Ljava/util/function/Consumer;)V
+		ARG 1 lootProcessor
 	METHOD m_qodetxpq getItemStack (Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 color

--- a/mappings/net/minecraft/block/SimpleFallingBlock.mapping
+++ b/mappings/net/minecraft/block/SimpleFallingBlock.mapping
@@ -1,6 +1,6 @@
-CLASS net/minecraft/unmapped/C_itgkwhcl net/minecraft/block/GravelBlock
+CLASS net/minecraft/unmapped/C_itgkwhcl net/minecraft/block/SimpleFallingBlock
+	FIELD f_qwjtqmlo fallingDustColor Lnet/minecraft/unmapped/C_cibvoqed;
 	FIELD f_yxybjzxl CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD <init> (Lnet/minecraft/unmapped/C_cibvoqed;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
-		ARG 2 settings
 	METHOD m_yleajjok (Lnet/minecraft/unmapped/C_itgkwhcl;)Lnet/minecraft/unmapped/C_cibvoqed;
 		ARG 0 block

--- a/mappings/net/minecraft/block/SkullBlock.mapping
+++ b/mappings/net/minecraft/block/SkullBlock.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_hxsyxqpk net/minecraft/block/SkullBlock
 	FIELD f_fgapzkrl ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_rmagnoue SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_upetgxnt ROTATIONS I
+	FIELD f_vlvwypim PIGLIN_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zhfyviib CODEC Lcom/mojang/serialization/MapCodec;
 	CLASS C_dhimybfk Type
 		FIELD f_fbwsdwdv type Ljava/lang/String;

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_uydyvltw net/minecraft/block/SlabBlock
+	FIELD f_fsyvfgnu BOTTOM_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_qbthpsch TOP_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_tztplpce CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_ughgjrgk WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_wiwaxqha TYPE Lnet/minecraft/unmapped/C_cgckxfsw;

--- a/mappings/net/minecraft/block/SnowBlock.mapping
+++ b/mappings/net/minecraft/block/SnowBlock.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/unmapped/C_ktljneel net/minecraft/block/SnowBlock
+	FIELD f_ljadxqrw SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_mcsxbovn CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_oyzvzfvo MAX_LAYERS I
 	FIELD f_qnknmtmz IMPASSABLE_HEIGHT I
 	FIELD f_wuwkgncr LAYERS Lnet/minecraft/unmapped/C_vltzvhxi;
+	METHOD m_sbizxyuh (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/SpreadBehavior.mapping
+++ b/mappings/net/minecraft/block/SpreadBehavior.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
+CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/SpreadBehavior
 	FIELD f_dzdqprmy settings Lnet/minecraft/unmapped/C_twpgwpwn$C_bkszmbsg;
 	FIELD f_hxidotvq PLACEMENT_TYPES [Lnet/minecraft/unmapped/C_twpgwpwn$C_qizcpldd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_qpwigkki;)V
@@ -11,7 +11,7 @@ CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-		ARG 4 direction
+		ARG 4 facing
 		ARG 5 postProcess
 	METHOD m_huvmmobp (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;ZLnet/minecraft/unmapped/C_xpuuihxf;)Ljava/util/Optional;
 		ARG 6 dir
@@ -19,8 +19,8 @@ CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-		ARG 4 dirA
-		ARG 5 dirB
+		ARG 4 facing
+		ARG 5 direction
 		ARG 6 spreadPredicate
 	METHOD m_jfrwlpgd (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 2 dir
@@ -66,7 +66,7 @@ CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
 		ARG 5 random
 		ARG 6 postProcess
 	METHOD m_zxdekzte (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;ZLnet/minecraft/unmapped/C_xpuuihxf;)Ljava/util/Optional;
-		ARG 6 dir
+		ARG 6 direction
 	CLASS C_bkszmbsg LichenGrowSettings
 		METHOD m_bkjsmvdk hasDirection (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 			ARG 1 state
@@ -84,18 +84,17 @@ CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
 			ARG 4 postProcess
 		METHOD m_uqmmicii getPlacementTypes ()[Lnet/minecraft/unmapped/C_twpgwpwn$C_qizcpldd;
 		METHOD m_usfyhdsi canSpreadTo (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_twpgwpwn$C_evcfujfb;)Z
+			ARG 3 placement
 	CLASS C_evcfujfb Placement
-		FIELD f_hnshqxjx pos Lnet/minecraft/unmapped/C_hynzadkk;
-		FIELD f_prscndxq face Lnet/minecraft/unmapped/C_xpuuihxf;
 		METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)V
 			ARG 1 pos
 			ARG 2 face
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
-		METHOD m_qvcivskc pos ()Lnet/minecraft/unmapped/C_hynzadkk;
-		METHOD m_wzrvmsnr face ()Lnet/minecraft/unmapped/C_xpuuihxf;
 	CLASS C_qizcpldd PlacementType
 		METHOD m_wikhcnvz getPlacement (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_twpgwpwn$C_evcfujfb;
+			ARG 2 direction
+			ARG 3 facing
 	CLASS C_tubanqjd DefaultLichenSpreadBehavior
 		FIELD f_fvrmmeon block Lnet/minecraft/unmapped/C_qpwigkki;
 		METHOD <init> (Lnet/minecraft/unmapped/C_qpwigkki;)V
@@ -107,3 +106,5 @@ CLASS net/minecraft/unmapped/C_twpgwpwn net/minecraft/block/LichenSpreadBehavior
 			ARG 4 dir
 			ARG 5 state
 	CLASS C_voceixjn LichenSpreadPredicate
+		METHOD test (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_twpgwpwn$C_evcfujfb;)Z
+			ARG 3 placement

--- a/mappings/net/minecraft/block/StairsBlock.mapping
+++ b/mappings/net/minecraft/block/StairsBlock.mapping
@@ -1,14 +1,25 @@
 CLASS net/minecraft/unmapped/C_cympqakq net/minecraft/block/StairsBlock
+	FIELD f_btbpflbi STRAIGHT_TOP_SHAPES Ljava/util/Map;
 	FIELD f_depvmvwy FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_dwucfilj WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_ewdzprbz baseBlockState Lnet/minecraft/unmapped/C_txtbiemp;
+	FIELD f_fepijcze OUTER_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_gszpaomv INNER_TOP_SHAPES Ljava/util/Map;
+	FIELD f_hsmmfvgu STRAIGHT_BOTTOM_SHAPES Ljava/util/Map;
+	FIELD f_iofmzwgy OUTER_TOP_SHAPES Ljava/util/Map;
 	FIELD f_jryfvpgt HALF Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_lnrumkcx STRAIGHT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_osrvxphi INNER_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_pcnuybnq INNER_BOTTOM_SHAPES Ljava/util/Map;
 	FIELD f_pqodobau SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_qxjmogum OUTER_BOTTOM_SHAPES Ljava/util/Map;
 	FIELD f_vdpjcmqo CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_xnbljgrj baseBlock Lnet/minecraft/unmapped/C_mmxmpdoq;
 	METHOD <init> (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 baseBlockState
 		ARG 2 settings
+	METHOD m_fihiitox (Lnet/minecraft/unmapped/C_cympqakq;)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 0 stairs
 	METHOD m_wegfelin getStairShape (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_cvhbrohc;
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/StemBlock.mapping
+++ b/mappings/net/minecraft/block/StemBlock.mapping
@@ -2,8 +2,15 @@ CLASS net/minecraft/unmapped/C_axspiekm net/minecraft/block/StemBlock
 	FIELD f_andaodyd gourdBlock Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_bcaiwwrj CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_ghfpagvn MAX_AGE I
+	FIELD f_gssbykfn SHAPES_BY_AGE [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_zumpxpvl AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD <init> (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 4 settings
+	METHOD m_aqalvceo (Lnet/minecraft/unmapped/C_axspiekm;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 stem
+	METHOD m_fnscnilo (Lnet/minecraft/unmapped/C_axspiekm;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 stem
 	METHOD m_ngodxzvh (I)Lnet/minecraft/unmapped/C_zscvhwbd;
-		ARG 0 index
+		ARG 0 age
+	METHOD m_wkzfwjtm (Lnet/minecraft/unmapped/C_axspiekm;)Lnet/minecraft/unmapped/C_xhhleach;
+		ARG 0 stem

--- a/mappings/net/minecraft/block/StemBlock.mapping
+++ b/mappings/net/minecraft/block/StemBlock.mapping
@@ -5,3 +5,5 @@ CLASS net/minecraft/unmapped/C_axspiekm net/minecraft/block/StemBlock
 	FIELD f_zumpxpvl AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	METHOD <init> (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 4 settings
+	METHOD m_ngodxzvh (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
+++ b/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_poezjjlg net/minecraft/block/SweetBerryBushBlock
+	FIELD f_duajqima AGE_2_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_hkjkzvus MAX_AGE I
+	FIELD f_hvvsosdg AGE_0_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_jprytqio AGE Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_oldqstau CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_xrieoxmk HURT_SPEED_THRESHOLD F

--- a/mappings/net/minecraft/block/TallDryGrassBlock.mapping
+++ b/mappings/net/minecraft/block/TallDryGrassBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_vpxcxlol net/minecraft/block/TallDryGrassBlock
+	FIELD f_qqyvldhi SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;

--- a/mappings/net/minecraft/block/TerracottaBlock.mapping
+++ b/mappings/net/minecraft/block/TerracottaBlock.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_ewsiefka net/minecraft/block/TerracottaBlock

--- a/mappings/net/minecraft/block/TintedLeavesBlock.mapping
+++ b/mappings/net/minecraft/block/TintedLeavesBlock.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_jphkfedl net/minecraft/block/TintedLeavesBlock
+	METHOD m_jjkeoxen (Lnet/minecraft/unmapped/C_jphkfedl;)Ljava/lang/Float;
+		ARG 0 leaves

--- a/mappings/net/minecraft/block/TntBlock.mapping
+++ b/mappings/net/minecraft/block/TntBlock.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/unmapped/C_iogckvwc net/minecraft/block/TntBlock
 	FIELD f_hpigguou UNSTABLE Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_vdxyexuy CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD m_jryipkhl tryPrime (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 igniter
+	METHOD m_uxablyoa tryPrime (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)Z

--- a/mappings/net/minecraft/block/TorchflowerCropBlock.mapping
+++ b/mappings/net/minecraft/block/TorchflowerCropBlock.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/unmapped/C_ujhirzat net/minecraft/block/TorchflowerCropBlock
+	FIELD f_ctdxlfvq SHAPES [Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_nexibmib BONE_MEAL_AGE_INCREASE I
 	FIELD f_oevbhszp CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_pqtlzkml MAX_AGE I
 	FIELD f_thxmbdfh AGE Lnet/minecraft/unmapped/C_vltzvhxi;
+	METHOD m_syfrbdwv (I)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 0 index

--- a/mappings/net/minecraft/block/TrapdoorBlock.mapping
+++ b/mappings/net/minecraft/block/TrapdoorBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_blienibu net/minecraft/block/TrapdoorBlock
 	FIELD f_dpypizye CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_epgffpvh SHAPES Ljava/util/Map;
 	FIELD f_kjzcyrld OPEN Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_oddlskad HALF Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_oekjcdrj blockSetType Lnet/minecraft/unmapped/C_hgpogkhy;
@@ -8,6 +9,8 @@ CLASS net/minecraft/unmapped/C_blienibu net/minecraft/block/TrapdoorBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_hgpogkhy;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 2 settings
 	METHOD m_ivpnsrmb getBlockSetType ()Lnet/minecraft/unmapped/C_hgpogkhy;
+	METHOD m_lqzxglqu (Lnet/minecraft/unmapped/C_blienibu;)Lnet/minecraft/unmapped/C_hgpogkhy;
+		ARG 0 trapdoor
 	METHOD m_xyknaeeg playToggleSound (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Z)V
 		ARG 1 player
 		ARG 2 world

--- a/mappings/net/minecraft/block/TrialSpawnerConfig.mapping
+++ b/mappings/net/minecraft/block/TrialSpawnerConfig.mapping
@@ -1,10 +1,14 @@
 CLASS net/minecraft/unmapped/C_pocjjnjk net/minecraft/block/TrialSpawnerConfig
 	FIELD f_mqsazqov HOLDER_CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_pgmmnfet spawnPotentials Lnet/minecraft/unmapped/C_bvkdjias;
 	FIELD f_vbllmfpg CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_ykrjgiui DEFAULT_INSTANCE Lnet/minecraft/unmapped/C_pocjjnjk;
 	METHOD m_akovexzz builder ()Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
 	METHOD m_fsslncbi getSimultaneousMobs (I)I
 		ARG 1 additionalPlayers
+	METHOD m_pfahxibi spawnPotentials ()Lnet/minecraft/unmapped/C_bvkdjias;
+	METHOD m_pnlczsea withSpawnedType (Lnet/minecraft/unmapped/C_ogavsvbr;)Lnet/minecraft/unmapped/C_pocjjnjk;
+		ARG 1 type
 	METHOD m_rjwfxsix getCooldown ()J
 	METHOD m_snjxtjjk getTotalMobs (I)I
 		ARG 1 additionalPlayers
@@ -21,6 +25,7 @@ CLASS net/minecraft/unmapped/C_pocjjnjk net/minecraft/block/TrialSpawnerConfig
 		FIELD f_tmgwtcsf spawnRange I
 		FIELD f_vfxijlzt totalMobs F
 		METHOD m_atarftzm spawnPotentialDefinition (Lnet/minecraft/unmapped/C_bvkdjias;)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
+			ARG 1 definitions
 		METHOD m_bdhifmhg spawnRange (I)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
 			ARG 1 range
 		METHOD m_cappnuim totalMobs (F)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
@@ -32,6 +37,7 @@ CLASS net/minecraft/unmapped/C_pocjjnjk net/minecraft/block/TrialSpawnerConfig
 		METHOD m_kavdpwjp ticksBetweenSpawn (I)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
 			ARG 1 ticks
 		METHOD m_oindwyhl lootTablesToEject (Lnet/minecraft/unmapped/C_bvkdjias;)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
+			ARG 1 lootTables
 		METHOD m_rmwakhzj totalMobsAddedPerPlayer (F)Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
 			ARG 1 total
 		METHOD m_uitredfl build ()Lnet/minecraft/unmapped/C_pocjjnjk;

--- a/mappings/net/minecraft/block/TrialSpawnerConfig.mapping
+++ b/mappings/net/minecraft/block/TrialSpawnerConfig.mapping
@@ -7,7 +7,8 @@ CLASS net/minecraft/unmapped/C_pocjjnjk net/minecraft/block/TrialSpawnerConfig
 	METHOD m_fsslncbi getSimultaneousMobs (I)I
 		ARG 1 additionalPlayers
 	METHOD m_pfahxibi spawnPotentials ()Lnet/minecraft/unmapped/C_bvkdjias;
-	METHOD m_pnlczsea withSpawnedType (Lnet/minecraft/unmapped/C_ogavsvbr;)Lnet/minecraft/unmapped/C_pocjjnjk;
+	METHOD m_pnlczsea spawning (Lnet/minecraft/unmapped/C_ogavsvbr;)Lnet/minecraft/unmapped/C_pocjjnjk;
+		COMMENT Creates a copy of this config that only spawns the passed entity {@code type}.
 		ARG 1 type
 	METHOD m_rjwfxsix getCooldown ()J
 	METHOD m_snjxtjjk getTotalMobs (I)I

--- a/mappings/net/minecraft/block/TripwireBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireBlock.mapping
@@ -4,18 +4,25 @@ CLASS net/minecraft/unmapped/C_jioxkxuh net/minecraft/block/TripwireBlock
 	FIELD f_brquvkhj ATTACHED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_bvmghuqu SCHEDULED_TICK_DELAY I
 	FIELD f_fejqsxzk POWERED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_firviavh ATTACHED_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_fzlcqibs SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_niwtbdvo FACING_PROPERTIES Ljava/util/Map;
+	FIELD f_ogclusit DETACHED_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_umgfotgd WEST Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_vixybtxv hookBlock Lnet/minecraft/unmapped/C_mmxmpdoq;
 	FIELD f_ygoevwny NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_zlnaiupe EAST Lnet/minecraft/unmapped/C_xhwijdsd;
 	METHOD <init> (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 2 settings
+	METHOD m_aoxnkfmr (Lnet/minecraft/unmapped/C_jioxkxuh;)Lnet/minecraft/unmapped/C_mmxmpdoq;
+		ARG 0 tripwire
+	METHOD m_lnqdcleo updatePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;)V
 	METHOD m_ujwatwhc update (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+	METHOD m_usfuznjy updatePowered (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/List;)V
+		ARG 3 overlappingEntites
 	METHOD m_zzwomknz shouldConnectTo (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 state
 		ARG 2 facing

--- a/mappings/net/minecraft/block/TripwireHookBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireHookBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_wyvomnwd net/minecraft/block/TripwireHookBlock
 	FIELD f_evgoeppb CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_fkkiqnbe SHAPES Ljava/util/Map;
 	FIELD f_gebdttag ATTACHED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_mpcyfvrl FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_ogkzjvcx MIN_WIRE_DISTANCE I

--- a/mappings/net/minecraft/block/VineBlock.mapping
+++ b/mappings/net/minecraft/block/VineBlock.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_fybkrjjz net/minecraft/block/VineBlock
 	FIELD f_nfnyosxp WEST Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_ucdkeaeo FACING_PROPERTIES Ljava/util/Map;
 	FIELD f_upgxtace SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_zisebrzg shapeGetter Ljava/util/function/Function;
 	METHOD m_apsjkgja getGrownState (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 1 above
 		ARG 2 state
@@ -30,6 +31,7 @@ CLASS net/minecraft/unmapped/C_fybkrjjz net/minecraft/block/VineBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 side
+	METHOD m_vuhonxzk createShapeGetter ()Ljava/util/function/Function;
 	METHOD m_waugikbm canGrowAt (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -1,7 +1,16 @@
 CLASS net/minecraft/unmapped/C_duybclay net/minecraft/block/WallBlock
+	FIELD f_cqeebotz SOUTH Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_doeyxeoh outlineShapeGetter Ljava/util/function/Function;
+	FIELD f_eyhgmehw WEST Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_iildrtsa WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_kctvuilr CONNECTION_PROPERTIES Ljava/util/Map;
+	FIELD f_kyylfftr POST_CHECK_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_lcbrbqqy CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_stcqveac collisionShapeGetter Ljava/util/function/Function;
+	FIELD f_tcrpcigc EAST Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_wfwahvuy UP Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_wlnhlbfg CONNECTION_SHAPES Ljava/util/Map;
+	FIELD f_wxwzafjx NORTH Lnet/minecraft/unmapped/C_cgckxfsw;
 	METHOD m_huumgauz getWallShape (ZLnet/minecraft/unmapped/C_zscvhwbd;Lnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_seqcnhpn;
 		ARG 1 connected
 		ARG 2 aboveShape
@@ -10,7 +19,7 @@ CLASS net/minecraft/unmapped/C_duybclay net/minecraft/block/WallBlock
 		ARG 1 state
 		ARG 2 aboveState
 		ARG 3 aboveShape
-	METHOD m_luvkvpwo updateSides (Lnet/minecraft/unmapped/C_txtbiemp;ZZZZLnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_luvkvpwo updateConnections (Lnet/minecraft/unmapped/C_txtbiemp;ZZZZLnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_txtbiemp;
 		ARG 1 state
 		ARG 2 north
 		ARG 3 east
@@ -21,7 +30,7 @@ CLASS net/minecraft/unmapped/C_duybclay net/minecraft/block/WallBlock
 		ARG 1 state
 		ARG 2 faceFullSquare
 		ARG 3 side
-	METHOD m_rxtmalgb getShapeMap (FF)Ljava/util/function/Function;
+	METHOD m_rxtmalgb createShapeGetter (FF)Ljava/util/function/Function;
 		ARG 1 minX
 		ARG 2 minY
 	METHOD m_uavsfxkd isConnected (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_vzlztuyw;)Z

--- a/mappings/net/minecraft/block/WallSkullBlock.mapping
+++ b/mappings/net/minecraft/block/WallSkullBlock.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/unmapped/C_allytoiq net/minecraft/block/WallSkullBlock
 	FIELD f_amyryghk FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_fdigciat SHAPES Ljava/util/Map;
 	FIELD f_pmmddbzz CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/WallTorchBlock.mapping
+++ b/mappings/net/minecraft/block/WallTorchBlock.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/unmapped/C_pqbshjyj net/minecraft/block/WallTorchBlock
 	FIELD f_gbciyzjv FACING Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_ocpptuid SHAPES Ljava/util/Map;
 	FIELD f_touxqlyd CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_asezpade canPlaceAt (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
-	METHOD m_lvkogfqx getBoundingShape (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_zscvhwbd;
+	METHOD m_hkdntgfo (Lnet/minecraft/unmapped/C_pqbshjyj;)Lnet/minecraft/unmapped/C_lwmufxcy;
+		ARG 0 tallTorch
+	METHOD m_lvkogfqx getShape (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 0 state

--- a/mappings/net/minecraft/block/WallTorchBlock.mapping
+++ b/mappings/net/minecraft/block/WallTorchBlock.mapping
@@ -4,6 +4,6 @@ CLASS net/minecraft/unmapped/C_pqbshjyj net/minecraft/block/WallTorchBlock
 	FIELD f_touxqlyd CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_asezpade canPlaceAt (Lnet/minecraft/unmapped/C_eemzphbi;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 	METHOD m_hkdntgfo (Lnet/minecraft/unmapped/C_pqbshjyj;)Lnet/minecraft/unmapped/C_lwmufxcy;
-		ARG 0 tallTorch
+		ARG 0 wallTorch
 	METHOD m_lvkogfqx getShape (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 0 state

--- a/mappings/net/minecraft/block/WeightedPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/WeightedPressurePlateBlock.mapping
@@ -5,3 +5,7 @@ CLASS net/minecraft/unmapped/C_foqamixq net/minecraft/block/WeightedPressurePlat
 	METHOD <init> (ILnet/minecraft/unmapped/C_hgpogkhy;Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 2 blockSetType
 		ARG 3 settings
+	METHOD m_crfnnimq (Lnet/minecraft/unmapped/C_foqamixq;)Lnet/minecraft/unmapped/C_hgpogkhy;
+		ARG 0 pressurePlate
+	METHOD m_jiimtgzw (Lnet/minecraft/unmapped/C_foqamixq;)Ljava/lang/Integer;
+		ARG 0 pressurePlate

--- a/mappings/net/minecraft/block/cauldron/AbstractCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/cauldron/AbstractCauldronBlock.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_ukinmebz net/minecraft/block/cauldron/AbstractCauldronBlock
 	FIELD f_cytxtxxd OUTLINE_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
+	FIELD f_kayjvfem RAYCAST_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_rmandepb behaviorMap Lnet/minecraft/unmapped/C_hwbtrnnh$C_iuwwgckx;
 	FIELD f_ydrbgwbm FLOOR_LEVEL I
 	METHOD <init> (Lnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;Lnet/minecraft/unmapped/C_hwbtrnnh$C_iuwwgckx;)V

--- a/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
+++ b/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
@@ -1,7 +1,32 @@
 CLASS net/minecraft/unmapped/C_ooeeaffg net/minecraft/block/dispenser/DispenserBehavior
 	FIELD f_qafvtfzb LOGGER Lorg/slf4j/Logger;
 	FIELD f_szadkszc NOOP Lnet/minecraft/unmapped/C_ooeeaffg;
+	METHOD dispense (Lnet/minecraft/unmapped/C_wzdnszcs;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
+		ARG 1 context
 	METHOD m_ujgviwhs doDispense (Lnet/minecraft/unmapped/C_wzdnszcs;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 context
 		ARG 1 stack
 	METHOD m_ummkrstn bootstrap ()V
+	CLASS C_hbfucibf
+		FIELD f_uamzjowc defaultBehavior Lnet/minecraft/unmapped/C_dnfsxzwl;
+	CLASS C_kaaebxym
+		METHOD m_nisfpukw (Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_nknvrhfn;)V
+			ARG 1 armorStand
+	CLASS C_leynamtw
+		METHOD m_puzffkiu (Lnet/minecraft/unmapped/C_javurlgg;)Z
+			ARG 0 mount
+	CLASS C_nbyoxujw
+		FIELD f_laoaxmgr defaultBehavior Lnet/minecraft/unmapped/C_dnfsxzwl;
+	CLASS C_uorzxdrk
+		METHOD m_auadiqpq (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
+			ARG 0 state
+		METHOD m_jrraztlk consumeBottle (Lnet/minecraft/unmapped/C_wzdnszcs;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
+			ARG 1 context
+			ARG 2 bottle
+			ARG 3 remainder
+	CLASS C_usdpumvw
+		METHOD m_spvebsig (Lnet/minecraft/unmapped/C_vorddnax;)V
+			ARG 0 item
+	CLASS C_xfkqmeey
+		METHOD m_bbrdkquq (Lnet/minecraft/unmapped/C_vorddnax;)V
+			ARG 0 item

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -1,20 +1,24 @@
 CLASS net/minecraft/unmapped/C_dlxbwxyf net/minecraft/block/entity/AbstractFurnaceBlockEntity
 	FIELD f_apovtvbw SIDE_SLOTS [I
 	FIELD f_bitqkham STANDARD_BURN_TIME I
+	FIELD f_btczpgme DEFAULT_FUEL_TIME S
 	FIELD f_cjviljdx FUEL_TIME_DATA I
 	FIELD f_debmtawn RESULT_SLOT I
 	FIELD f_dswenqhr cookTimeTotal I
 	FIELD f_erasrdjo FUEL_SLOT I
 	FIELD f_fwsjbtjw TOP_SLOTS [I
+	FIELD f_gtdcdsiv DEFAULT_COOK_TIME S
 	FIELD f_hpqapnfb BURN_DECAY_RATE I
 	FIELD f_kekgcosu propertyDelegate Lnet/minecraft/unmapped/C_fwwsyhuv;
 	FIELD f_mzaccpku BOTTOM_SLOTS [I
 	FIELD f_nqwyvoxy TOTAL_COOK_TIME_DATA I
 	FIELD f_rhexgeen recipeCache Lnet/minecraft/unmapped/C_hjseusrb$C_bvtkxdyi;
 	FIELD f_ruznenwn INPUT_SLOT I
+	FIELD f_tjmroghf DEFAULT_TOTAL_COOK_TIME S
 	FIELD f_uunwympm BURN_TIME_DATA I
 	FIELD f_vmpcjcui recipesUsed Lit/unimi/dsi/fastutil/objects/Reference2IntOpenHashMap;
 	FIELD f_vnrsgghy COOK_TIME_DATA I
+	FIELD f_xipobnlf DEFAULT_BURN_TIME S
 	FIELD f_xyumtyfp DATA_VALUES I
 	FIELD f_ymhvwhvo inventory Lnet/minecraft/unmapped/C_rnrfftze;
 	METHOD <init> (Lnet/minecraft/unmapped/C_wgqvodus;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_rhnqznys;)V
@@ -24,6 +28,7 @@ CLASS net/minecraft/unmapped/C_dlxbwxyf net/minecraft/block/entity/AbstractFurna
 		ARG 4 recipeType
 	METHOD m_dctsvboi canAcceptRecipeOutput (Lnet/minecraft/unmapped/C_wqxmvzdq;Lnet/minecraft/unmapped/C_dscbrwbj;Lnet/minecraft/unmapped/C_hsoxiypb;Lnet/minecraft/unmapped/C_rnrfftze;I)Z
 		ARG 1 recipe
+		ARG 2 input
 		ARG 3 slots
 		ARG 4 count
 	METHOD m_emoezrql dropExperienceForRecipesUsed (Lnet/minecraft/unmapped/C_mxrobsgg;)V
@@ -31,9 +36,14 @@ CLASS net/minecraft/unmapped/C_dlxbwxyf net/minecraft/block/entity/AbstractFurna
 	METHOD m_ezerfwpi getRecipesUsedAndDropExperience (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;)Ljava/util/List;
 		ARG 1 world
 		ARG 2 pos
+	METHOD m_gsiprfzc (Lnet/minecraft/unmapped/C_dscbrwbj;)Ljava/lang/Integer;
+		ARG 0 recipe
 	METHOD m_igiksnup isBurning ()Z
+	METHOD m_stamsazk (Ljava/util/List;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;Lit/unimi/dsi/fastutil/objects/Reference2IntMap$Entry;Lnet/minecraft/unmapped/C_dscbrwbj;)V
+		ARG 4 recipe
 	METHOD m_szsvrwtz craftRecipe (Lnet/minecraft/unmapped/C_wqxmvzdq;Lnet/minecraft/unmapped/C_dscbrwbj;Lnet/minecraft/unmapped/C_hsoxiypb;Lnet/minecraft/unmapped/C_rnrfftze;I)Z
 		ARG 1 recipe
+		ARG 2 input
 		ARG 3 slots
 		ARG 4 count
 	METHOD m_utdugskh dropExperience (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;IF)V

--- a/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
@@ -70,3 +70,5 @@ CLASS net/minecraft/unmapped/C_lxkuepdf net/minecraft/block/entity/BellBlockEnti
 	METHOD m_zsnmqtdz (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
 	CLASS C_ptangjtm Effect
+		METHOD run (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/List;)V
+			ARG 3 hearingEntities

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -24,6 +24,7 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 		ARG 1 pos
 		ARG 2 state
 	METHOD m_culdahst readBlockPosFromNbt (Lnet/minecraft/unmapped/C_ynrszrtu;Lnet/minecraft/unmapped/C_hhlwcnih;)Lnet/minecraft/unmapped/C_hynzadkk;
+		ARG 0 pos
 		ARG 1 nbt
 	METHOD m_dzrbmfhv toNbtWithId (Lnet/minecraft/unmapped/C_vtbxyypo$C_etmlgbig;)Lnet/minecraft/unmapped/C_hhlwcnih;
 		ARG 1 lookupProvider
@@ -95,6 +96,8 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 		ARG 2 lookupProvider
 	METHOD m_xokvytvt toNbtWithIdAndPos (Lnet/minecraft/unmapped/C_vtbxyypo$C_etmlgbig;)Lnet/minecraft/unmapped/C_hhlwcnih;
 		ARG 1 lookupProvider
+	METHOD m_yctdjwfx (Ljava/lang/String;)V
+		ARG 0 error
 	METHOD m_yymkkcjv populateCrashReport (Lnet/minecraft/unmapped/C_qympisds;)V
 		ARG 1 crashReportSection
 	METHOD m_zasadoxf writeIdentifyingData (Lnet/minecraft/unmapped/C_hhlwcnih;Lnet/minecraft/unmapped/C_wgqvodus;)V

--- a/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/unmapped/C_hedzytvj net/minecraft/block/entity/BlockEntityTicker
-	METHOD tick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_kvegafmh;)V
+	METHOD tick tick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_kvegafmh;)V
 		COMMENT Runs this action on the given block entity. The world, block position, and block state are passed
 		COMMENT as context.

--- a/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
@@ -3,10 +3,12 @@ CLASS net/minecraft/unmapped/C_sqxxaglx net/minecraft/block/entity/BrewingStandB
 	FIELD f_edzjwvco brewTime I
 	FIELD f_fkcwasfe propertyDelegate Lnet/minecraft/unmapped/C_fwwsyhuv;
 	FIELD f_fxdchcgg fuel I
+	FIELD f_fyaiccdq DEFAULT_BREW_TIME S
 	FIELD f_gylkmdei SIDE_SLOTS [I
 	FIELD f_hoaeyujo slotsEmptyLastTick [Z
 	FIELD f_hoibfolb DATA_VALUES I
 	FIELD f_ilynkgdg BREW_TIME_DATA I
+	FIELD f_irfxtrcb DEFAULT_FUEL B
 	FIELD f_jlpksfdh inventory Lnet/minecraft/unmapped/C_rnrfftze;
 	FIELD f_odncodim TOP_SLOTS [I
 	FIELD f_rlzpnxen FUEL_SLOT I

--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -7,6 +7,8 @@ CLASS net/minecraft/unmapped/C_wmubauif net/minecraft/block/entity/CampfireBlock
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos
 		ARG 2 state
+	METHOD m_lakebgxq ([I)V
+		ARG 1 cookingTimes
 	METHOD m_qqexwynq clientTick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_wmubauif;)V
 		ARG 0 world
 		ARG 1 pos
@@ -19,12 +21,15 @@ CLASS net/minecraft/unmapped/C_wmubauif net/minecraft/block/entity/CampfireBlock
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 campfire
+	METHOD m_xrvgpjxk ([I)V
+		ARG 1 cookingTotalTimes
 	METHOD m_xuujaryq (Lnet/minecraft/unmapped/C_hsoxiypb;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dscbrwbj;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 2 recipe
 	METHOD m_yfgcktbg litServerTick (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_wmubauif;Lnet/minecraft/unmapped/C_hjseusrb$C_bvtkxdyi;)V
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 campfire
+		ARG 4 recipeCheck
 	METHOD m_yvsijcdr addItem (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 2 source
 		ARG 3 item

--- a/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_ondgvlom net/minecraft/block/entity/ChiseledBookshelfBlockEntity
 	FIELD f_ehqmffog inventory Lnet/minecraft/unmapped/C_rnrfftze;
 	FIELD f_icyfjkjo lastInteractedSlot I
+	FIELD f_ptuflqfg DEFAULT_INTERACTED_SLOT I
 	FIELD f_tmzkgdvl LOGGER Lorg/slf4j/Logger;
 	FIELD f_zfmfofee MAX_BOOK_COUNT I
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
@@ -10,3 +11,5 @@ CLASS net/minecraft/unmapped/C_ondgvlom net/minecraft/block/entity/ChiseledBooks
 		ARG 1 slot
 	METHOD m_dwbqlobu getLastInteractedSlot ()I
 	METHOD m_lbecqtzc getEmptySlots ()I
+	METHOD m_tdzvjmqy (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_pjtstjoq;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
+		ARG 2 inventoryStack

--- a/mappings/net/minecraft/block/entity/CommandBlockBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CommandBlockBlockEntity.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/unmapped/C_qpgfeghp net/minecraft/block/entity/CommandBlockBlockEntity
+	FIELD f_dyxzmkti DEFAULT_CONDITION_MET Z
 	FIELD f_hrzuxcdt auto Z
+	FIELD f_myrnninp DEFAULT_AUTO Z
 	FIELD f_xoaiocgt conditionMet Z
 	FIELD f_ynzunzvq powered Z
 	FIELD f_ypcqukwr commandExecutor Lnet/minecraft/unmapped/C_ufmydvnm;
+	FIELD f_ysafldnc DEFAULT_POWERED Z
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/entity/ComparatorBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ComparatorBlockEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_xyabiheu net/minecraft/block/entity/ComparatorBlockEntity
 	FIELD f_huelvtix outputSignal I
+	FIELD f_kqulynxr DEFAULT_OUTPUT_SIGNAL I
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/entity/CrafterBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CrafterBlockEntity.mapping
@@ -3,8 +3,10 @@ CLASS net/minecraft/unmapped/C_lamqkfie net/minecraft/block/entity/CrafterBlockE
 	FIELD f_bqaatywv inputStacks Lnet/minecraft/unmapped/C_rnrfftze;
 	FIELD f_drlbgikn GRID_WIDTH I
 	FIELD f_gkepqhms propertyDelegate Lnet/minecraft/unmapped/C_fwwsyhuv;
+	FIELD f_ijinflkl DEFAULT_TRIGGERED I
 	FIELD f_jfytfxan SLOT_DISABLED I
 	FIELD f_llifrlpt GRID_SIZE I
+	FIELD f_nbuzkqmr DEFAULT_CRAFTING_TICKS_REMAINING I
 	FIELD f_tbepijuw TRIGGERED_PROPERTY I
 	FIELD f_uvbziebv craftingTicksRemaining I
 	FIELD f_xaisqwwk PROPERTIES_COUNT I
@@ -25,6 +27,8 @@ CLASS net/minecraft/unmapped/C_lamqkfie net/minecraft/block/entity/CrafterBlockE
 		ARG 1 slot
 	METHOD m_qgwfsxfb setTriggered (Z)V
 		ARG 1 triggered
+	METHOD m_qhhwergd ([I)V
+		ARG 1 disabledSlots
 	METHOD m_uufcmiby putTriggered (Lnet/minecraft/unmapped/C_hhlwcnih;)V
 		ARG 1 nbt
 	METHOD m_ycajyjlg tickCrafting (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_lamqkfie;)V

--- a/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeart
 	METHOD m_truxfmoq getConnectedCreaking ()Ljava/util/Optional;
 	METHOD m_ukbxwqla spawnConnectionParticles (Lnet/minecraft/unmapped/C_bdwnwhiu;IZ)V
 		ARG 2 count
-		ARG 3 towardEntity
+		ARG 3 towardConnectedCreaking
 	METHOD m_wkuprtkd updateState (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_tkqzsaas;)Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_xchfcfll trySpawn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_tkqzsaas;)Lnet/minecraft/unmapped/C_vbugwmii;
 	METHOD m_younygpo (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_vbugwmii;)Ljava/lang/Boolean;

--- a/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeart
 	FIELD f_bsnmvbck UPDATE_INTERVAL_VARIANCE I
 	FIELD f_bwukcwqb updateCooldown I
 	FIELD f_cvfzwxtz PLAYER_DETECTION_RANGE I
-	FIELD f_cwvstxzb GROWTH_SEARCH_MAX_ITERATIONS I
+	FIELD f_cwvstxzb MAX_GROWTH_SEARCH_ITERATIONS I
 	FIELD f_ehzrfpkl HURT_CALL_COUNT I
 	FIELD f_grilakjj CREAKING_ROAMING_RADIUS I
 	FIELD f_hlwtxpld MIN_UPDATE_INTERVAL I
@@ -24,7 +24,7 @@ CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeart
 	METHOD m_aobtifjk tryGrowResin ()Ljava/util/Optional;
 	METHOD m_crfbayyq setConnectedCreakingUuid (Ljava/util/UUID;)V
 	METHOD m_eyesyodx calculateComparatorOutput ()I
-	METHOD m_jfayrjth unsetConnectedCreaking ()V
+	METHOD m_jfayrjth clearConnectedCreaking ()V
 	METHOD m_kgjofmyq removeConnectedCreaking (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
 	METHOD m_lpfewmky onCreakingDamaged ()V

--- a/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
@@ -1,0 +1,51 @@
+CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeartBlockEntity
+	FIELD f_bsnmvbck UPDATE_INTERVAL_VARIANCE I
+	FIELD f_bwukcwqb updateCooldown I
+	FIELD f_cvfzwxtz PLAYER_DETECTION_RANGE I
+	FIELD f_cwvstxzb GROWTH_SEARCH_MAX_ITERATIONS I
+	FIELD f_ehzrfpkl HURT_CALL_COUNT I
+	FIELD f_grilakjj CREAKING_ROAMING_RADIUS I
+	FIELD f_hlwtxpld MIN_UPDATE_INTERVAL I
+	FIELD f_ilcnsrbn lastCreakingEntityPos Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_kebdbxxl connectedCreaking Lcom/mojang/datafixers/util/Either;
+	FIELD f_kmnsfoas comparatorOutput I
+	FIELD f_mjtvqmci HURT_CALL_PARTICLE_TICKS I
+	FIELD f_mmycfyrt VERTICAL_SPAWN_RANGE I
+	FIELD f_mxplpjim MAX_SQUARED_DISTANCE_TO_CREAKING I
+	FIELD f_nsxjvugv HURT_CALL_INTERVAL I
+	FIELD f_okledrbs HORIZONTAL_SPAWN_RANGE I
+	FIELD f_pperjfcu NO_CREAKING_ENTITY Ljava/util/Optional;
+	FIELD f_rmipaiio particleAndGrowthCooldown I
+	FIELD f_rnzvkqzx GROWTH_SEARCH_MAX_DEPTH I
+	FIELD f_tfhcwwsd ALLOWED_UNLOADED_CREAKING_TICKS I
+	FIELD f_tgjlbnaj SPAWN_ATTEMPTS I
+	FIELD f_xsvwxixc PARTICLE_AND_GROWTH_INTERVAL I
+	FIELD f_xyizqhss ticksLoaded J
+	METHOD m_aobtifjk tryGrowResin ()Ljava/util/Optional;
+	METHOD m_crfbayyq setConnectedCreakingUuid (Ljava/util/UUID;)V
+	METHOD m_eyesyodx calculateComparatorOutput ()I
+	METHOD m_jfayrjth unsetConnectedCreaking ()V
+	METHOD m_kgjofmyq removeConnectedCreaking (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+		ARG 1 source
+	METHOD m_lpfewmky onCreakingDamaged ()V
+	METHOD m_njakthmx tick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_tkqzsaas;)V
+	METHOD m_pdifqvvr (Lnet/minecraft/unmapped/C_tkqzsaas;Lnet/minecraft/unmapped/C_vbugwmii;)V
+		ARG 1 entity
+	METHOD m_plrjfebb (Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/function/Consumer;)V
+		ARG 2 assess
+	METHOD m_podpbpnz (Lnet/minecraft/unmapped/C_vbugwmii;)Ljava/lang/Double;
+		ARG 1 entity
+	METHOD m_rmtrhxwb setConnectedCreaking (Lnet/minecraft/unmapped/C_vbugwmii;)V
+		ARG 1 entity
+	METHOD m_ticrsnxx getComparatorOutput ()I
+	METHOD m_truxfmoq getConnectedCreaking ()Ljava/util/Optional;
+	METHOD m_ukbxwqla spawnConnectionParticles (Lnet/minecraft/unmapped/C_bdwnwhiu;IZ)V
+		ARG 2 count
+		ARG 3 towardEntity
+	METHOD m_wkuprtkd updateState (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_tkqzsaas;)Lnet/minecraft/unmapped/C_txtbiemp;
+	METHOD m_xchfcfll trySpawn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_tkqzsaas;)Lnet/minecraft/unmapped/C_vbugwmii;
+	METHOD m_younygpo (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_vbugwmii;)Ljava/lang/Boolean;
+		ARG 1 connectedCreaking
+	METHOD m_zfegalql isConnected (Lnet/minecraft/unmapped/C_vbugwmii;)Z
+		ARG 1 creaking
+	METHOD m_zzkxgvhl getSquaredDistanceToCreakingEntity ()D

--- a/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CreakingHeartBlockEntity.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeart
 	FIELD f_ehzrfpkl HURT_CALL_COUNT I
 	FIELD f_grilakjj CREAKING_ROAMING_RADIUS I
 	FIELD f_hlwtxpld MIN_UPDATE_INTERVAL I
-	FIELD f_ilcnsrbn lastCreakingEntityPos Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_ilcnsrbn lastConnectedCreakingPos Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_kebdbxxl connectedCreaking Lcom/mojang/datafixers/util/Either;
 	FIELD f_kmnsfoas comparatorOutput I
 	FIELD f_mjtvqmci HURT_CALL_PARTICLE_TICKS I
@@ -14,7 +14,7 @@ CLASS net/minecraft/unmapped/C_tkqzsaas net/minecraft/block/entity/CreakingHeart
 	FIELD f_mxplpjim MAX_SQUARED_DISTANCE_TO_CREAKING I
 	FIELD f_nsxjvugv HURT_CALL_INTERVAL I
 	FIELD f_okledrbs HORIZONTAL_SPAWN_RANGE I
-	FIELD f_pperjfcu NO_CREAKING_ENTITY Ljava/util/Optional;
+	FIELD f_pperjfcu NO_CONNECTED_CREAKING Ljava/util/Optional;
 	FIELD f_rmipaiio particleAndGrowthCooldown I
 	FIELD f_rnzvkqzx GROWTH_SEARCH_MAX_DEPTH I
 	FIELD f_tfhcwwsd ALLOWED_UNLOADED_CREAKING_TICKS I

--- a/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
@@ -2,16 +2,20 @@ CLASS net/minecraft/unmapped/C_bgmbcwaf net/minecraft/block/entity/EndGatewayBlo
 	FIELD f_clvbweur COOLDOWN_TIME I
 	FIELD f_hbueogow age J
 	FIELD f_lyxdrqew exactTeleport Z
+	FIELD f_mtyoedvw DEFAULT_AGE J
 	FIELD f_qbzfuobf COOLDOWN_EVENT I
 	FIELD f_qtxslrtb SPAWN_TIME I
 	FIELD f_rrsolgpd LOGGER Lorg/slf4j/Logger;
 	FIELD f_tpapkeob HEIGHT_ABOVE_SURFACE I
 	FIELD f_ugqemgmn ATTENTION_INTERVAL I
+	FIELD f_vcmubhms DEFAULT_EXACT_TELEPORT Z
 	FIELD f_wdxicond teleportCooldown I
 	FIELD f_znnzlcll exitPortalPos Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_aewxjlqe findPortalPosition (Lnet/minecraft/unmapped/C_hrdsvlkq;)Lnet/minecraft/unmapped/C_hynzadkk;
 		ARG 0 chunk
 	METHOD m_cccmfxop getDrawnSidesCount ()I
+	METHOD m_dgttwcgh (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)V
+		ARG 2 endIsland
 	METHOD m_dsqgudra clientTick (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_bgmbcwaf;)V
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_nblomyyt net/minecraft/block/entity/HopperBlockEntity
 	FIELD f_azmfqpby transferCooldown I
+	FIELD f_emzemscf NO_TRANSFER_COOLDOWN I
 	FIELD f_hcniobcr SLOTS I
 	FIELD f_iqqzslts ITEM_MOVE_SPEED I
 	FIELD f_ktuvlsrj inventory Lnet/minecraft/unmapped/C_rnrfftze;

--- a/mappings/net/minecraft/block/entity/JigsawBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/JigsawBlockEntity.mapping
@@ -1,18 +1,22 @@
 CLASS net/minecraft/unmapped/C_epwegwuj net/minecraft/block/entity/JigsawBlockEntity
+	FIELD f_aocctfbv DEFAULT_PLACEMENT_PRIORITY I
 	FIELD f_bdjzsjak PLACEMENT_PRIORITY_KEY Ljava/lang/String;
 	FIELD f_dsiaieuj POOL_KEY Ljava/lang/String;
 	FIELD f_gabseuwr finalState Ljava/lang/String;
 	FIELD f_gspyggmk FINAL_STATE_KEY Ljava/lang/String;
 	FIELD f_lcpiixct pool Lnet/minecraft/unmapped/C_xhhleach;
 	FIELD f_lepmnexz SELECTION_PRIORITY_KEY Ljava/lang/String;
+	FIELD f_oyhdyykd DEFAULT_SELECTION_PRIORITY I
 	FIELD f_pjgzefnm placementPriority I
 	FIELD f_qayxtlva target Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_rflqmaju joint Lnet/minecraft/unmapped/C_epwegwuj$C_exgsbpfq;
 	FIELD f_smoqjtqe selectionPriority I
 	FIELD f_sqvaljke JOINT_KEY Ljava/lang/String;
+	FIELD f_sucujknr DEFAULT_FINAL_STATE Ljava/lang/String;
 	FIELD f_vletmsls TARGET_KEY Ljava/lang/String;
 	FIELD f_xdvjxegm name Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_yptqnhuw NAME_KEY Ljava/lang/String;
+	FIELD f_zxinnolh EMPTY_ID Lnet/minecraft/unmapped/C_ncpywfca;
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/entity/LockableContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LockableContainerBlockEntity.mapping
@@ -10,4 +10,7 @@ CLASS net/minecraft/unmapped/C_uomuzarq net/minecraft/block/entity/LockableConta
 		ARG 1 lock
 		ARG 2 containerName
 	METHOD m_nnlaacjo setInventory (Lnet/minecraft/unmapped/C_rnrfftze;)V
+		ARG 1 inventory
 	METHOD m_zoafdewc createScreenHandler (ILnet/minecraft/unmapped/C_sxzqocrm;)Lnet/minecraft/unmapped/C_mkrkudpa;
+		ARG 1 syncId
+		ARG 2 playerInventory

--- a/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
@@ -1,15 +1,19 @@
 CLASS net/minecraft/unmapped/C_wpearmnv net/minecraft/block/entity/PistonBlockEntity
 	COMMENT A piston block entity represents the block being pushed by a piston.
 	FIELD f_arjyvzgo TICK_MOVEMENT D
+	FIELD f_csmauuma DEFAULT_SOURCE Z
 	FIELD f_ejhvuroq lastProgress F
 	FIELD f_jmavxxxf savedWorldTime J
 	FIELD f_kqmwaqkf deathTicks I
 	FIELD f_kuqnpbhp progress F
+	FIELD f_mbwswjjy DEFAULT_MOVED_STATE Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_nljvvfry NO_CLIP Ljava/lang/ThreadLocal;
 	FIELD f_quxysgyu TICKS_TO_EXTEND I
 	FIELD f_qviclatw source Z
 	FIELD f_rbuxpdya facing Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_rnoaciqo DEFAULT_EXTENDING Z
 	FIELD f_rvkdkxam movedState Lnet/minecraft/unmapped/C_txtbiemp;
+	FIELD f_smyrvevz DEFAULT_PROGRESS F
 	FIELD f_wpwkhlxx extending Z
 	FIELD f_xadmeyxn PUSH_OFFSET D
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V

--- a/mappings/net/minecraft/block/entity/SculkSensorBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SculkSensorBlockEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_pqjuvriw net/minecraft/block/entity/SculkSensorBlockEntity
 	FIELD f_atiuulsx vibrationCallback Lnet/minecraft/unmapped/C_ddxrijfx$C_vnbbhkol;
+	FIELD f_dpwdsxvq DEFAULT_LAST_VIBRATION_FREQUENCY I
 	FIELD f_gbzdibtr vibrationData Lnet/minecraft/unmapped/C_ddxrijfx$C_qhpiojal;
 	FIELD f_ssyorzpw lastVibrationFrequency I
 	FIELD f_vttirlon listener Lnet/minecraft/unmapped/C_ddxrijfx$C_bbtmyknw;

--- a/mappings/net/minecraft/block/entity/SculkShriekerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SculkShriekerBlockEntity.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_pnalulqo net/minecraft/block/entity/SculkShrieker
 	FIELD f_agtboayy vibrationListener Lnet/minecraft/unmapped/C_ddxrijfx$C_bbtmyknw;
 	FIELD f_dohdlyye vibrationData Lnet/minecraft/unmapped/C_ddxrijfx$C_qhpiojal;
 	FIELD f_fjvcgmly WARNING_SOUNDS Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD f_jnuivitt DEFAULT_WARNING_LEVEL I
 	FIELD f_krxnjfnn SHRIEKING_TICKS I
 	FIELD f_otkrddol warningLevel I
 	FIELD f_oxhcskzs vibrationCallback Lnet/minecraft/unmapped/C_ddxrijfx$C_vnbbhkol;
@@ -30,6 +31,8 @@ CLASS net/minecraft/unmapped/C_pnalulqo net/minecraft/block/entity/SculkShrieker
 	METHOD m_tbzjryqw playWarningSound (Lnet/minecraft/unmapped/C_cdctfzbn;)V
 	METHOD m_ylnbrutv (Lit/unimi/dsi/fastutil/ints/Int2ObjectOpenHashMap;)V
 		ARG 0 map
+	METHOD m_zkjwfisw (I)V
+		ARG 1 warningLevel
 	METHOD m_zwmuarxc shriek (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 world
 		ARG 2 entity

--- a/mappings/net/minecraft/block/entity/Sherds.mapping
+++ b/mappings/net/minecraft/block/entity/Sherds.mapping
@@ -2,6 +2,9 @@ CLASS net/minecraft/unmapped/C_cpmlbyix net/minecraft/block/entity/Sherds
 	FIELD f_gautzvog DEFAULT Lnet/minecraft/unmapped/C_cpmlbyix;
 	METHOD m_bzxeuray (Ljava/util/Optional;)Lnet/minecraft/unmapped/C_vorddnax;
 		ARG 0 optionalSherd
+	METHOD m_flbmestk appendSide (Ljava/util/function/Consumer;Ljava/util/Optional;)V
+		ARG 0 textAdder
+		ARG 1 side
 	METHOD m_icoizewj getSherd (Ljava/util/List;I)Ljava/util/Optional;
 		ARG 0 sherds
 		ARG 1 index

--- a/mappings/net/minecraft/block/entity/Sherds.mapping
+++ b/mappings/net/minecraft/block/entity/Sherds.mapping
@@ -2,9 +2,9 @@ CLASS net/minecraft/unmapped/C_cpmlbyix net/minecraft/block/entity/Sherds
 	FIELD f_gautzvog DEFAULT Lnet/minecraft/unmapped/C_cpmlbyix;
 	METHOD m_bzxeuray (Ljava/util/Optional;)Lnet/minecraft/unmapped/C_vorddnax;
 		ARG 0 optionalSherd
-	METHOD m_flbmestk appendSide (Ljava/util/function/Consumer;Ljava/util/Optional;)V
+	METHOD m_flbmestk appendSherd (Ljava/util/function/Consumer;Ljava/util/Optional;)V
 		ARG 0 textAdder
-		ARG 1 side
+		ARG 1 sherd
 	METHOD m_icoizewj getSherd (Ljava/util/List;I)Ljava/util/Optional;
 		ARG 0 sherds
 		ARG 1 index

--- a/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/unmapped/C_gauehqwp net/minecraft/block/entity/ShulkerBoxBlo
 	METHOD m_jqvxostv readInventoryNbt (Lnet/minecraft/unmapped/C_hhlwcnih;Lnet/minecraft/unmapped/C_vtbxyypo$C_etmlgbig;)V
 		ARG 1 nbt
 	METHOD m_makmsuni getAnimationStage ()Lnet/minecraft/unmapped/C_gauehqwp$C_tdtslcqu;
-	METHOD m_ocipgdcq suffocates ()Z
+	METHOD m_ocipgdcq isClosed ()Z
 	METHOD m_ojeklclb pushEntities (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/entity/SignBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SignBlockEntity.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_axouvzlg net/minecraft/block/entity/SignBlockEnti
 	FIELD f_dcjzrjbm LOGGER Lorg/slf4j/Logger;
 	FIELD f_gbeckede waxed Z
 	FIELD f_kglqtpyy TEXT_LINE_HEIGHT I
+	FIELD f_ofescbpc DEFAULT_WAXED Z
 	FIELD f_orlvhjhd editor Ljava/util/UUID;
 	FIELD f_xnbbfgln MAX_TEXT_LINE_WIDTH I
 	FIELD f_xwgesugz frontText Lnet/minecraft/unmapped/C_ralzcant;
@@ -12,6 +13,8 @@ CLASS net/minecraft/unmapped/C_axouvzlg net/minecraft/block/entity/SignBlockEnti
 	METHOD m_apdvaphb setMessages (Lnet/minecraft/unmapped/C_jzrpycqo;Ljava/util/List;Lnet/minecraft/unmapped/C_ralzcant;)Lnet/minecraft/unmapped/C_ralzcant;
 		ARG 1 player
 		ARG 2 messages
+		ARG 3 text
+	METHOD m_bsrkpwwj (Lnet/minecraft/unmapped/C_jzrpycqo;Ljava/util/List;Lnet/minecraft/unmapped/C_ralzcant;)Lnet/minecraft/unmapped/C_ralzcant;
 		ARG 3 text
 	METHOD m_cbizgexi createText ()Lnet/minecraft/unmapped/C_ralzcant;
 	METHOD m_ciqmeakn setText (Lnet/minecraft/unmapped/C_ralzcant;Z)Z

--- a/mappings/net/minecraft/block/entity/Spawner.mapping
+++ b/mappings/net/minecraft/block/entity/Spawner.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/unmapped/C_xheeywhc net/minecraft/block/entity/Spawner
 	METHOD m_aohplshh setEntityType (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_rlomrsco;)V
+		ARG 1 type
+	METHOD m_fstbxqxz (Lnet/minecraft/unmapped/C_ogavsvbr;)Lnet/minecraft/unmapped/C_npqneive;
+		ARG 0 type
+	METHOD m_jdhkawxq (Lnet/minecraft/unmapped/C_hhlwcnih;)Ljava/util/Optional;
+		ARG 0 spawnData
 	METHOD m_mfyyxczo getEntityTypeText (Lnet/minecraft/unmapped/C_incrreuu;Ljava/lang/String;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 blockEntityData
+		ARG 1 spawnDataKey
+	METHOD m_nefranfw (Lnet/minecraft/unmapped/C_hhlwcnih;)Ljava/util/Optional;
+		ARG 0 entityCompound
 	METHOD m_vysbdnfp appendTooltip (Lnet/minecraft/unmapped/C_incrreuu;Ljava/util/function/Consumer;Ljava/lang/String;)V
+		ARG 0 blockEntityData
+		ARG 1 append

--- a/mappings/net/minecraft/block/entity/StructureBlockBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/StructureBlockBlockEntity.mapping
@@ -1,14 +1,26 @@
 CLASS net/minecraft/unmapped/C_bfrzytnu net/minecraft/block/entity/StructureBlockBlockEntity
 	FIELD f_apvypbtb powered Z
+	FIELD f_bttbaaxw DEFAULT_SHOW_BOUNDING_BOX Z
+	FIELD f_cgaewmsy DEFAULT_SIZE Lnet/minecraft/unmapped/C_ceivtqhh;
+	FIELD f_cvxvkhjs DEFAULT_AUTHOR Ljava/lang/String;
 	FIELD f_eknqjnvy CORNER_BLOCKS_SCAN_RANGE I
 	FIELD f_evbnocyi showBoundingBox Z
 	FIELD f_fdytftki integrity F
 	FIELD f_fwyazwsi showAir Z
+	FIELD f_gihajovn DEFAULT_STRICT Z
+	FIELD f_howkuppx DEFAULT_ROTATION Lnet/minecraft/unmapped/C_mboglirk;
+	FIELD f_idazaqbd DEFAULT_IGNORE_ENTITIES Z
+	FIELD f_imvynxip DEFAULT_OFFSET Lnet/minecraft/unmapped/C_hynzadkk;
 	FIELD f_iuqnbokt strict Z
+	FIELD f_jeytwdcf DEFAULT_SEED J
 	FIELD f_jhaicskj MAX_OFFSET_PER_AXIS I
 	FIELD f_jjhdjqus ignoreEntities Z
+	FIELD f_lenikerd DEFAULT_POWERED Z
 	FIELD f_nfzauhsk mirror Lnet/minecraft/unmapped/C_qomzaqud;
+	FIELD f_nkiuexca DEFAULT_MIRROR Lnet/minecraft/unmapped/C_qomzaqud;
+	FIELD f_qjoxbtkb DEFAULT_METADATA Ljava/lang/String;
 	FIELD f_rdocvtbc offset Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_rdxbtuti DEFAULT_SHOW_AIR Z
 	FIELD f_rhdnvzap seed J
 	FIELD f_rkqgkbzy metadata Ljava/lang/String;
 	FIELD f_vmshqnyj rotation Lnet/minecraft/unmapped/C_mboglirk;
@@ -17,6 +29,7 @@ CLASS net/minecraft/unmapped/C_bfrzytnu net/minecraft/block/entity/StructureBloc
 	FIELD f_xmyxcbij structureName Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_ybwujkdg mode Lnet/minecraft/unmapped/C_uihldlpc;
 	FIELD f_ydaxwbqd author Ljava/lang/String;
+	FIELD f_zkgbpada DEFAULT_INTEGRITY F
 	FIELD f_zvfenthw MAX_SIZE_PER_AXIS I
 	METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
 		ARG 1 pos

--- a/mappings/net/minecraft/block/entity/TestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/TestBlockEntity.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_yxyvgcqr net/minecraft/block/entity/TestBlockEntity
 	FIELD f_kxvaxlal complete Z
+	FIELD f_lofkmwlm DEFAULT_MESSAGE Ljava/lang/String;
+	FIELD f_lwznhmxz DEFAULT_POWERED Z
 	FIELD f_mqzkeetx mode Lnet/minecraft/unmapped/C_dgfvnzfk;
 	FIELD f_pgpobxxz message Ljava/lang/String;
 	FIELD f_yrqxbgrq powered Z

--- a/mappings/net/minecraft/block/entity/TrialSpawnerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/TrialSpawnerBlockEntity.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/unmapped/C_ndgqjckh net/minecraft/block/entity/TrialSpawnerBlockEntity
 	FIELD f_fhtosxqw spawnerLogic Lnet/minecraft/unmapped/C_jelkcvqk;
+	METHOD m_hmmtelqa createDefaultLogic ()Lnet/minecraft/unmapped/C_jelkcvqk;
 	METHOD m_wvhkrgdu getSpawnerLogic ()Lnet/minecraft/unmapped/C_jelkcvqk;

--- a/mappings/net/minecraft/block/entity/ViewerCountManager.mapping
+++ b/mappings/net/minecraft/block/entity/ViewerCountManager.mapping
@@ -31,5 +31,7 @@ CLASS net/minecraft/unmapped/C_fuettijt net/minecraft/block/entity/ViewerCountMa
 	METHOD m_xktxaxdw onViewerCountUpdate (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;II)V
 		COMMENT Called when the viewer count updates, such as when a player interact with this container
 		COMMENT or when {@linkplain #updateViewerCount distance-based checks} are run.
+		ARG 4 oldViewerCount
+		ARG 5 newViewerCount
 	METHOD m_xndcmkdl isPlayerViewing (Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 		COMMENT Determines whether the given player is currently viewing this container.

--- a/mappings/net/minecraft/block/entity/vault/VaultBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/vault/VaultBlockEntity.mapping
@@ -54,6 +54,8 @@ CLASS net/minecraft/unmapped/C_xclnoluc net/minecraft/block/entity/vault/VaultBl
 			ARG 1 state
 			ARG 2 config
 			ARG 3 sharedData
+		METHOD m_rlrwoomb generateLoot (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_cudfnjix;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)Ljava/util/List;
+			ARG 1 config
 		METHOD m_suqfgtrx tick (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_cudfnjix;Lnet/minecraft/unmapped/C_nsbycoiv;Lnet/minecraft/unmapped/C_czyoqmgb;)V
 			ARG 3 config
 			ARG 4 serverData

--- a/mappings/net/minecraft/block/entity/vault/VaultSharedData.mapping
+++ b/mappings/net/minecraft/block/entity/vault/VaultSharedData.mapping
@@ -25,4 +25,5 @@ CLASS net/minecraft/unmapped/C_czyoqmgb net/minecraft/block/entity/vault/VaultSh
 	METHOD m_uflgzskl updateConnectedPlayers (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_nsbycoiv;Lnet/minecraft/unmapped/C_cudfnjix;D)V
 		ARG 3 serverData
 		ARG 4 config
+		ARG 5 range
 	METHOD m_urrekdhr hasDisplayItem ()Z

--- a/mappings/net/minecraft/block/enums/ConnectionHeight.mapping
+++ b/mappings/net/minecraft/block/enums/ConnectionHeight.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_seqcnhpn net/minecraft/block/enums/WallConnection
+CLASS net/minecraft/unmapped/C_seqcnhpn net/minecraft/block/enums/ConnectionHeight
 	FIELD f_rfriwggi name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 		ARG 3 name

--- a/mappings/net/minecraft/block/enums/JigsawOrientation.mapping
+++ b/mappings/net/minecraft/block/enums/JigsawOrientation.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_vukkmxtr net/minecraft/block/enums/JigsawOrientation
 	FIELD f_dtzdyapf facing Lnet/minecraft/unmapped/C_xpuuihxf;
+	FIELD f_ikytgmdj BY_DIRECTIONS [Lnet/minecraft/unmapped/C_vukkmxtr;
 	FIELD f_jotzrqnz name Ljava/lang/String;
+	FIELD f_kutsmjkh COUNT I
 	FIELD f_pmmqicos rotation Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_xpuuihxf;)V
 		ARG 3 name
@@ -13,4 +15,6 @@ CLASS net/minecraft/unmapped/C_vukkmxtr net/minecraft/block/enums/JigsawOrientat
 	METHOD m_lyfptwnz getIndex (Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_xpuuihxf;)I
 		ARG 0 facing
 		ARG 1 rotation
+	METHOD m_mbpxageh ([Lnet/minecraft/unmapped/C_vukkmxtr;)V
+		ARG 0 byDirections
 	METHOD m_qxsikjqd getRotation ()Lnet/minecraft/unmapped/C_xpuuihxf;

--- a/mappings/net/minecraft/block/enums/TrialSpawnerState.mapping
+++ b/mappings/net/minecraft/block/enums/TrialSpawnerState.mapping
@@ -20,8 +20,12 @@ CLASS net/minecraft/unmapped/C_mefvrcdp net/minecraft/block/enums/TrialSpawnerSt
 	METHOD m_lbcodxhm hasRotatingEntity ()Z
 	METHOD m_mlumwbvs trySpawnOminousItemSpawner (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_jelkcvqk;)V
 		ARG 3 logic
+	METHOD m_nlhrasxl (Lnet/minecraft/unmapped/C_jelkcvqk;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 3 lootTable
 	METHOD m_qeqintcw hasCooledDown (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_kxkfzuix;)Z
 		ARG 2 spawnerData
+	METHOD m_tpuvsmwl (Lnet/minecraft/unmapped/C_kxkfzuix;Lnet/minecraft/unmapped/C_jelkcvqk;Lnet/minecraft/unmapped/C_edcjbljn;)V
+		ARG 2 entry
 	METHOD m_ucdxdqvw isCapableOfSpawning ()Z
 	METHOD m_uexavfok calculatePosAbove (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
 		ARG 0 entity
@@ -36,6 +40,8 @@ CLASS net/minecraft/unmapped/C_mefvrcdp net/minecraft/block/enums/TrialSpawnerSt
 		FIELD f_ibbxvdpf ACTIVE Lnet/minecraft/unmapped/C_mefvrcdp$C_bccyitsl;
 		FIELD f_kjgegjdt COOLDOWN Lnet/minecraft/unmapped/C_mefvrcdp$C_bccyitsl;
 		FIELD f_niudltvq WAITING Lnet/minecraft/unmapped/C_mefvrcdp$C_bccyitsl;
+		METHOD emit (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;Z)V
+			ARG 4 ominous
 		METHOD m_gdzvmyph addParticle (Lnet/minecraft/unmapped/C_lwmufxcy;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_cdctfzbn;)V
 			ARG 0 particleType
 			ARG 1 pos

--- a/mappings/net/minecraft/block/enums/VaultState.mapping
+++ b/mappings/net/minecraft/block/enums/VaultState.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/unmapped/C_oocnpsfc net/minecraft/block/enums/VaultState
 	METHOD m_ekopnsum checkConnectedPlayers (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cudfnjix;Lnet/minecraft/unmapped/C_nsbycoiv;Lnet/minecraft/unmapped/C_czyoqmgb;D)Lnet/minecraft/unmapped/C_oocnpsfc;
 		ARG 0 world
 		ARG 4 sharedData
+		ARG 5 range
 	METHOD m_mecavbto transitionTo (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_oocnpsfc;Lnet/minecraft/unmapped/C_cudfnjix;Lnet/minecraft/unmapped/C_czyoqmgb;Z)V
 		ARG 1 world
 		ARG 3 vaultState

--- a/mappings/net/minecraft/block/enums/WallConnection.mapping
+++ b/mappings/net/minecraft/block/enums/WallConnection.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_seqcnhpn net/minecraft/block/enums/WallShape
+CLASS net/minecraft/unmapped/C_seqcnhpn net/minecraft/block/enums/WallConnection
 	FIELD f_rfriwggi name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 		ARG 3 name

--- a/mappings/net/minecraft/block/piston/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/piston/PistonBlock.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_tpdcefvs net/minecraft/block/piston/PistonBlock
 	FIELD f_pvzpicqg EXTENDED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_tnkwsjri EXTEND_EVENT I
 	FIELD f_uodnnqjt PLATFORM_THICKNESS I
+	FIELD f_vhelczzz EXTENDED_SHAPES Ljava/util/Map;
 	METHOD <init> (ZLnet/minecraft/unmapped/C_triydqro$C_xnkxsdfy;)V
 		ARG 1 sticky
 		ARG 2 settings

--- a/mappings/net/minecraft/block/piston/PistonHeadBlock.mapping
+++ b/mappings/net/minecraft/block/piston/PistonHeadBlock.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/unmapped/C_kovydcjx net/minecraft/block/piston/PistonHeadBlock
 	FIELD f_fsdkqqeh SHORT_HEAD_SHAPES Ljava/util/Map;
 	FIELD f_mlpracwk SHORT Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_odfolkzz PLATFORM_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_pfmwgbqv TYPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_tevjvrei LONG_HEAD_SHAPES Ljava/util/Map;
+	FIELD f_xdnuvvtz PLATFORM_THICKNESS I
 	FIELD f_yycapthl CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD m_danlnhky isAttached (Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		ARG 1 headState

--- a/mappings/net/minecraft/block/sculk/SculkBehavior.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkBehavior.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_eprlufrn net/minecraft/block/sculk/SculkBehavior
 	FIELD f_fozckfxo SHRIEKER_PLACEMENT_RATE I
+	FIELD f_fsiyuprm MAX_CURSOR_DISTANCE I
 	FIELD f_gzgdwxbc additionalDecayRate I
 	FIELD f_jlcibacz MAX_CURSORS I
 	FIELD f_lxsuulcx noGrowthRadius I
@@ -31,6 +32,9 @@ CLASS net/minecraft/unmapped/C_eprlufrn net/minecraft/block/sculk/SculkBehavior
 	METHOD m_oriomfed createWorldGenBehavior ()Lnet/minecraft/unmapped/C_eprlufrn;
 	METHOD m_qexekxvj read (Lnet/minecraft/unmapped/C_hhlwcnih;)V
 		ARG 1 nbt
+	METHOD m_soqcxfmg (Lnet/minecraft/unmapped/C_eprlufrn$C_gzpsastu;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/lang/Integer;)Ljava/lang/Integer;
+		ARG 1 blockPos
+		ARG 2 priorCharge
 	METHOD m_uclrpgkw createBehavior ()Lnet/minecraft/unmapped/C_eprlufrn;
 	METHOD m_ujfthohn getAdditionalDecayRate ()I
 	METHOD m_uvpxfkrm getNoGrowthRadius ()I
@@ -93,6 +97,7 @@ CLASS net/minecraft/unmapped/C_eprlufrn net/minecraft/block/sculk/SculkBehavior
 		METHOD m_wdwijcpm getVeinSpreaderForState (Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_uevszakc;
 			ARG 0 state
 		METHOD m_xbmqmrfs getCharge ()I
+		METHOD m_yedswcio isOutOfRange (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		METHOD m_yiyeoclc getMovementPosition (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_hynzadkk;
 			ARG 0 world
 			ARG 1 pos

--- a/mappings/net/minecraft/block/sculk/SculkShriekerBlock.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkShriekerBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_wxvelcrz net/minecraft/block/sculk/SculkShriekerBlock
+	FIELD f_embghxhj SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_ihidkmxi CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_lfdezzzn WATERLOGGED Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_reudzzme CAN_SUMMON Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/block/sculk/SculkVeinSpreader.mapping
+++ b/mappings/net/minecraft/block/sculk/SculkVeinSpreader.mapping
@@ -16,6 +16,10 @@ CLASS net/minecraft/unmapped/C_uevszakc net/minecraft/block/sculk/SculkVeinSprea
 	METHOD m_xlnmmtrm updateDecayDelay (I)I
 		ARG 1 delay
 	METHOD m_ypvcpziw tryUseCharge (Lnet/minecraft/unmapped/C_eprlufrn$C_gzpsastu;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_eprlufrn;Z)I
+		ARG 1 cursor
+		ARG 2 world
+		ARG 5 behavior
+		ARG 6 spread
 	METHOD m_zwrnsftu useCharge (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/sign/CeilingHangingSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/CeilingHangingSignBlock.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_vsqrirpz net/minecraft/block/sign/CeilingHangingSignBlock
 	FIELD f_bgkwzdia CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_klrfckzy DEFAULT_SHAPE Lnet/minecraft/unmapped/C_zscvhwbd;
 	FIELD f_nvyebogo ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;
 	FIELD f_thwcrbgt ATTACHED Lnet/minecraft/unmapped/C_xhwijdsd;
+	FIELD f_wqyzesui SHAPES_BY_ROTATION Ljava/util/Map;
+	METHOD m_iynrqalw (Ljava/util/Map$Entry;)Ljava/lang/Integer;
+		ARG 0 entry
 	METHOD m_othkwkht shouldTryChaining (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_jdakttms;Lnet/minecraft/unmapped/C_axouvzlg;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 player
 		ARG 2 hitResult

--- a/mappings/net/minecraft/block/sign/WallHangingSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/WallHangingSignBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_hzvmpvoj net/minecraft/block/sign/WallHangingSignBlock
+	FIELD f_davumfqv COLLISION_SHAPES Ljava/util/Map;
+	FIELD f_hzjrlcgb OUTLINE_SHAPES Ljava/util/Map;
 	FIELD f_pmfjalmx CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD f_rvvimqrj FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	METHOD m_ffwkilen axisMatchesFacing (Lnet/minecraft/unmapped/C_jdakttms;Lnet/minecraft/unmapped/C_txtbiemp;)Z

--- a/mappings/net/minecraft/block/sign/WallSignBlock.mapping
+++ b/mappings/net/minecraft/block/sign/WallSignBlock.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/unmapped/C_rgitojot net/minecraft/block/sign/WallSignBlock
 	FIELD f_jlirgbrx FACING Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_uvotelfr CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD f_yqdvysaf SHAPES Ljava/util/Map;

--- a/mappings/net/minecraft/client/block/ChestAnimationProgress.mapping
+++ b/mappings/net/minecraft/client/block/ChestAnimationProgress.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_tjabimsu net/minecraft/client/block/ChestAnimationProgress
 	METHOD m_vychuftq getAnimationProgress (F)F
+		ARG 1 delta

--- a/mappings/net/minecraft/client/render/entity/ItemFrameEntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/ItemFrameEntityRenderState.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_sguhxyrg net/minecraft/client/render/entity/ItemFrameEntityRenderState
+	FIELD f_cafxggoe mapId Lnet/minecraft/unmapped/C_qqxyyzzm;
+	FIELD f_eafydurh glowing Z
+	FIELD f_fyybdvpv mapRenderState Lnet/minecraft/unmapped/C_ikcmtvuf;
+	FIELD f_wbdupphk rotation I

--- a/mappings/net/minecraft/client/render/entity/StateManagers.mapping
+++ b/mappings/net/minecraft/client/render/entity/StateManagers.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/unmapped/C_cjgtokpr net/minecraft/client/render/entity/StateManagers
+	FIELD f_estnjycj GLOW_ITEM_FRAME_ID Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_lcztvpfe GLOW_ITEM_FRAME_MANAGER Lnet/minecraft/unmapped/C_ezfeikaq;
+	FIELD f_lvhudnqf ITEM_FRAME_MANAGER Lnet/minecraft/unmapped/C_ezfeikaq;
+	FIELD f_wxbvvpzs ITEM_FRAME_ID Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_zhadbbac STATE_MANAGERS Ljava/util/Map;
+	METHOD m_htjzcync createBlockStateManagerByIdGetter ()Ljava/util/function/Function;
+	METHOD m_jgqmykcx createStateManager ()Lnet/minecraft/unmapped/C_ezfeikaq;
+	METHOD m_ntesmgni getItemFrameState (ZZ)Lnet/minecraft/unmapped/C_txtbiemp;
+		ARG 0 glowing
+		ARG 1 map

--- a/mappings/net/minecraft/component/type/ChargedProjectilesComponent.mapping
+++ b/mappings/net/minecraft/component/type/ChargedProjectilesComponent.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_lukqwasx net/minecraft/component/type/ChargedProjectilesComponent
 	FIELD f_gcqrlcog projectileItems Ljava/util/List;
 	FIELD f_rwwhxkdd DEFAULT Lnet/minecraft/unmapped/C_lukqwasx;
+	METHOD m_cklclykr (Lnet/minecraft/unmapped/C_vorddnax$C_rdhfmrgz;Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_sddaxwyk;I)V
+		ARG 1 append
 	METHOD m_fizibuil create (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_lukqwasx;
 		ARG 0 projectile
 	METHOD m_fsxlueuz isEmpty ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -107,6 +107,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_yfdxpwmi lastRenderZ D
 	FIELD f_ynvrafke FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_yqdhmihw INVISIBLE_FLAG_INDEX I
+	FIELD f_yqhkkypy currentCollisionChecks Ljava/util/List;
 	FIELD f_yqjyujwv SILENT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_yyonjapw prevX D
 	FIELD f_yyqamqtt verticalCollision Z
@@ -166,6 +167,8 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_bibfwntw adjustMovementForSneaking (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_eojqvxuw;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 movement
 		ARG 2 type
+	METHOD m_bibhvpyc applyBlockCollisionEffectsImpl (Ljava/util/List;)V
+		ARG 1 collisionChecks
 	METHOD m_bikcqssn setInsidePortal (Lnet/minecraft/unmapped/C_teerivzm;Lnet/minecraft/unmapped/C_hynzadkk;)V
 		ARG 1 portal
 	METHOD m_bjibgujk onRemovedClient ()V
@@ -525,7 +528,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 1 player
 	METHOD m_mcdfsxav teleport (Lnet/minecraft/unmapped/C_sqhjwpkh;)Lnet/minecraft/unmapped/C_astfners;
 		ARG 1 target
-	METHOD m_mcimzscq setOnFireFromLava ()V
+	METHOD m_mcimzscq applyLavaDamage ()V
 	METHOD m_mdjbjjrz getServer ()Lnet/minecraft/server/MinecraftServer;
 	METHOD m_mhvikmsw isPushedByFluids ()Z
 	METHOD m_misouebt canTeleportBetween (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_cdctfzbn;)Z
@@ -660,6 +663,8 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_qqdihtpc shouldSetPositionOnLoad ()Z
 	METHOD m_qufdccav onExploded (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 entity
+	METHOD m_qvcfilaf (Lit/unimi/dsi/fastutil/longs/LongSet;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_bummdtgu$C_ybqvbnjz;Lnet/minecraft/unmapped/C_hynzadkk;I)V
+		ARG 6 iteration
 	METHOD m_qvezifat isDescending ()Z
 	METHOD m_qwhvqkqc setInPowderSnow (Z)V
 		ARG 1 inPowderSnow
@@ -693,6 +698,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_rykuwyoq getPosition (F)Lnet/minecraft/unmapped/C_hynzadkk;
 		ARG 1 downwardOffset
 	METHOD m_ryyntoxx getStepHeight ()F
+	METHOD m_sanzqvie collidesWithFluid (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;)Z
 	METHOD m_sciubbmh getStandingEyeHeight ()F
 	METHOD m_scrtnsdg canPlayLavaBurnSound ()Z
 	METHOD m_sdtijuxq getPositionSync ()Lnet/minecraft/unmapped/C_kfofqpqr;
@@ -864,6 +870,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 1 passenger
 	METHOD m_wmrqudhe checkBlockCollisions (Ljava/util/List;Lnet/minecraft/unmapped/C_bummdtgu$C_ybqvbnjz;)V
 		ARG 1 collisionChecks
+		ARG 2 effectManager
 	METHOD m_wmxlrpiw getPos ()Lnet/minecraft/unmapped/C_vgpupfxx;
 		COMMENT {@return the position in the world of this entity}
 	METHOD m_wnmvwdkc playSwimSound ()V
@@ -887,6 +894,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_xpuekaoa setUuid (Ljava/util/UUID;)V
 		ARG 1 uuid
 	METHOD m_xrhuexzc dropStack (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gmbqjnle;)Lnet/minecraft/unmapped/C_uqpzijng;
+	METHOD m_xrjmjfqu lavaIgnite ()V
 	METHOD m_xrvghdnl getLandingBlockStateLegacy ()Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_xthhawdp onStartedTrackingBy (Lnet/minecraft/unmapped/C_mxrobsgg;)V
 		ARG 1 player
@@ -962,6 +970,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_zskfvtfy setPrevAngles (FF)V
 		ARG 1 yaw
 		ARG 2 pitch
+	METHOD m_zudbjjsd popCollisionCheck ()V
 	METHOD m_zvtbefqn teleportSameDimension (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sqhjwpkh;)Lnet/minecraft/unmapped/C_astfners;
 		ARG 2 target
 	CLASS C_aipuagbw Movement

--- a/mappings/net/minecraft/entity/JumpingMount.mapping
+++ b/mappings/net/minecraft/entity/JumpingMount.mapping
@@ -3,4 +3,6 @@ CLASS net/minecraft/unmapped/C_yerxgbau net/minecraft/entity/JumpingMount
 	METHOD m_vbenrwbf getJumpCooldown ()I
 	METHOD m_vjbheary canJump ()Z
 	METHOD m_vjqgmppp startJumping (I)V
+		ARG 1 height
 	METHOD m_zjzgqzky setJumpStrength (I)V
+		ARG 1 inputStrength

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -276,6 +276,9 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_iraseeho getStuckArrowCount ()I
 	METHOD m_isvuhvoe isPartOfGame ()Z
 	METHOD m_itkmziir getMainArm ()Lnet/minecraft/unmapped/C_njjnizsa;
+	METHOD m_ixaetezv getEquipSound (Lnet/minecraft/unmapped/C_yuycoehb;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_duiqsjgf;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 1 slot
+		ARG 3 component
 	METHOD m_jclvfrxe tickItemStackUsage (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 stack
 	METHOD m_jeizdffm getPreferredEquipmentSlot (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_yuycoehb;
@@ -381,11 +384,13 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_ozivsxrd turnHead (F)V
 		ARG 1 bodyRotation
 	METHOD m_pdfqoxex travel (Lnet/minecraft/unmapped/C_vgpupfxx;)V
-		COMMENT Allows you to do certain speed and velocity calculations. This is useful for custom vehicle behavior, or custom entity movement. This is not to be confused with AI.
-		COMMENT
-		COMMENT <p>See vanilla examples of {@linkplain net.minecraft.entity.passive.AbstractHorseEntity#travel
-		COMMENT custom horse vehicle} and {@linkplain net.minecraft.entity.mob.FlyingEntity#travel
-		COMMENT flying entities}.
+		COMMENT Allows you to do certain speed and velocity calculations. This is useful for
+		COMMENT custom vehicle behavior, or custom entity movement.<br>
+		COMMENT This is not to be confused with AI.
+		COMMENT <p>
+		COMMENT See vanilla examples in
+		COMMENT {@linkplain net.minecraft.entity.passive.TamableMountEntity#travel mounts}
+		COMMENT and {@linkplain net.minecraft.entity.mob.FlyingEntity#travel flying entities}.
 		ARG 1 movementInput
 			COMMENT represents the sidewaysSpeed, upwardSpeed, and forwardSpeed of the entity in that order
 	METHOD m_pewhzjbc computeUnsafeFallenDistance (D)D

--- a/mappings/net/minecraft/entity/mob/CreakingEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/CreakingEntity.mapping
@@ -16,6 +16,8 @@ CLASS net/minecraft/unmapped/C_vbugwmii net/minecraft/entity/mob/CreakingEntity
 	FIELD f_yaenaqzq FIGHTING_MOVEMENT_SPEED F
 	METHOD m_japnsene setActive (Z)V
 	METHOD m_jkvxeltg buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_jysxmfcv (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+		ARG 1 source
 	METHOD m_ohccomft animate ()V
 	METHOD m_qnnyojvb checkCanMove ()Z
 	METHOD m_xchtvnyy canMove ()Z

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -183,6 +183,7 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_wjpwvwky playSpawnEffects ()V
 	METHOD m_wjrpjxbl createEquipmentLootParameters (Lnet/minecraft/unmapped/C_bdwnwhiu;)Lnet/minecraft/unmapped/C_nzsnkdtl;
 	METHOD m_wmjahmev getLookYawSpeed ()I
+	METHOD m_wpjpirof isSaddled ()Z
 	METHOD m_wuplhywr setBaby (Z)V
 		ARG 1 baby
 	METHOD m_xijbocdi spawnsTooManyForEachTry (I)Z

--- a/mappings/net/minecraft/entity/passive/AnimalEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AnimalEntity.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/unmapped/C_tprvtfff net/minecraft/entity/passive/AnimalEntit
 	METHOD m_fficjzem isInLove ()Z
 	METHOD m_kgvkegms breed (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_tprvtfff;)V
 		ARG 1 world
-		ARG 2 other
+		ARG 2 mate
 	METHOD m_lmbkeded getLoveTicks ()I
 	METHOD m_lyumrhdj eat (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_laxmzoqs;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 player

--- a/mappings/net/minecraft/entity/passive/PackMountEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PackMountEntity.mapping
@@ -1,6 +1,7 @@
-CLASS net/minecraft/unmapped/C_javurlgg net/minecraft/entity/passive/AbstractDonkeyEntity
+CLASS net/minecraft/unmapped/C_javurlgg net/minecraft/entity/passive/PackMountEntity
 	FIELD f_loaorggp CHEST Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_quviykji dimensions Lnet/minecraft/unmapped/C_sszpscpo;
+	FIELD f_uipqwqtj DEFAULT_HAS_CHEST Z
 	METHOD m_qcurzppd buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_ufvruazd playAddChestSound ()V
 	METHOD m_xbbuagfx addChest (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)V

--- a/mappings/net/minecraft/entity/passive/PassiveEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PassiveEntity.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/unmapped/C_jvojbnla net/minecraft/entity/passive/PassiveEnti
 	METHOD m_eyazmlyb getGrowthSeconds (I)I
 		ARG 0 remainingTicks
 	METHOD m_hftuejnb createChild (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_jvojbnla;)Lnet/minecraft/unmapped/C_jvojbnla;
+		ARG 2 mate
 	METHOD m_joivblzf growUp (I)V
 		ARG 1 age
 	METHOD m_jwrgxfdo getForcedAge ()I

--- a/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHorseEntity
+CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/TamableMountEntity
 	FIELD f_abtzxcfc lastEatingAnimationProgress F
 	FIELD f_arsvwxpt inAir Z
 	FIELD f_buzirmfu lastEatingGrassAnimationProgress F
@@ -6,9 +6,12 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 	FIELD f_catxtgyu BREEDING_CROSS_FACTOR D
 	FIELD f_cdewjdee INVENTORY_ROWS I
 	FIELD f_cjthlgvf items Lnet/minecraft/unmapped/C_rsloiwzx;
+	FIELD f_cobtmsbu DEFAULT_TEMPER I
 	FIELD f_cxooziyz EATING_FLAG I
 	FIELD f_edcpbqlo sprintCounter I
+	FIELD f_flvvhhqs DEFAULT_EATING_GRASS Z
 	FIELD f_fstbmray MAX_MOVEMENT_SPEED_BONUS F
+	FIELD f_fyzuhdni DEFAULT_BRED Z
 	FIELD f_gdzbsaga eatingAnimationProgress F
 	FIELD f_hbyhydyx SIDEWAYS_MOVEMENT_SPEED_FACTOR F
 	FIELD f_hdxhgdko eatingGrassTicks I
@@ -24,6 +27,7 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 	FIELD f_ntiwstyo MIN_HEALTH_BONUS F
 	FIELD f_oquxiife eatingGrassAnimationProgress F
 	FIELD f_osljbzmg CHEST_SLOT_OFFSET I
+	FIELD f_osvredga DEFAULT_TAME Z
 	FIELD f_rbeqlhug BACKWARDS_MOVEMENT_SPEED_FACTOR F
 	FIELD f_rewxrkfk MAX_HEALTH_BONUS F
 	FIELD f_rkfnbjcq EATING_GRASS_FLAG I
@@ -73,6 +77,8 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 	METHOD m_heiraznc isAngry ()Z
 	METHOD m_iqosbrnr isEatingGrass ()Z
 	METHOD m_ixcteuff getInventorySize ()I
+	METHOD m_jahineqk (I)I
+		ARG 0 initial
 	METHOD m_jcddjwwg getSound ()Lnet/minecraft/unmapped/C_avavozay;
 	METHOD m_krorfdje getEatingAnimationProgress (F)F
 		ARG 1 tickDelta
@@ -94,11 +100,13 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 		ARG 1 group
 	METHOD m_nsgfuztq getHorseFlag (I)Z
 		ARG 1 bitmask
+	METHOD m_ogkaauyv (I)I
+		ARG 0 initial
 	METHOD m_pgiwydii setHorseFlag (IZ)V
 		ARG 1 bitmask
 		ARG 2 flag
 	METHOD m_qhxpjozn generateSpeedBonus (Ljava/util/function/DoubleSupplier;)D
-		ARG 0 randomGetter
+		ARG 0 randomizer
 	METHOD m_rebcmcfu getEatSound ()Lnet/minecraft/unmapped/C_avavozay;
 	METHOD m_rnxhdlpt equipBodyArmor (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 	METHOD m_rrbiqiat getInventoryColumns ()I
@@ -110,7 +118,7 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 		ARG 1 player
 	METHOD m_uhtevheg playEatingAnimation ()V
 	METHOD m_utvezgku generateMaxHealthBonus (Ljava/util/function/IntUnaryOperator;)F
-		ARG 0 randomGetter
+		ARG 0 randomizer
 	METHOD m_uzaawbaz getMaxTemper ()I
 	METHOD m_vnhkinwe getTemper ()I
 	METHOD m_vrlngusg setAngry (Z)V
@@ -137,6 +145,6 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/AbstractHor
 		ARG 2 passenger
 	METHOD m_yvcfnlwg buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_zhrpcxsv generateJumpStrengthBonus (Ljava/util/function/DoubleSupplier;)D
-		ARG 0 randomGetter
+		ARG 0 randomizer
 	METHOD m_zpkkhcub isDifferentInventory (Lnet/minecraft/unmapped/C_pjtstjoq;)Z
 		ARG 1 inventory

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -149,6 +149,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_jnzfvwue isMainPlayer ()Z
 	METHOD m_kgvhhcun tickRegeneration ()V
 	METHOD m_knabeuog vanishCursedItems ()V
+	METHOD m_kvorjuof preventsBlockDrops ()Z
 	METHOD m_kxxqgmsc sendTradeOffers (ILnet/minecraft/unmapped/C_eygsjfgm;IIZZ)V
 		ARG 1 syncId
 		ARG 2 offers

--- a/mappings/net/minecraft/fluid/FlowableFluid.mapping
+++ b/mappings/net/minecraft/fluid/FlowableFluid.mapping
@@ -66,6 +66,7 @@ CLASS net/minecraft/unmapped/C_vneqepda net/minecraft/fluid/FlowableFluid
 		ARG 3 state
 	METHOD m_lngltdkk getLevelDecreasePerBlock (Lnet/minecraft/unmapped/C_eemzphbi;)I
 	METHOD m_lshwjkeq beforeBreakingBlock (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V
+		ARG 1 world
 	METHOD m_mvvtqxwz flow (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_xpuuihxf;Lnet/minecraft/unmapped/C_xqketiuf;)V
 		ARG 1 world
 		ARG 2 pos
@@ -106,3 +107,6 @@ CLASS net/minecraft/unmapped/C_vneqepda net/minecraft/fluid/FlowableFluid
 		METHOD m_kqslwepa getState (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
 		METHOD m_nnlgqqbg packHorizontalOffset (Lnet/minecraft/unmapped/C_hynzadkk;)S
 		METHOD m_swnccerv canFlowDownFrom (Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	CLASS C_rblmlrzb
+		METHOD rehash (I)V
+			ARG 1 newN

--- a/mappings/net/minecraft/fluid/Fluid.mapping
+++ b/mappings/net/minecraft/fluid/Fluid.mapping
@@ -21,6 +21,8 @@ CLASS net/minecraft/unmapped/C_rxhyurmy net/minecraft/fluid/Fluid
 	METHOD m_hkiydxui setDefaultState (Lnet/minecraft/unmapped/C_xqketiuf;)V
 		ARG 1 state
 	METHOD m_hpmvvmie canBeReplacedWith (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rxhyurmy;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
+		ARG 1 thisState
+		ARG 4 fluid
 	METHOD m_iovysrti getDefaultState ()Lnet/minecraft/unmapped/C_xqketiuf;
 	METHOD m_knecptla toBlockState (Lnet/minecraft/unmapped/C_xqketiuf;)Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_lrjhvxds getShape (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zscvhwbd;
@@ -32,6 +34,7 @@ CLASS net/minecraft/unmapped/C_rxhyurmy net/minecraft/fluid/Fluid
 	METHOD m_pfqcawvv getVelocity (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xqketiuf;)Lnet/minecraft/unmapped/C_vgpupfxx;
 	METHOD m_qdxselfr getBucketFillSound ()Ljava/util/Optional;
 		COMMENT Returns the sound played when filling a bucket with this fluid.
+	METHOD m_rzubjknj getCollisionBox (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hbcjzgoe;
 	METHOD m_skhoygrv getStateManager ()Lnet/minecraft/unmapped/C_ezfeikaq;
 	METHOD m_tgvruohf onRandomTick (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_rlomrsco;)V
 		ARG 2 pos
@@ -42,5 +45,7 @@ CLASS net/minecraft/unmapped/C_rxhyurmy net/minecraft/fluid/Fluid
 		ARG 2 pos
 		ARG 3 state
 	METHOD m_ujruvhoa getHeight (Lnet/minecraft/unmapped/C_xqketiuf;Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)F
+	METHOD m_urkekfmy onEntityCollision (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_bummdtgu;)V
+		ARG 4 effectManager
 	METHOD m_ytkqcfqu getTickRate (Lnet/minecraft/unmapped/C_eemzphbi;)I
 	METHOD m_zcckkdqh isSource (Lnet/minecraft/unmapped/C_xqketiuf;)Z

--- a/mappings/net/minecraft/fluid/FluidState.mapping
+++ b/mappings/net/minecraft/fluid/FluidState.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/unmapped/C_xqketiuf net/minecraft/fluid/FluidState
 	METHOD m_fzmzbbxh getParticle ()Lnet/minecraft/unmapped/C_nqucohct;
 	METHOD m_gdypaenc isOf (Lnet/minecraft/unmapped/C_rxhyurmy;)Z
 		ARG 1 fluid
+	METHOD m_hiquyily getCollisionBox (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hbcjzgoe;
 	METHOD m_jxadadpa canBeReplacedWith (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rxhyurmy;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 world
 		ARG 2 pos
@@ -30,6 +31,8 @@ CLASS net/minecraft/unmapped/C_xqketiuf net/minecraft/fluid/FluidState
 		ARG 1 world
 		ARG 2 pos
 	METHOD m_myjucdzw getFluid ()Lnet/minecraft/unmapped/C_rxhyurmy;
+	METHOD m_oicpcbjv onEntityCollision (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_bummdtgu;)V
+		ARG 4 effectManager
 	METHOD m_qxoetaqe hasRandomTicks ()Z
 	METHOD m_rbymegfm getShape (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 world

--- a/mappings/net/minecraft/inventory/Inventory.mapping
+++ b/mappings/net/minecraft/inventory/Inventory.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_pjtstjoq net/minecraft/inventory/Inventory
 	FIELD f_vlssyyaw DEFAULT_MAX_INTERACTION_RANGE F
 	METHOD m_akaynoad setStack (ILnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 1 slot
 	METHOD m_crvopqlx canPlayerUse (Lnet/minecraft/unmapped/C_kvegafmh;Lnet/minecraft/unmapped/C_jzrpycqo;F)Z
 		ARG 0 blockEntity
 		ARG 1 player
@@ -15,9 +16,12 @@ CLASS net/minecraft/unmapped/C_pjtstjoq net/minecraft/inventory/Inventory
 		COMMENT Removes a specific number of items from the given slot.
 		COMMENT
 		COMMENT @return the removed items as a stack
+		ARG 1 slot
+		ARG 2 amount
 	METHOD m_jzosiplc getStack (I)Lnet/minecraft/unmapped/C_sddaxwyk;
 		COMMENT Fetches the stack currently stored at the given slot. If the slot is empty,
 		COMMENT or is outside the bounds of this inventory, returns see {@link ItemStack#EMPTY}.
+		ARG 1 slot
 	METHOD m_kvljutzx getMaxCount (Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 1 stack
 	METHOD m_mwetohsb getMaxCountPerStack ()I
@@ -37,6 +41,7 @@ CLASS net/minecraft/unmapped/C_pjtstjoq net/minecraft/inventory/Inventory
 		COMMENT Removes the stack currently stored at the indicated slot.
 		COMMENT
 		COMMENT @return the stack previously stored at the indicated slot.
+		ARG 1 slot
 	METHOD m_umfxwlmm isValid (ILnet/minecraft/unmapped/C_sddaxwyk;)Z
 		COMMENT Returns whether the given stack is a valid for the indicated slot position.
 		ARG 1 slot

--- a/mappings/net/minecraft/inventory/SidedInventory.mapping
+++ b/mappings/net/minecraft/inventory/SidedInventory.mapping
@@ -4,5 +4,7 @@ CLASS net/minecraft/unmapped/C_dqieilpc net/minecraft/inventory/SidedInventory
 		COMMENT Gets the available slot positions that are reachable from a given side.
 	METHOD m_kdgofkkq canExtract (ILnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		COMMENT Determines whether the given stack can be removed from this inventory at the specified slot position from the given direction.
+		ARG 1 slot
 	METHOD m_mkcjjlxd canInsert (ILnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		COMMENT Determines whether the given stack can be inserted into this inventory at the specified slot position from the given direction.
+		ARG 1 slot

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -109,6 +109,7 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		ARG 1 state
 	METHOD m_hdopgosb appendTooltip (Lnet/minecraft/unmapped/C_pscqxfcs;Lnet/minecraft/unmapped/C_vorddnax$C_rdhfmrgz;Lnet/minecraft/unmapped/C_idvlscju;Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_taebrtdw;)V
 		ARG 1 componentType
+		ARG 2 context
 		ARG 5 config
 	METHOD m_hmrpegvi onClickedOnOther (Lnet/minecraft/unmapped/C_nhvqfffd;Lnet/minecraft/unmapped/C_qcuteihm;Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 		COMMENT Called when the stack is placed on another {@link ItemStack} in a slot.
@@ -256,6 +257,10 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		ARG 4 player
 		ARG 5 cursorStackReference
 	METHOD m_umudukuf onCraft (Lnet/minecraft/unmapped/C_cdctfzbn;)V
+	METHOD m_utrkycgn appendTooltip (Lnet/minecraft/unmapped/C_vorddnax$C_rdhfmrgz;Lnet/minecraft/unmapped/C_idvlscju;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_taebrtdw;Ljava/util/function/Consumer;)V
+		ARG 1 context
+		ARG 4 config
+		ARG 5 append
 	METHOD m_utrmkjnp setCooldown (I)V
 		ARG 1 cooldown
 	METHOD m_uzwjgkgy minimizeCount (I)V

--- a/mappings/net/minecraft/item/SpawnEggItem.mapping
+++ b/mappings/net/minecraft/item/SpawnEggItem.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/unmapped/C_vhhtwwcq net/minecraft/item/SpawnEggItem
 		ARG 0 type
 	METHOD m_jqfwshyx spawnBaby (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_sddaxwyk;)Ljava/util/Optional;
 		ARG 1 user
-		ARG 2 entity
+		ARG 2 mate
 		ARG 3 entityType
 		ARG 4 world
 		ARG 5 pos

--- a/mappings/net/minecraft/item/TooltipAppender.mapping
+++ b/mappings/net/minecraft/item/TooltipAppender.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/unmapped/C_lcgmmrzz net/minecraft/item/TooltipAppender
 	METHOD m_eqoeoqpg appendToTooltip (Lnet/minecraft/unmapped/C_vorddnax$C_rdhfmrgz;Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_taebrtdw;Lnet/minecraft/unmapped/C_hmcnusfu;)V
+		ARG 1 context
+		ARG 2 append
+		ARG 3 config
+		ARG 4 components

--- a/mappings/net/minecraft/loot/LootChoice.mapping
+++ b/mappings/net/minecraft/loot/LootChoice.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/unmapped/C_iozoltsq net/minecraft/loot/LootChoice
 	METHOD m_hhpvfhmc getWeight (F)I
 	METHOD m_tqhpjsxa generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_iakykpgh;)V
+		ARG 1 lootConsumer

--- a/mappings/net/minecraft/loot/LootPool.mapping
+++ b/mappings/net/minecraft/loot/LootPool.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/unmapped/C_yaprhqrh net/minecraft/loot/LootPool
 		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD m_ozbdjpls supplyOnce (Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_iakykpgh;)V
-		ARG 1 lootConsumer
+		ARG 1 lootProcessor
 		ARG 2 context
 	METHOD m_tvubdoxl validate (Lnet/minecraft/unmapped/C_eumtgsbp;)V
 		ARG 1 reporter

--- a/mappings/net/minecraft/loot/context/LootContext.mapping
+++ b/mappings/net/minecraft/loot/context/LootContext.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/unmapped/C_iakykpgh net/minecraft/loot/context/LootContext
 		ARG 1 entry
 	METHOD m_tjqtsntr drop (Lnet/minecraft/unmapped/C_ncpywfca;Ljava/util/function/Consumer;)V
 		ARG 1 id
-		ARG 2 lootConsumer
+		ARG 2 lootProcessor
 	METHOD m_vnevydll getOrThrow (Lnet/minecraft/unmapped/C_fwhrecir;)Ljava/lang/Object;
 		ARG 1 parameter
 	METHOD m_wajkhgmd getRandom ()Lnet/minecraft/unmapped/C_rlomrsco;

--- a/mappings/net/minecraft/loot/context/LootContextParameterSet.mapping
+++ b/mappings/net/minecraft/loot/context/LootContextParameterSet.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/unmapped/C_nzsnkdtl net/minecraft/loot/context/LootContextPa
 	FIELD f_qhizdbwi parameters Lnet/minecraft/unmapped/C_zcrtzabd;
 	METHOD m_akasmvkf addDynamicDrops (Lnet/minecraft/unmapped/C_ncpywfca;Ljava/util/function/Consumer;)V
 		ARG 1 id
-		ARG 2 lootConsumer
+		ARG 2 lootProcessor
 	METHOD m_kiqemlmv getLuck ()F
 	METHOD m_nrjpuwzz getParameters ()Lnet/minecraft/unmapped/C_zcrtzabd;
 	METHOD m_spcgjjtv getWorld ()Lnet/minecraft/unmapped/C_bdwnwhiu;
@@ -31,3 +31,5 @@ CLASS net/minecraft/unmapped/C_nzsnkdtl net/minecraft/loot/context/LootContextPa
 		METHOD m_ytumowlr add (Lnet/minecraft/unmapped/C_fwhrecir;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_nzsnkdtl$C_oqhigtaq;
 			ARG 2 value
 	CLASS C_tcvvixye DynamicDrop
+		METHOD add (Ljava/util/function/Consumer;)V
+			ARG 1 lootConsumer

--- a/mappings/net/minecraft/loot/context/LootContextParameterSet.mapping
+++ b/mappings/net/minecraft/loot/context/LootContextParameterSet.mapping
@@ -32,4 +32,4 @@ CLASS net/minecraft/unmapped/C_nzsnkdtl net/minecraft/loot/context/LootContextPa
 			ARG 2 value
 	CLASS C_tcvvixye DynamicDrop
 		METHOD add (Ljava/util/function/Consumer;)V
-			ARG 1 lootConsumer
+			ARG 1 lootProcessor

--- a/mappings/net/minecraft/loot/context/LootContextParameterSets.mapping
+++ b/mappings/net/minecraft/loot/context/LootContextParameterSets.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/unmapped/C_oepzwcin net/minecraft/loot/context/LootContextParamSets
+CLASS net/minecraft/unmapped/C_oepzwcin net/minecraft/loot/context/LootContextParameterSets
 	FIELD f_nbczipks MAP Lcom/google/common/collect/BiMap;
 	METHOD m_vyxqvrqd register (Ljava/lang/String;Ljava/util/function/Consumer;)Lnet/minecraft/unmapped/C_ykthnceq;
 		ARG 0 name

--- a/mappings/net/minecraft/loot/entry/LeafEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/LeafEntry.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/unmapped/C_sphmzmsf net/minecraft/loot/entry/LeafEntry
 		ARG 0 entry
 	METHOD m_jmkfgrnf addLeafFields (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P4;
 	METHOD m_jptxqkrt generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_iakykpgh;)V
+		ARG 1 lootProcessor
 	METHOD m_tzhapdtn (Lnet/minecraft/unmapped/C_sphmzmsf;)Ljava/util/List;
 		ARG 0 entry
 	METHOD m_uvcklnbk (Lnet/minecraft/unmapped/C_sphmzmsf;)Ljava/lang/Integer;

--- a/mappings/net/minecraft/recipe/CraftingHandler.mapping
+++ b/mappings/net/minecraft/recipe/CraftingHandler.mapping
@@ -4,3 +4,4 @@ CLASS net/minecraft/unmapped/C_mudajugr net/minecraft/recipe/CraftingHandler
 	METHOD m_rdzxlwhl shouldCraft (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_dscbrwbj;)Z
 		ARG 2 recipe
 	METHOD m_shzndkyk onResultUpdate (Lnet/minecraft/unmapped/C_dscbrwbj;)V
+		ARG 1 recipe

--- a/mappings/net/minecraft/recipe/Recipe.mapping
+++ b/mappings/net/minecraft/recipe/Recipe.mapping
@@ -16,6 +16,7 @@ CLASS net/minecraft/unmapped/C_awrmdwqd net/minecraft/recipe/Recipe
 		COMMENT {@return the serializer associated with this recipe}
 	METHOD m_bsknoala getGroup ()Ljava/lang/String;
 	METHOD m_jjsxdttb matches (Lnet/minecraft/unmapped/C_cxmcihwl;Lnet/minecraft/unmapped/C_cdctfzbn;)Z
+		ARG 1 input
 	METHOD m_kwgjnprn getDisplays ()Ljava/util/List;
 	METHOD m_nmeksozi isIgnoredInRecipeBook ()Z
 		COMMENT {@return whether this recipe is ignored by the recipe book} If a recipe
@@ -25,6 +26,8 @@ CLASS net/minecraft/unmapped/C_awrmdwqd net/minecraft/recipe/Recipe
 	METHOD m_qqucltqj showNotification ()Z
 		COMMENT {@return whenever this recipe should show a toast notification on being unlocked or not}
 	METHOD m_tikgmnde craft (Lnet/minecraft/unmapped/C_cxmcihwl;Lnet/minecraft/unmapped/C_vtbxyypo$C_etmlgbig;)Lnet/minecraft/unmapped/C_sddaxwyk;
+		ARG 1 input
+		ARG 2 lookupProvider
 	METHOD m_ttbvwfef getType ()Lnet/minecraft/unmapped/C_rhnqznys;
 		COMMENT {@return the type of this recipe}
 		COMMENT

--- a/mappings/net/minecraft/recipe/RecipeInputProvider.mapping
+++ b/mappings/net/minecraft/recipe/RecipeInputProvider.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/unmapped/C_npzwysac net/minecraft/recipe/RecipeInputProvider
+	METHOD fillStackedContents (Lnet/minecraft/unmapped/C_fcquvjby;)V
+		ARG 1 finder

--- a/mappings/net/minecraft/recipe/SingleItemRecipe.mapping
+++ b/mappings/net/minecraft/recipe/SingleItemRecipe.mapping
@@ -12,4 +12,10 @@ CLASS net/minecraft/unmapped/C_ziizojwa net/minecraft/recipe/SingleItemRecipe
 	CLASS C_jqwnrmvy Serializer
 		FIELD f_oganfshl packetCodec Lnet/minecraft/unmapped/C_qsrmwluu;
 		FIELD f_uewnlcpg codec Lcom/mojang/serialization/MapCodec;
+		METHOD <init> (Lnet/minecraft/unmapped/C_ziizojwa$C_yunnfuov;)V
+			ARG 1 factory
 	CLASS C_yunnfuov RecipeFactory
+		METHOD create (Ljava/lang/String;Lnet/minecraft/unmapped/C_tcpsydrv;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_ziizojwa;
+			ARG 1 group
+			ARG 2 ingredient
+			ARG 3 result

--- a/mappings/net/minecraft/screen/EnchantmentScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/EnchantmentScreenHandler.mapping
@@ -25,3 +25,5 @@ CLASS net/minecraft/unmapped/C_pyejtqnd net/minecraft/screen/EnchantmentScreenHa
 		ARG 2 world
 		ARG 3 pos
 	METHOD m_ryytoerl getSeed ()I
+	METHOD m_zttnkgab generateEnchantments (Lnet/minecraft/unmapped/C_wqxmvzdq;Lnet/minecraft/unmapped/C_sddaxwyk;II)Ljava/util/List;
+		ARG 3 seedOffset

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -110,7 +110,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 	FIELD f_lwoavpue EYE Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if an end portal frame contains an eye of ender.
 	FIELD f_lxkidxgu CHARGES_MAX I
-	FIELD f_lxvnqopd EAST_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_lxvnqopd EAST_CONNECTION_HEIGHT Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the east.
 	FIELD f_mdkbidiq SIGNAL_FIRE Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if a campfire's smoke should be taller.
@@ -139,7 +139,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 		COMMENT  <p>In vanilla, if TNT is unstable, it will ignite when broken.
 	FIELD f_ntocvslm NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if this block is connected to another block from the north.
-	FIELD f_nukmetwo SOUTH_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_nukmetwo SOUTH_CONNECTION_HEIGHT Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the south.
 	FIELD f_oanlunvg ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the rotation of a block on a 0 to 15 scale.
@@ -167,7 +167,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 	FIELD f_rnvfyssr VERTICAL_DIRECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_rpaaueeh DISTANCE_1_7 Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the overhang distance of a block on a scale of 1-7.
-	FIELD f_rrutmhdh NORTH_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_rrutmhdh NORTH_CONNECTION_HEIGHT Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the north.
 	FIELD f_sfkockqo LEVEL_8 Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the level of a composter.
@@ -179,7 +179,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 		COMMENT A property that specifies if a daylight sensor's output is inverted.
 	FIELD f_sotephho HAS_BOTTLE_0 Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if a brewing stand has a bottle in slot 0.
-	FIELD f_tkyxjveq WEST_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_tkyxjveq WEST_CONNECTION_HEIGHT Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the west.
 	FIELD f_tqwhmysb NATURAL Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_uuqvhfqz SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -28,6 +28,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 		COMMENT A property that specifies if a block is persistent.
 		COMMENT
 		COMMENT <p>In vanilla, this is used to specify whether leaves should disappear when the logs are removed.
+	FIELD f_cxzywzhc MAP Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_dccgrmht EAST_WIRE_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how redstone wire attaches to the east.
 	FIELD f_dstodryn MOISTURE Lnet/minecraft/unmapped/C_vltzvhxi;

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -110,7 +110,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 	FIELD f_lwoavpue EYE Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if an end portal frame contains an eye of ender.
 	FIELD f_lxkidxgu CHARGES_MAX I
-	FIELD f_lxvnqopd EAST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_lxvnqopd EAST_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the east.
 	FIELD f_mdkbidiq SIGNAL_FIRE Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if a campfire's smoke should be taller.
@@ -139,7 +139,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 		COMMENT  <p>In vanilla, if TNT is unstable, it will ignite when broken.
 	FIELD f_ntocvslm NORTH Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if this block is connected to another block from the north.
-	FIELD f_nukmetwo SOUTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_nukmetwo SOUTH_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the south.
 	FIELD f_oanlunvg ROTATION Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the rotation of a block on a 0 to 15 scale.
@@ -167,7 +167,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 	FIELD f_rnvfyssr VERTICAL_DIRECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 	FIELD f_rpaaueeh DISTANCE_1_7 Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the overhang distance of a block on a scale of 1-7.
-	FIELD f_rrutmhdh NORTH_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_rrutmhdh NORTH_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the north.
 	FIELD f_sfkockqo LEVEL_8 Lnet/minecraft/unmapped/C_vltzvhxi;
 		COMMENT A property that specifies the level of a composter.
@@ -179,7 +179,7 @@ CLASS net/minecraft/unmapped/C_fvhzmori net/minecraft/state/property/Properties
 		COMMENT A property that specifies if a daylight sensor's output is inverted.
 	FIELD f_sotephho HAS_BOTTLE_0 Lnet/minecraft/unmapped/C_xhwijdsd;
 		COMMENT A property that specifies if a brewing stand has a bottle in slot 0.
-	FIELD f_tkyxjveq WEST_WALL_SHAPE Lnet/minecraft/unmapped/C_cgckxfsw;
+	FIELD f_tkyxjveq WEST_WALL_CONNECTION Lnet/minecraft/unmapped/C_cgckxfsw;
 		COMMENT A property that specifies how a wall extends from the center post to the west.
 	FIELD f_tqwhmysb NATURAL Lnet/minecraft/unmapped/C_xhwijdsd;
 	FIELD f_uuqvhfqz SOUTH Lnet/minecraft/unmapped/C_xhwijdsd;

--- a/mappings/net/minecraft/structure/Structure.mapping
+++ b/mappings/net/minecraft/structure/Structure.mapping
@@ -149,6 +149,8 @@ CLASS net/minecraft/unmapped/C_abvlwuej net/minecraft/structure/Structure
 		ARG 1 pos
 		ARG 2 mirror
 		ARG 3 rotation
+	CLASS C_awytwwja JigsawBlockInfo
+		METHOD m_vmrpvici ofStructureInfo (Lnet/minecraft/unmapped/C_abvlwuej$C_vmcrhozi;)Lnet/minecraft/unmapped/C_abvlwuej$C_awytwwja;
 	CLASS C_dicenpcy Palette
 		FIELD f_nsbovcli currentIndex I
 		FIELD f_sherqzsu ids Lnet/minecraft/unmapped/C_lwiadjvw;

--- a/mappings/net/minecraft/structure/Structure.mapping
+++ b/mappings/net/minecraft/structure/Structure.mapping
@@ -150,7 +150,7 @@ CLASS net/minecraft/unmapped/C_abvlwuej net/minecraft/structure/Structure
 		ARG 2 mirror
 		ARG 3 rotation
 	CLASS C_awytwwja JigsawBlockInfo
-		METHOD m_vmrpvici ofStructureInfo (Lnet/minecraft/unmapped/C_abvlwuej$C_vmcrhozi;)Lnet/minecraft/unmapped/C_abvlwuej$C_awytwwja;
+		METHOD m_vmrpvici of (Lnet/minecraft/unmapped/C_abvlwuej$C_vmcrhozi;)Lnet/minecraft/unmapped/C_abvlwuej$C_awytwwja;
 	CLASS C_dicenpcy Palette
 		FIELD f_nsbovcli currentIndex I
 		FIELD f_sherqzsu ids Lnet/minecraft/unmapped/C_lwiadjvw;

--- a/mappings/net/minecraft/util/SpawnUtil.mapping
+++ b/mappings/net/minecraft/util/SpawnUtil.mapping
@@ -1,9 +1,35 @@
 CLASS net/minecraft/unmapped/C_pofeqtmv net/minecraft/util/SpawnUtil
-	METHOD m_rnihnvvc (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;Lnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;)Z
+	METHOD m_rnihnvvc canSpawnInColumn (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;Lnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;)Z
+		ARG 1 range
 		ARG 3 spawnStrategy
-	METHOD m_vmxczuhc (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;IIILnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;Z)Ljava/util/Optional;
+	METHOD m_vmxczuhc trySpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;IIILnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;Z)Ljava/util/Optional;
 		ARG 0 entityType
+		ARG 4 attempts
+		ARG 5 horizontalRange
+		ARG 6 verticalRange
 		ARG 7 spawnStrategy
+		ARG 8 checkOverlap
 	CLASS C_pupsclxf Strategy
+		FIELD f_guwflhua WARDEN Lnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;
+		FIELD f_wgpkhkuo CREAKING Lnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;
+		FIELD f_zmtolkgw IRON_GOLEM Lnet/minecraft/unmapped/C_pofeqtmv$C_pupsclxf;
+		METHOD canSpawnOn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+			ARG 2 posBelow
+			ARG 3 stateBelow
+			ARG 4 footPos
+			ARG 5 footState
 		METHOD m_ejuorjko (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
-			ARG 1 pos1
+			ARG 1 posBelow
+			ARG 2 stateBelow
+			ARG 3 footPos
+			ARG 4 footState
+		METHOD m_kbkqoocs (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+			ARG 1 posBelow
+			ARG 2 stateBelow
+			ARG 3 footPos
+			ARG 4 footState
+		METHOD m_qdkatsfh (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)Z
+			ARG 1 posBelow
+			ARG 2 stateBelow
+			ARG 3 footPos
+			ARG 4 footState

--- a/mappings/net/minecraft/util/collection/ShufflingList.mapping
+++ b/mappings/net/minecraft/util/collection/ShufflingList.mapping
@@ -1,0 +1,40 @@
+CLASS net/minecraft/unmapped/C_zcaovjhs net/minecraft/util/collection/ShufflingList
+	FIELD f_foiaoslh random Lnet/minecraft/unmapped/C_rlomrsco;
+	FIELD f_nkovmckk entries Ljava/util/List;
+	METHOD <init> (Ljava/util/List;)V
+		ARG 1 list
+	METHOD m_hxwgwpcn shuffle ()Lnet/minecraft/unmapped/C_zcaovjhs;
+	METHOD m_jowdppdv (Lnet/minecraft/unmapped/C_zcaovjhs$C_jkfpyrca;)V
+		ARG 1 entry
+	METHOD m_ociexkmf stream ()Ljava/util/stream/Stream;
+	METHOD m_qkixgtkk createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 codec
+	METHOD m_tkhxhnwf add (Ljava/lang/Object;I)Lnet/minecraft/unmapped/C_zcaovjhs;
+		ARG 1 data
+		ARG 2 weight
+	METHOD m_zhejvbky (Lnet/minecraft/unmapped/C_zcaovjhs;)Ljava/util/List;
+		ARG 0 weightedList
+	CLASS C_jkfpyrca Entry
+		FIELD f_ivikegey shuffledOrder D
+		FIELD f_qrqordhh data Ljava/lang/Object;
+		FIELD f_suwmibmw weight I
+		METHOD <init> (Ljava/lang/Object;I)V
+			ARG 1 data
+			ARG 2 weight
+		METHOD m_eswnguyk getElement ()Ljava/lang/Object;
+		METHOD m_myftqaed createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+			ARG 0 codec
+		METHOD m_vitekfkz getShuffledOrder ()D
+		METHOD m_wimyripe setShuffledOrder (F)V
+			ARG 1 random
+		METHOD m_yuaucprh getWeight ()I
+		CLASS C_nghilmfh
+			METHOD decode (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+				ARG 2 input
+			METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+				ARG 1 entry
+				ARG 3 prefix
+			METHOD m_hcqkeugn (Lcom/mojang/serialization/Dynamic;Ljava/lang/Object;)Lnet/minecraft/unmapped/C_zcaovjhs$C_jkfpyrca;
+				ARG 1 data
+			METHOD m_qjlxfbjl (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/unmapped/C_zcaovjhs$C_jkfpyrca;)Lcom/mojang/datafixers/util/Pair;
+				ARG 1 entry

--- a/mappings/net/minecraft/util/collection/WeightedEntry.mapping
+++ b/mappings/net/minecraft/util/collection/WeightedEntry.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_hwvdvfmt net/minecraft/util/collection/WeightedEntry
+	METHOD m_ivbjycgt map (Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_hwvdvfmt;
+		ARG 1 mapper
+	METHOD m_jnfdnkur createCodec (Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/Codec;
+		ARG 0 valueCodec
+	METHOD m_vbvudgse createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 valueCodec

--- a/mappings/net/minecraft/util/collection/WeightedList.mapping
+++ b/mappings/net/minecraft/util/collection/WeightedList.mapping
@@ -1,30 +1,49 @@
-CLASS net/minecraft/unmapped/C_zcaovjhs net/minecraft/util/collection/WeightedList
-	FIELD f_foiaoslh random Lnet/minecraft/unmapped/C_rlomrsco;
-	FIELD f_nkovmckk entries Ljava/util/List;
+CLASS net/minecraft/unmapped/C_bvkdjias net/minecraft/util/collection/WeightedList
+	FIELD f_cwfvplde impl Lnet/minecraft/unmapped/C_bvkdjias$C_wsrfqrrn;
+	FIELD f_dgdnntpb MIN_COMPACT_WEIGHT_SUM I
+	FIELD f_qareelam weightSum I
+	FIELD f_qeespzdd entries Ljava/util/List;
 	METHOD <init> (Ljava/util/List;)V
-		ARG 1 list
-	METHOD m_hxwgwpcn shuffle ()Lnet/minecraft/unmapped/C_zcaovjhs;
-	METHOD m_jowdppdv (Lnet/minecraft/unmapped/C_zcaovjhs$C_jkfpyrca;)V
+		ARG 1 entries
+	METHOD m_bqytjolk map (Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_bvkdjias;
+		ARG 1 mapper
+	METHOD m_dbueagjr createNonEmptyCodec (Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/Codec;
+	METHOD m_euuafcab (Ljava/util/function/Function;Lnet/minecraft/unmapped/C_hwvdvfmt;)Lnet/minecraft/unmapped/C_hwvdvfmt;
 		ARG 1 entry
-	METHOD m_ociexkmf stream ()Ljava/util/stream/Stream;
-	METHOD m_qkixgtkk createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
-		ARG 0 codec
-	METHOD m_tkhxhnwf add (Ljava/lang/Object;I)Lnet/minecraft/unmapped/C_zcaovjhs;
-		ARG 1 data
-		ARG 2 weight
-	METHOD m_zhejvbky (Lnet/minecraft/unmapped/C_zcaovjhs;)Ljava/util/List;
-		ARG 0 weightedList
-	CLASS C_jkfpyrca Entry
-		FIELD f_ivikegey shuffledOrder D
-		FIELD f_qrqordhh data Ljava/lang/Object;
-		FIELD f_suwmibmw weight I
-		METHOD <init> (Ljava/lang/Object;I)V
-			ARG 1 data
-			ARG 2 weight
-		METHOD m_eswnguyk getElement ()Ljava/lang/Object;
-		METHOD m_myftqaed createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
-			ARG 0 codec
-		METHOD m_vitekfkz getShuffledOrder ()D
-		METHOD m_wimyripe setShuffledOrder (F)V
-			ARG 1 random
-		METHOD m_yuaucprh getWeight ()I
+	METHOD m_fjcmuvat chooseOrThrow (Lnet/minecraft/unmapped/C_rlomrsco;)Ljava/lang/Object;
+		COMMENT @throws IllegalStateException if this list is empty
+	METHOD m_ieoacgfn getEntries ()Ljava/util/List;
+		COMMENT Returns the entries of this list.
+		COMMENT <p>
+		COMMENT The list is unmodifiable.
+	METHOD m_iltxdqxs of ([Lnet/minecraft/unmapped/C_hwvdvfmt;)Lnet/minecraft/unmapped/C_bvkdjias;
+	METHOD m_knfttcss choose (Lnet/minecraft/unmapped/C_rlomrsco;)Ljava/util/Optional;
+	METHOD m_meiyqivj of (Ljava/util/List;)Lnet/minecraft/unmapped/C_bvkdjias;
+	METHOD m_sdrdllpl createCodec (Lcom/mojang/serialization/MapCodec;)Lcom/mojang/serialization/Codec;
+		ARG 0 valueCodec
+	METHOD m_tmiytjod empty ()Lnet/minecraft/unmapped/C_bvkdjias;
+	METHOD m_txfpijht isEmpty ()Z
+	METHOD m_vykxvqkv contains (Ljava/lang/Object;)Z
+		ARG 1 value
+	METHOD m_ylinjudz createNonEmptyCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+	METHOD m_yxvmrvck builder ()Lnet/minecraft/unmapped/C_bvkdjias$C_ykcycqkc;
+	METHOD m_zsvgtahm of (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_bvkdjias;
+	METHOD m_zswsmxis createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 valueCodec
+	CLASS C_jhjimjer FlatImpl
+		FIELD f_uujxbmfj entriesByWeightIndex [Ljava/lang/Object;
+		METHOD <init> (Ljava/util/List;I)V
+			ARG 1 entries
+			ARG 2 weightSum
+	CLASS C_skqkwwdw CompactImpl
+		FIELD f_xvrobjpc entries [Lnet/minecraft/unmapped/C_hwvdvfmt;
+		METHOD <init> (Ljava/util/List;)V
+			ARG 1 entries
+	CLASS C_wsrfqrrn WeightIndexed
+		METHOD m_pjjrgmpj getEntry (I)Ljava/lang/Object;
+			ARG 1 weightIndex
+	CLASS C_ykcycqkc Builder
+		FIELD f_ckepfnev entries Lcom/google/common/collect/ImmutableList$Builder;
+		METHOD m_hetlsrmx build ()Lnet/minecraft/unmapped/C_bvkdjias;
+		METHOD m_mmundxji add (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_bvkdjias$C_ykcycqkc;
+		METHOD m_xregoffp add (Ljava/lang/Object;I)Lnet/minecraft/unmapped/C_bvkdjias$C_ykcycqkc;

--- a/mappings/net/minecraft/util/crash/CrashReportSection.mapping
+++ b/mappings/net/minecraft/util/crash/CrashReportSection.mapping
@@ -35,6 +35,8 @@ CLASS net/minecraft/unmapped/C_qympisds net/minecraft/util/crash/CrashReportSect
 		ARG 3 state
 	METHOD m_rapwevfh addStackTrace (Ljava/lang/StringBuilder;)V
 		ARG 1 crashReportBuilder
+	METHOD m_uvphnwik addBlockLocation (Lnet/minecraft/unmapped/C_qympisds;Lnet/minecraft/unmapped/C_qpninoyb;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_qympisds;
+		ARG 0 element
 	METHOD m_vvpbdiqj add (Ljava/lang/String;Lnet/minecraft/unmapped/C_nnyjrhxb;)Lnet/minecraft/unmapped/C_qympisds;
 		ARG 1 name
 		ARG 2 callable

--- a/mappings/net/minecraft/util/math/DirectionTransformation.mapping
+++ b/mappings/net/minecraft/util/math/DirectionTransformation.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_yipxoxer net/minecraft/util/math/DirectionTransformation
+	FIELD f_awvsfjat INVERSES [Lnet/minecraft/unmapped/C_yipxoxer;
+	FIELD f_lgdwslvc BY_QUADRANTS [[Lnet/minecraft/unmapped/C_yipxoxer;
 	FIELD f_lwjafnsa mappings Ljava/util/Map;
 	FIELD f_mdkatkwn matrix Lorg/joml/Matrix3fc;
 	FIELD f_qwvubqzy axisTransformation Lnet/minecraft/unmapped/C_wniajcud;
@@ -7,12 +9,15 @@ CLASS net/minecraft/unmapped/C_yipxoxer net/minecraft/util/math/DirectionTransfo
 	FIELD f_wuokdepp flipZ Z
 	FIELD f_yipykrby flipX Z
 	FIELD f_yrfpdohs flipY Z
+	FIELD f_yyobwojo COMBINATIONS [[Lnet/minecraft/unmapped/C_yipxoxer;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/unmapped/C_wniajcud;ZZZ)V
 		ARG 3 name
 		ARG 4 axisTransformation
 		ARG 5 flipX
 		ARG 6 flipY
 		ARG 7 flipZ
+	METHOD m_avchsluk ([[Lnet/minecraft/unmapped/C_yipxoxer;)V
+		ARG 0 byQuadrants
 	METHOD m_cyfqslwj shouldFlipDirection (Lnet/minecraft/unmapped/C_xpuuihxf$C_rmpfouoz;)Z
 		ARG 1 axis
 	METHOD m_debzduan mapJigsawOrientation (Lnet/minecraft/unmapped/C_vukkmxtr;)Lnet/minecraft/unmapped/C_vukkmxtr;
@@ -24,6 +29,9 @@ CLASS net/minecraft/unmapped/C_yipxoxer net/minecraft/util/math/DirectionTransfo
 	METHOD m_hupdgeio getMatrix ()Lorg/joml/Matrix3fc;
 	METHOD m_invcgtcr (Lnet/minecraft/unmapped/C_yipxoxer;)Lnet/minecraft/unmapped/C_yipxoxer;
 		ARG 0 transformation
+	METHOD m_jnsnasau byQuadrants (Lnet/minecraft/unmapped/C_aarrmehi;Lnet/minecraft/unmapped/C_aarrmehi;)Lnet/minecraft/unmapped/C_yipxoxer;
+		ARG 0 xQuadrant
+		ARG 1 yQuadrant
 	METHOD m_lmsejfmm ([[Lnet/minecraft/unmapped/C_yipxoxer;)V
 		ARG 0 combinations
 	METHOD m_lubgvkzf (Lnet/minecraft/unmapped/C_yipxoxer;)Lnet/minecraft/unmapped/C_yipxoxer;

--- a/mappings/net/minecraft/util/math/Quadrant.mapping
+++ b/mappings/net/minecraft/util/math/Quadrant.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/unmapped/C_aarrmehi net/minecraft/util/math/Quadrant
+	FIELD f_fhremzso index I
+	METHOD m_ahiyfpqz of (I)Lnet/minecraft/unmapped/C_aarrmehi;
+		ARG 0 degrees
+	METHOD m_ayacgdhk next (I)I
+		ARG 1 step
+	METHOD m_ldozmgki (Lnet/minecraft/unmapped/C_aarrmehi;)Ljava/lang/Integer;
+		ARG 0 degrees
+	METHOD m_sftzmkmk (Ljava/lang/Integer;)Lcom/mojang/serialization/DataResult;
+		ARG 0 degrees

--- a/mappings/net/minecraft/util/random/RandomGenerator.mapping
+++ b/mappings/net/minecraft/util/random/RandomGenerator.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_rlomrsco net/minecraft/util/random/RandomGenerato
 	METHOD m_afzjxjzq nextInt (I)I
 		COMMENT @return a random value between {@code 0} (inclusive) and {@code max} (exclusive)
 		COMMENT @throws IllegalArgumentException if {@code max} isn't positive
+		ARG 1 max
 	METHOD m_aokkzmee nextTriangular (DD)D
 		COMMENT {@return a random {@code double} between {@code mode - deviation} and
 		COMMENT {@code mode + deviation} (both exclusive) with mode {@code mode}}
@@ -26,6 +27,7 @@ CLASS net/minecraft/unmapped/C_rlomrsco net/minecraft/util/random/RandomGenerato
 	METHOD m_ifdmmgky nextLong ()J
 	METHOD m_imwpekuz createUnsafe ()Lnet/minecraft/unmapped/C_rlomrsco;
 	METHOD m_iwfdczgh setSeed (J)V
+		ARG 1 seed
 	METHOD m_lzlwtgyn nextGaussian ()D
 	METHOD m_mkdxraps nextBoolean ()Z
 	METHOD m_ngqtmirh createLegacy (J)Lnet/minecraft/unmapped/C_rlomrsco;

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -8,9 +8,11 @@ CLASS net/minecraft/unmapped/C_peaveboq net/minecraft/world/BlockView
 		ARG 0 context
 	METHOD m_cwgupilf getBlockState (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_txtbiemp;
 	METHOD m_futnjlxi collectCollisions (Lit/unimi/dsi/fastutil/longs/LongSet;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_peaveboq$C_pmqljjcz;)I
+		ARG 0 visitedPositions
 		ARG 1 startPos
 		ARG 2 endPos
 		ARG 3 box
+		ARG 4 visitor
 	METHOD m_gpwzkbdj raycast (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Ljava/lang/Object;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
 		ARG 0 start
 		ARG 1 end
@@ -34,6 +36,10 @@ CLASS net/minecraft/unmapped/C_peaveboq net/minecraft/world/BlockView
 	METHOD m_ueemzmzo (Lnet/minecraft/unmapped/C_uyikqwzv;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_jdakttms;
 		ARG 1 context
 		ARG 2 pos
+	METHOD m_umvjwyir collectCollisions (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_peaveboq$C_pmqljjcz;)V
+		ARG 0 from
+		ARG 1 to
+		ARG 2 box
 	METHOD m_uqbtjvun raycastBlock (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_zscvhwbd;Lnet/minecraft/unmapped/C_txtbiemp;)Lnet/minecraft/unmapped/C_jdakttms;
 		ARG 1 start
 		ARG 2 end
@@ -46,3 +52,6 @@ CLASS net/minecraft/unmapped/C_peaveboq net/minecraft/world/BlockView
 		ARG 0 context
 	METHOD m_zqixworh getStatesInBox (Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/util/stream/Stream;
 		ARG 1 box
+	CLASS C_pmqljjcz CollisionVisitor
+		METHOD visit (Lnet/minecraft/unmapped/C_hynzadkk;I)V
+			ARG 2 iteration

--- a/mappings/net/minecraft/world/TrialSpawnerLogic.mapping
+++ b/mappings/net/minecraft/world/TrialSpawnerLogic.mapping
@@ -45,4 +45,5 @@ CLASS net/minecraft/unmapped/C_jelkcvqk net/minecraft/world/TrialSpawnerLogic
 	CLASS C_onmhuuws TrialSpawner
 		METHOD m_khbvxtru getState ()Lnet/minecraft/unmapped/C_mefvrcdp;
 		METHOD m_qubjusrv setState (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_mefvrcdp;)V
+			ARG 2 state
 		METHOD m_wvpnseil updateListeners ()V

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -165,6 +165,7 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 13 velocityZ
 	METHOD m_rsnbcuug getWorldChunk (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hrdsvlkq;
 		ARG 1 pos
+	METHOD m_rzbihfgi isNaturalNight ()Z
 	METHOD m_shcorzhl broadcastDamageEvent (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 entity
 		ARG 2 damageSource

--- a/mappings/net/minecraft/world/chunk/Chunk.mapping
+++ b/mappings/net/minecraft/world/chunk/Chunk.mapping
@@ -116,6 +116,7 @@ CLASS net/minecraft/unmapped/C_lwzmmmqr net/minecraft/world/chunk/Chunk
 	METHOD m_yrcpifpe setLightCorrect (Z)V
 		ARG 1 lightCorrect
 	METHOD m_yuipgvpr getInhabitedTime ()J
+	METHOD m_zhcsnntn setBlockState (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;I)Lnet/minecraft/unmapped/C_txtbiemp;
 	CLASS C_ozbhqkkq PackedTicks
 		FIELD f_juvuxeon blockTicks Ljava/util/List;
 		FIELD f_rhsbjeav fluidTicks Ljava/util/List;

--- a/mappings/net/minecraft/world/entity/UuidLookup.mapping
+++ b/mappings/net/minecraft/world/entity/UuidLookup.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_cwthlthi net/minecraft/world/entity/UuidLookup
+	METHOD m_xuuarnut getEntity (Ljava/util/UUID;)Lnet/minecraft/unmapped/C_fbmwdlsj;

--- a/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
+++ b/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
@@ -4,6 +4,9 @@ CLASS net/minecraft/unmapped/C_sbgxqpya net/minecraft/world/event/listener/GameE
 		COMMENT Listens to an incoming game event.
 		COMMENT
 		COMMENT @return {@code true} if the game event has been accepted by this listener
+		ARG 2 event
+		ARG 3 context
+		ARG 4 sourcePos
 	METHOD m_atojrfns getPositionSource ()Lnet/minecraft/unmapped/C_duzerrml;
 		COMMENT Returns the position source of this listener.
 	METHOD m_btrjhyuz getRange ()I

--- a/mappings/net/minecraft/world/event/vibration/VibrationInfo.mapping
+++ b/mappings/net/minecraft/world/event/vibration/VibrationInfo.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/unmapped/C_xctzkvoy net/minecraft/world/event/vibration/Vibr
 		ARG 4 projectileOwnerUuid
 	METHOD m_cdezoyin getOwner (Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
 		ARG 1 world
-	METHOD m_feiiomik getEntity (Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
+	METHOD m_feiiomik getSource (Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
 		ARG 1 world
 	METHOD m_ggyfueel (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance

--- a/mappings/net/minecraft/world/event/vibration/VibrationManager.mapping
+++ b/mappings/net/minecraft/world/event/vibration/VibrationManager.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_ddxrijfx net/minecraft/world/event/vibration/VibrationManager
 	FIELD f_afelhybc FREQUENCIES Ljava/util/function/ToIntFunction;
 	FIELD f_chcearum RESONATION_EVENTS Ljava/util/List;
+	FIELD f_hvmjsfvb NO_VIBRATION_FREQUENCY I
 	METHOD m_afqazgpz getFrequency (Lnet/minecraft/unmapped/C_xhhleach;)I
 		ARG 0 event
 	METHOD m_bggysyds getResonationEvent (I)Lnet/minecraft/unmapped/C_xhhleach;
@@ -72,12 +73,18 @@ CLASS net/minecraft/unmapped/C_ddxrijfx net/minecraft/world/event/vibration/Vibr
 	CLASS C_vnbbhkol Callback
 		METHOD m_bspimwvf getRange ()I
 		METHOD m_dklxlkwy accept (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_astfners;F)V
+			ARG 3 event
+			ARG 4 source
+			ARG 5 owner
+			ARG 6 distance
 		METHOD m_eostbwyz onDataChanged ()V
 		METHOD m_evpmgeke getDelay (F)I
 			ARG 1 distance
 		METHOD m_kplvqliv getVibrationTag ()Lnet/minecraft/unmapped/C_ednuhnnn;
 		METHOD m_pawjdfag triggersAvoidCriterion ()Z
 		METHOD m_psccpmnp accepts (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_cgkchrmc$C_cjhidzon;)Z
+			ARG 3 event
+			ARG 4 context
 		METHOD m_xjmfyyvn canAccept (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_cgkchrmc$C_cjhidzon;)Z
 			ARG 1 gameEvent
 			ARG 2 eventContext

--- a/mappings/net/minecraft/world/gen/feature/Feature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/Feature.mapping
@@ -49,3 +49,4 @@ CLASS net/minecraft/unmapped/C_lowstvki net/minecraft/world/gen/feature/Feature
 		ARG 1 world
 		ARG 2 pos
 	METHOD m_yrekxmnr place (Lnet/minecraft/unmapped/C_kihhwquw;)Z
+		ARG 1 context

--- a/unpick/definitions/entity_flags.unpick
+++ b/unpick/definitions/entity_flags.unpick
@@ -24,15 +24,15 @@ target_method net/minecraft/entity/passive/FoxEntity setFoxFlag (IZ)V
 	param 0 fox_flags
 
 
-constant horse_flags net/minecraft/entity/passive/AbstractHorseEntity TAMED_FLAG
-constant horse_flags net/minecraft/entity/passive/AbstractHorseEntity BRED_FLAG
-constant horse_flags net/minecraft/entity/passive/AbstractHorseEntity EATING_GRASS_FLAG
-constant horse_flags net/minecraft/entity/passive/AbstractHorseEntity ANGRY_FLAG
-constant horse_flags net/minecraft/entity/passive/AbstractHorseEntity EATING_FLAG
+constant horse_flags net/minecraft/entity/passive/TamableMountEntity TAMED_FLAG
+constant horse_flags net/minecraft/entity/passive/TamableMountEntity BRED_FLAG
+constant horse_flags net/minecraft/entity/passive/TamableMountEntity EATING_GRASS_FLAG
+constant horse_flags net/minecraft/entity/passive/TamableMountEntity ANGRY_FLAG
+constant horse_flags net/minecraft/entity/passive/TamableMountEntity EATING_FLAG
 
-target_method net/minecraft/entity/passive/AbstractHorseEntity getHorseFlag (I)Z
+target_method net/minecraft/entity/passive/TamableMountEntity getHorseFlag (I)Z
 	param 0 horse_flags
-target_method net/minecraft/entity/passive/AbstractHorseEntity setHorseFlag (IZ)V
+target_method net/minecraft/entity/passive/TamableMountEntity setHorseFlag (IZ)V
 	param 0 horse_flags
 
 


### PR DESCRIPTION
Completes `n.m.block`

Notable fixes/refactors:
- renames `AbstractLichenBlock` -> `MultifaceBlock`, closes #383
- renames `AbstractPlantBlock` -> `BushBlock` and maps `C_yqpevhlg` -> `AbstractPlantBlock`
- renames `AbstractDonkeyEntity` -> `PackMountEntity` and `AbstractHorseEntity` -> `TamableMountEntity`, closes #388 (`DispenserBehavior` referenced `AbstractDonkeyEntity`...)
- renames `LeavesBlock` -> `AbstractLeavesBlock`, maps `C_skmvaljl` -> `LeavesBlock`, maps `C_jphkfedl` -> `TintedLeavesBlock`
- renames `WeightedList` -> `ShufflingList` (from a string), maps `C_bvkdjias` -> `WeightedList`, maps `WeightedEntry`
- renames `GravelBlock` -> `SimpleFallingBlock`, maps `C_hdfyaaty` -> `SandBlock`