### PR TITLE
fix `StackOverflowError`s

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -571,7 +571,14 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 1 slot
 	METHOD m_xgwxqkgb swingHand (Lnet/minecraft/unmapped/C_laxmzoqs;)V
 		ARG 1 hand
-	METHOD m_xjvsabgy buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_xjvsabgy buildLivingAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+		COMMENT Builds attributes common to all living entities.<br>
+		COMMENT Subclasses of {@code LivingEntity} should add their custom attributes to the
+		COMMENT builder this returns.
+		COMMENT <p>
+		COMMENT Note: this isn't named {@code buildAttributes} because subclasses call it from
+		COMMENT their methods with that name without using the {@code LivingEntity} class
+		COMMENT qualifier, so naming it as such would cause recursion.
 	METHOD m_xnfqqzkv isMobOrPlayer ()Z
 	METHOD m_xotweprj indicateDamage (DD)V
 		ARG 1 x

--- a/mappings/net/minecraft/entity/passive/PackMountEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PackMountEntity.mapping
@@ -2,7 +2,14 @@ CLASS net/minecraft/unmapped/C_javurlgg net/minecraft/entity/passive/PackMountEn
 	FIELD f_loaorggp CHEST Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_quviykji dimensions Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_uipqwqtj DEFAULT_HAS_CHEST Z
-	METHOD m_qcurzppd buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_qcurzppd buildPackMountAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+		COMMENT Builds attributes common to all pack mount entities.<br>
+		COMMENT Subclasses of {@code PackMountEntity} should add their custom attributes to the
+		COMMENT builder this returns.
+		COMMENT <p>
+		COMMENT Note: this isn't named {@code buildAttributes} because subclasses call it from
+		COMMENT their methods with that name without using the {@code PackMountEntity} class
+		COMMENT qualifier, so naming it as such would cause recursion.
 	METHOD m_ufvruazd playAddChestSound ()V
 	METHOD m_xbbuagfx addChest (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 player

--- a/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
@@ -143,7 +143,14 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/TamableMoun
 	METHOD m_yukcocww getDismountLocation (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_usxaxydn;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 dismountDirection
 		ARG 2 passenger
-	METHOD m_yvcfnlwg buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_yvcfnlwg buildTamableMountAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+		COMMENT Builds attributes common to all tamable mount entities.<br>
+		COMMENT Subclasses of {@code TamableMountEntity} should add their custom attributes to
+		COMMENT the builder this returns.
+		COMMENT <p>
+		COMMENT Note: this isn't named {@code buildAttributes} because subclasses call it from
+		COMMENT their methods with that name without using the {@code TamableMountEntity} class
+		COMMENT qualifier, so naming it as such would cause recursion.
 	METHOD m_zhrpcxsv generateJumpStrengthBonus (Ljava/util/function/DoubleSupplier;)D
 		ARG 0 randomizer
 	METHOD m_zpkkhcub isDifferentInventory (Lnet/minecraft/unmapped/C_pjtstjoq;)Z


### PR DESCRIPTION
renames and javadocs `buildAttributes` methods whose subclasses call them without a class qualifier

fixes `StackOverflowError`s caused by recursion