### PR TITLE
fix `Tameable` `AbstractMethodError`

### DIFF
--- a/mappings/net/minecraft/entity/Tameable.mapping
+++ b/mappings/net/minecraft/entity/Tameable.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/unmapped/C_lkirduch net/minecraft/entity/Tameable
 	METHOD m_jaxlomko getOwner ()Lnet/minecraft/unmapped/C_usxaxydn;
+	METHOD m_kqxvnqqn getWorld ()Lnet/minecraft/unmapped/C_cdctfzbn;


### PR DESCRIPTION
map `Tameable::getWorld` so implementing entities use `Entity::getWorld`'s implementation

fixes `AbstractMethodError` that crashed the game whenever a `Tameable` mob was loaded