### PR TITLE
restore `Angerable::isAngry` -> `hasAngerTime`

### DIFF
--- a/mappings/net/minecraft/entity/mob/Angerable.mapping
+++ b/mappings/net/minecraft/entity/mob/Angerable.mapping
@@ -10,7 +10,9 @@ CLASS net/minecraft/unmapped/C_ceqittzp net/minecraft/entity/mob/Angerable
 	METHOD m_cfljxifr chooseRandomAngerTime ()V
 	METHOD m_fqffmeys setAttacker (Lnet/minecraft/unmapped/C_usxaxydn;)V
 	METHOD m_hykyexft setTarget (Lnet/minecraft/unmapped/C_usxaxydn;)V
-	METHOD m_igzwsudv isAngry ()Z
+	METHOD m_igzwsudv hasAngerTime ()Z
+		COMMENT Note: this can't be named {@code isAngry} because implementers use that name for
+		COMMENT getting their {@code ANGRY} tracked data.
 	METHOD m_lazolqzm canTarget (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 	METHOD m_lsgfuuiy setAngerTime (I)V
 		ARG 1 time


### PR DESCRIPTION
fixes
> java.lang.RuntimeException: Unfixable conflicts

`Angerable` implementers have `isAngry` methods for getting their `ANGRY` tracked data.