### PR TITLE
Registered stuff 1.21.5

### DIFF
--- a/mappings/net/minecraft/block/TrialSpawnerConfigurations.mapping
+++ b/mappings/net/minecraft/block/TrialSpawnerConfigurations.mapping
@@ -1,0 +1,51 @@
+CLASS net/minecraft/unmapped/C_fttqwxfv net/minecraft/block/TrialSpawnerConfigurations
+	FIELD f_dkjuhdez SMALL_MELEE_SLIME Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_gdvplohh RANGED_STRAY Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_irqpvuns SMALL_MELEE_BABY_ZOMBIE Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_mmigfuco SMALL_MELEE_CAVE_SPIDER Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_ncvtokkx RANGED_POISON_SKELETON Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_phhbipyu SMALL_MELEE_SILVERFISH Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_qaitpicm MELEE_ZOMBIE Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_skufwcyl SLOW_RANGED_POISON_SKELETON Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_tdmnsroi MELEE_SPIDER Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_unvoiabx BREEZE Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_uoskkvnl MELEE_HUSK Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_velpgpnx RANGED_SKELETON Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_vtihedpi SLOW_RANGED_STRAY Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	FIELD f_xhqrgxuu SLOW_RANGED_SKELETON Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+	METHOD m_azeroflb (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	METHOD m_bcecldcl (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	METHOD m_horyqczf genericBuilder ()Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
+	METHOD m_kccxcphs ominousMeleeBuilder ()Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
+	METHOD m_kgleveoz slowRangedBuilder ()Lnet/minecraft/unmapped/C_pocjjnjk$C_vnrwaphu;
+	METHOD m_kstxfcvg createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
+	METHOD m_lalqemqp (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 nbt
+	METHOD m_nhboedce createEntry (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_edcjbljn;
+	METHOD m_ovusgbxg bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+	METHOD m_pczrhxhk register (Lnet/minecraft/unmapped/C_hqoyyfco;Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;Lnet/minecraft/unmapped/C_pocjjnjk;Lnet/minecraft/unmapped/C_pocjjnjk;)V
+		ARG 1 keys
+		ARG 2 normalConfig
+		ARG 3 ominousConfig
+	METHOD m_ptvhxshb (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	METHOD m_tdnwniwz (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	METHOD m_tqdrxqxb createEntry (Lnet/minecraft/unmapped/C_ogavsvbr;Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_edcjbljn;
+		ARG 1 writeEntityNbt
+		ARG 2 lootTable
+	METHOD m_ucqsvvgd (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	METHOD m_wrzuebse createEntry (Lnet/minecraft/unmapped/C_ogavsvbr;)Lnet/minecraft/unmapped/C_edcjbljn;
+	METHOD m_xeiocbfc createEntry (Lnet/minecraft/unmapped/C_ogavsvbr;Ljava/util/function/Consumer;)Lnet/minecraft/unmapped/C_edcjbljn;
+	METHOD m_zjhkfhlx (Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_fiwnwrrf;
+		ARG 0 loot
+	METHOD m_zpgmngcx (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 nbt
+	METHOD m_zpmiasuy (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 0 entityNbt
+	CLASS C_vjnltfes Keys
+		METHOD m_utnpbjef of (Ljava/lang/String;)Lnet/minecraft/unmapped/C_fttqwxfv$C_vjnltfes;
+			ARG 0 pathPrefix

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -14,8 +14,8 @@ CLASS net/minecraft/unmapped/C_dlxbwxyf net/minecraft/block/entity/AbstractFurna
 	FIELD f_nqwyvoxy TOTAL_COOK_TIME_DATA I
 	FIELD f_rhexgeen recipeCache Lnet/minecraft/unmapped/C_hjseusrb$C_bvtkxdyi;
 	FIELD f_ruznenwn INPUT_SLOT I
-	FIELD f_tkkblcco cookTime I
 	FIELD f_tjmroghf DEFAULT_TOTAL_COOK_TIME S
+	FIELD f_tkkblcco cookTime I
 	FIELD f_uunwympm BURN_TIME_DATA I
 	FIELD f_vmpcjcui recipesUsed Lit/unimi/dsi/fastutil/objects/Reference2IntOpenHashMap;
 	FIELD f_vnrsgghy COOK_TIME_DATA I

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -6,7 +6,6 @@ CLASS net/minecraft/unmapped/C_oddtxnnw net/minecraft/client/render/entity/Entit
 	FIELD f_tcpdnrwv state Lnet/minecraft/unmapped/C_vptppxob;
 	FIELD f_ucdktcjj shadowRadius F
 	FIELD f_zzvkubit dispatcher Lnet/minecraft/unmapped/C_gmkqxljo;
-	METHOD <init> (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)V
 	METHOD m_azsmpcdv renderLeashSegment (Lnet/minecraft/unmapped/C_igthdzux;Lorg/joml/Matrix4f;FFFIIIIFFFFIZ)V
 		ARG 0 vertexConsumer
 		ARG 1 modelMatrix

--- a/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
@@ -4,38 +4,13 @@ CLASS net/minecraft/unmapped/C_qcsjcrtc net/minecraft/client/render/entity/Entit
 	FIELD f_zddgwxtw LOGGER Lorg/slf4j/Logger;
 	METHOD m_anmoehia reloadPlayerRenderers (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Ljava/util/Map;
 	METHOD m_brctolmh isMissingRendererFactories ()Z
-	METHOD m_cfkkaomj (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_dmpxrdlx (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_eycumyqm (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_fektpkex (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_fjyodxov (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
 	METHOD m_fslytwpv (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_ycdfjsnw;)V
 		ARG 2 type
 		ARG 3 factory
-	METHOD m_fxzcwgni (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_iwokgkot (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_ixbxokgs (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_iycvgnsb (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_lktokzuu (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_miukwvvw (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_omtgsipy (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
 	METHOD m_qbcgfwrd reloadEntityRenderers (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Ljava/util/Map;
-	METHOD m_qmmoqelf (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_rbbnoiak (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_rlrzcgfz (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_rqwvqtpr (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
 	METHOD m_sihqzsfd register (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_ycdfjsnw;)V
 		ARG 0 type
 		ARG 1 factory
-	METHOD m_sjupylzx (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_tvksgagn (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_ugeylvvb (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_uxdlnyna (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_wgclfclr (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_wsskayjl (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_wyyzonil (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
 	METHOD m_xaubcpmz (Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;Lnet/minecraft/unmapped/C_idvschhb$C_hdrocqaw;Lnet/minecraft/unmapped/C_ycdfjsnw;)V
 		ARG 2 model
 		ARG 3 factory
-	METHOD m_xdvcbsbt (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;
-	METHOD m_zgnrragr (Lnet/minecraft/unmapped/C_ycdfjsnw$C_bnclqjzp;)Lnet/minecraft/unmapped/C_oddtxnnw;

--- a/mappings/net/minecraft/data/client/BlockStateDefinitionProvider.mapping
+++ b/mappings/net/minecraft/data/client/BlockStateDefinitionProvider.mapping
@@ -7,8 +7,6 @@ CLASS net/minecraft/unmapped/C_cbtixrmx net/minecraft/data/client/BlockStateDefi
 	CLASS C_mkzvyblh
 		METHOD accept (Ljava/lang/Object;Ljava/lang/Object;)V
 			ARG 2 modelSupplier
-		METHOD m_cdekbdqr (Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_txhzdzba;)V
-			ARG 1 id
 		METHOD m_kjcvdnpx (Lnet/minecraft/unmapped/C_temnquoh;Lnet/minecraft/unmapped/C_ugkmwocs$C_ehniswvc;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 writer
 			ARG 2 resolver

--- a/mappings/net/minecraft/item/Instruments.mapping
+++ b/mappings/net/minecraft/item/Instruments.mapping
@@ -4,4 +4,4 @@ CLASS net/minecraft/unmapped/C_cffsqeei net/minecraft/item/Instruments
 	METHOD m_qiyrmnpc register (Lnet/minecraft/unmapped/C_hqoyyfco;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_cjzoxshv;FF)V
 		ARG 1 instrument
 	METHOD m_uoauhstj createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;
-	METHOD m_vmyhpcqf initialize (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+	METHOD m_vmyhpcqf bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V

--- a/mappings/net/minecraft/predicate/DataComponentPredicate.mapping
+++ b/mappings/net/minecraft/predicate/DataComponentPredicate.mapping
@@ -1,1 +1,28 @@
 CLASS net/minecraft/unmapped/C_naseleda net/minecraft/predicate/DataComponentPredicate
+	FIELD f_enoyyziw BY_TYPE_PACKET_CODEC Lnet/minecraft/unmapped/C_qsrmwluu;
+	FIELD f_erwtylty BY_TYPE_CODEC Lcom/mojang/serialization/Codec;
+	FIELD f_mqebjxag INDIVIDUAL_PACKET_CODEC Lnet/minecraft/unmapped/C_qsrmwluu;
+	METHOD m_atxfyftp createEntryCodec (Ljava/lang/String;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 typeKey
+	METHOD m_ksyvmmjp (Ljava/util/Map;)Ljava/util/List;
+		ARG 0 map
+	METHOD m_oqktxnld (Ljava/util/List;)Ljava/util/Map;
+		ARG 0 typed
+	METHOD m_wdxkcege test (Lnet/minecraft/unmapped/C_hmcnusfu;)Z
+		ARG 1 componentAccess
+	CLASS C_bxoynfyp Typed
+		METHOD m_hbsldboc ofEntry (Ljava/util/Map$Entry;)Lnet/minecraft/unmapped/C_naseleda$C_bxoynfyp;
+			ARG 0 entry
+	CLASS C_zwyzyezt Type
+		FIELD f_iejxdjko entryCodec Lcom/mojang/serialization/MapCodec;
+		FIELD f_nokokajv entryPacketCodec Lnet/minecraft/unmapped/C_qsrmwluu;
+		FIELD f_qbylfuyg predicateCodec Lcom/mojang/serialization/Codec;
+		METHOD <init> (Lcom/mojang/serialization/Codec;)V
+			ARG 1 predicateCodec
+		METHOD m_hwdgbbhx getPredicateCodec ()Lcom/mojang/serialization/Codec;
+		METHOD m_lnlnojev (Lnet/minecraft/unmapped/C_naseleda;)Lnet/minecraft/unmapped/C_naseleda$C_bxoynfyp;
+			ARG 1 predicate
+		METHOD m_rjcujbfh (Lnet/minecraft/unmapped/C_naseleda;)Lnet/minecraft/unmapped/C_naseleda$C_bxoynfyp;
+			ARG 1 predicate
+		METHOD m_wptrozkx getEntryPacketCodec ()Lnet/minecraft/unmapped/C_qsrmwluu;
+		METHOD m_zioishxh getEntryCodec ()Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/predicate/DataComponentPredicateTypes.mapping
+++ b/mappings/net/minecraft/predicate/DataComponentPredicateTypes.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_bhirrrhb net/minecraft/predicate/DataComponentPredicateTypes
+	METHOD m_dlcgkhpo bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_naseleda$C_zwyzyezt;
+	METHOD m_mqybxowr create (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/unmapped/C_naseleda$C_zwyzyezt;

--- a/mappings/net/minecraft/recipe/book/RecipeBookCategories.mapping
+++ b/mappings/net/minecraft/recipe/book/RecipeBookCategories.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_rlyqwzkz net/minecraft/recipe/book/RecipeBookCategories
+	METHOD m_hkrqlzhw bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_loximogs;
+	METHOD m_ozmtuiiq create (Ljava/lang/String;)Lnet/minecraft/unmapped/C_loximogs;

--- a/mappings/net/minecraft/recipe/display/RecipeDisplayTypes.mapping
+++ b/mappings/net/minecraft/recipe/display/RecipeDisplayTypes.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_sjqwcuir net/minecraft/recipe/display/RecipeDisplayTypes
+	METHOD m_whmzxxbr bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_vhhfbyhp$C_mnosxpyd;

--- a/mappings/net/minecraft/recipe/display/SlotDisplayTypes.mapping
+++ b/mappings/net/minecraft/recipe/display/SlotDisplayTypes.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_vscjjvbx net/minecraft/recipe/display/SlotDisplayTypes
+	METHOD m_baacowpb bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_lahbbtfn$C_bhpspplm;

--- a/mappings/net/minecraft/registry/Holder.mapping
+++ b/mappings/net/minecraft/registry/Holder.mapping
@@ -2,15 +2,19 @@ CLASS net/minecraft/unmapped/C_cjzoxshv net/minecraft/registry/Holder
 	METHOD m_aizevecj isBound ()Z
 	METHOD m_bgnpepne isRegistryKeyId (Lnet/minecraft/unmapped/C_ncpywfca;)Z
 	METHOD m_cdttpfsq matches (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 1 holder
 	METHOD m_dcbwlfmo isIn (Lnet/minecraft/unmapped/C_ednuhnnn;)Z
 	METHOD m_ejvoczrq isRegistryKey (Lnet/minecraft/unmapped/C_xhhleach;)Z
+		ARG 1 key
 	METHOD m_hkxploul createDirect (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 0 value
 	METHOD m_igwfqztq unwrap ()Lcom/mojang/datafixers/util/Either;
 	METHOD m_jdiodhmc getKey ()Ljava/util/Optional;
 	METHOD m_jhcqoiku matches (Ljava/util/function/Predicate;)Z
+		ARG 1 predicate
 	METHOD m_orzakqff getRegisteredName ()Ljava/lang/String;
 	METHOD m_uexsrrou isOwnedBy (Lnet/minecraft/unmapped/C_hkebgttw;)Z
+		ARG 1 owner
 	METHOD m_uwpxznsu streamTags ()Ljava/util/stream/Stream;
 	METHOD m_ydnvjjng getValue ()Ljava/lang/Object;
 	METHOD m_ynppqgwx (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/lang/String;

--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -75,10 +75,14 @@ CLASS net/minecraft/unmapped/C_nusqeapl net/minecraft/registry/Registries
 	METHOD m_lzhvsneq createDefaultMappedFrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Ljava/lang/String;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_zogerkic;
 		ARG 0 key
 	METHOD m_mwsegmux bootstrap ()V
+	METHOD m_phnlnmoa (Lnet/minecraft/unmapped/C_ncpywfca;Ljava/util/function/Supplier;)V
+		ARG 1 loader
 	METHOD m_sgrkhfqj validate (Lnet/minecraft/unmapped/C_tqxyjqsk;)V
 		ARG 0 root
 	METHOD m_uavjgjwm getHolderProvider (Lnet/minecraft/unmapped/C_tqxyjqsk;)Lnet/minecraft/unmapped/C_pzdchrcy;
 	METHOD m_ybecmlwo createContents ()V
 	METHOD m_ydemdayj createSimpleFrozenRegistry (Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_nusqeapl$C_qpkaxgeh;)Lnet/minecraft/unmapped/C_tqxyjqsk;
 		ARG 0 key
+	METHOD m_ztbsjjea (Lnet/minecraft/unmapped/C_tqxyjqsk;Lnet/minecraft/unmapped/C_tqxyjqsk;)V
+		ARG 1 registry
 	CLASS C_qpkaxgeh RegistryBootstrap

--- a/mappings/net/minecraft/registry/VanillaDynamicRegistries.mapping
+++ b/mappings/net/minecraft/registry/VanillaDynamicRegistries.mapping
@@ -12,5 +12,7 @@ CLASS net/minecraft/unmapped/C_apczbzsn net/minecraft/registry/VanillaDynamicReg
 		ARG 1 biomeProvider
 	METHOD m_pjzucola (Lnet/minecraft/unmapped/C_pzdchrcy;Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;Lnet/minecraft/unmapped/C_cjzoxshv;)V
 		ARG 3 feature
+	METHOD m_qqmdtske (Lnet/minecraft/unmapped/C_pzdchrcy;Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 2 key
 	METHOD m_saajdbea validateBiomeFeatures (Lnet/minecraft/unmapped/C_vtbxyypo$C_etmlgbig;)V
 		ARG 0 lookupProvider

--- a/mappings/net/minecraft/sound/SoundEvents.mapping
+++ b/mappings/net/minecraft/sound/SoundEvents.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_jtkcimte net/minecraft/sound/SoundEvents
+	FIELD f_ipbjatfv WOLF_SOUND_VARIANTS Ljava/util/Map;
 	FIELD f_jkyfydrb GOAT_HORN_SOUND_VARIANTS Lcom/google/common/collect/ImmutableList;
 	FIELD f_smefbnfi GOAT_HORN_SOUND_VARIANT_COUNT I
 	METHOD m_acxzmtqt registerHolder (Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;
@@ -12,6 +13,8 @@ CLASS net/minecraft/unmapped/C_jtkcimte net/minecraft/sound/SoundEvents
 		ARG 0 id
 	METHOD m_ctvsgkyo register (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 0 id
+	METHOD m_djvvdado (Lnet/minecraft/unmapped/C_nvnpkjhq$C_ebqtnumz;)Lnet/minecraft/unmapped/C_nvnpkjhq$C_ebqtnumz;
+		ARG 0 type
 	METHOD m_jhjlxsaf register (Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 0 id
 		ARG 1 soundId
@@ -19,6 +22,9 @@ CLASS net/minecraft/unmapped/C_jtkcimte net/minecraft/sound/SoundEvents
 		ARG 0 i
 	METHOD m_kdgarqjp register (Ljava/lang/String;)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 0 id
-	METHOD m_xalqcruq getGoatHornSoundVariants ()Lcom/google/common/collect/ImmutableList;
+	METHOD m_majotbei (Lnet/minecraft/unmapped/C_nvnpkjhq$C_ebqtnumz;)Lnet/minecraft/unmapped/C_xrqgzvqn;
+		ARG 0 type
+	METHOD m_userxskw createWolfSoundVariants ()Ljava/util/Map;
+	METHOD m_xalqcruq createGoatHornSoundVariants ()Lcom/google/common/collect/ImmutableList;
 	METHOD m_yqdabwph registerHolder (Lnet/minecraft/unmapped/C_ncpywfca;)Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;
 		ARG 0 id

--- a/mappings/net/minecraft/test/AbstractTestFunction.mapping
+++ b/mappings/net/minecraft/test/AbstractTestFunction.mapping
@@ -7,4 +7,4 @@ CLASS net/minecraft/unmapped/C_pxdgchfu net/minecraft/test/AbstractTestFunction
 		ARG 2 implementation
 	METHOD m_jrdkroot register (Lnet/minecraft/unmapped/C_pxdgchfu;)V
 		ARG 0 function
-	METHOD m_kiwfmpqi bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)V
+	METHOD m_kiwfmpqi registerFunctions (Lnet/minecraft/unmapped/C_tqxyjqsk;)V

--- a/mappings/net/minecraft/test/AbstractTestFunction.mapping
+++ b/mappings/net/minecraft/test/AbstractTestFunction.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/unmapped/C_pxdgchfu net/minecraft/test/AbstractTestFunction
+	FIELD f_ogumchae FUNCTIONS Ljava/util/List;
+	METHOD m_dnnnzaiu register (Ljava/util/function/BiConsumer;)V
+		ARG 1 registrar
+	METHOD m_iozwjpla (Lnet/minecraft/unmapped/C_tqxyjqsk;Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Consumer;)V
+		ARG 1 key
+		ARG 2 implementation
+	METHOD m_jrdkroot register (Lnet/minecraft/unmapped/C_pxdgchfu;)V
+		ARG 0 function
+	METHOD m_kiwfmpqi bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)V

--- a/mappings/net/minecraft/test/TestEnvironments.mapping
+++ b/mappings/net/minecraft/test/TestEnvironments.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_ebdaouoo net/minecraft/test/TestEnvironments
+	FIELD f_ueqzszzi DEFAULT_PATH Ljava/lang/String;
+	METHOD m_lvedvhgq bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+	METHOD m_mjqkduwq createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;

--- a/mappings/net/minecraft/test/TestFunction.mapping
+++ b/mappings/net/minecraft/test/TestFunction.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/unmapped/C_zmxlezwg net/minecraft/test/TestFunction
+	FIELD f_zsucyyya COMPLETE Ljava/util/function/Consumer;
+	METHOD m_pqcpzmen bootstrap (Lnet/minecraft/unmapped/C_tqxyjqsk;)Ljava/util/function/Consumer;
+	METHOD m_rlqdaagi createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;

--- a/mappings/net/minecraft/test/TestInstances.mapping
+++ b/mappings/net/minecraft/test/TestInstances.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_ljxqdndm net/minecraft/test/TestInstances
+	METHOD m_uqccniuj bootstrap (Lnet/minecraft/unmapped/C_hqoyyfco;)V
+	METHOD m_vsmjtvbe createKey (Ljava/lang/String;)Lnet/minecraft/unmapped/C_xhhleach;


### PR DESCRIPTION
ports #702 to 1.21.5
for qsl's `:core:testing` `quilt_testing.accesswidener` which references `TestFunction`

edit: the aw isn't necessary on 1.21.5, but the class should still be mapped for usability
