### PR TITLE
fix `getName` conflict

### DIFF
--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/unmapped/C_kvegafmh net/minecraft/block/entity/BlockEntity
 	METHOD m_apmtvpji addComponents (Lnet/minecraft/unmapped/C_kouhnfig$C_vfzyoahz;)V
 		ARG 1 builder
 	METHOD m_auxezlat writeId (Lnet/minecraft/unmapped/C_kespdwpv;)V
-	METHOD m_bczwkfko getName ()Ljava/lang/String;
+	METHOD m_bczwkfko getReportableName ()Ljava/lang/String;
 	METHOD m_cckjpvhm readComponents (Lnet/minecraft/unmapped/C_hmcnusfu;)V
 		ARG 1 access
 	METHOD m_cjlndzcv markDirty (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_txtbiemp;)V


### PR DESCRIPTION
rename `BlockEntity::getName` -> `getReportableName` so it doesn't clash with `Nameable::getName` (implemented by subclasses)