### PR TITLE
Complete `n.m.entity` 1.21.8

### DIFF
--- a/buildSrc/src/main/resources/minecraft_specific_words.txt
+++ b/buildSrc/src/main/resources/minecraft_specific_words.txt
@@ -278,6 +278,7 @@ equippee
 hitbox
 hitpoint
 knockback
+knockee
 nametag
 pathing
 respawn
@@ -456,6 +457,7 @@ clickable
 cloneable
 collidable
 compostable
+copyable
 craftable
 disablable
 dumpable

--- a/enigma/simple_type_field_names.json5
+++ b/enigma/simple_type_field_names.json5
@@ -153,6 +153,21 @@
       "livingEntity"
     ]
   },
+  "net/minecraft/unmapped/C_dxkfswlz": { // MobEntity
+    local_name: "entity",
+    exclusive: true,
+    fallback: [
+      "mob",
+      "mobEntity"
+    ]
+  },
+  "net/minecraft/unmapped/C_hqdayibh": { // PathAwareEntity
+    local_name: "entity",
+    exclusive: true,
+    fallback: [
+      "pathAwareEntity"
+    ]
+  },
   "net/minecraft/unmapped/C_ogavsvbr": { // EntityType
     local_name: "type",
     exclusive: true,
@@ -167,11 +182,20 @@
       "spawnReason"
     ]
   },
-  "net/minecraft/unmapped/C_yuycoehb" : { // EquipmentSlot
+  "net/minecraft/unmapped/C_yuycoehb": { // EquipmentSlot
     local_name: "slot",
     exclusive: true,
     fallback: [
       "equipmentSlot"
+    ]
+  },
+  "net/minecraft/unmapped/C_rcqaryar$C_loqvwuht": { // TaskBuilder.Instance
+    local_name: "instance",
+    exclusive: true,
+    fallback: [
+      "instance",
+      "builderInstance",
+      "taskBuilderInstance"
     ]
   },
 
@@ -318,8 +342,22 @@
 
   "net/minecraft/unmapped/C_xucdsrtl": { // Waypoint
     local_name: "waypoint",
-    inherit: true,
     exclusive: true
+  },
+  "net/minecraft/unmapped/C_jmwfvpzz": { // TrackedWaypoint
+    local_name: "waypoint",
+    exclusive: true,
+    inherit: true,
+    fallback: [
+      "trackedWaypoint"
+    ]
+  },
+  "net/minecraft/unmapped/C_jtpeboen": { // WaypointSource
+    local_name: "waypoint",
+    exclusive: true,
+    fallback: [
+      "waypointSource"
+    ]
   },
   "net/minecraft/unmapped/C_xucdsrtl$C_ozyhcqwy": { // Waypoint$Icon
     local_name: "icon",

--- a/enigma/simple_type_field_names.json5
+++ b/enigma/simple_type_field_names.json5
@@ -22,6 +22,20 @@
 
   // Data
   "net/minecraft/unmapped/C_nykrdyol": "exporter", // RecipeExporter
+  "net/minecraft/unmapped/C_djkzhngg": { // DataReader
+    local_name: "reader",
+    exclusive: true,
+    fallback: [
+      "dataReader"
+    ]
+  },
+  "net/minecraft/unmapped/C_kespdwpv": { // DataWriter
+    local_name: "writer",
+    exclusive: true,
+    fallback: [
+      "dataWriter"
+    ]
+  },
 
   // Loot
   "net/minecraft/unmapped/C_ykthnceq$C_frcifljd": "builder", // LootContextType.Builder

--- a/enigma/simple_type_field_names.json5
+++ b/enigma/simple_type_field_names.json5
@@ -318,6 +318,21 @@
       "worldView"
     ]
   },
+  "net/minecraft/unmapped/C_vdvbsyle": { // WorldAccess
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "worldAccess"
+    ]
+  },
+  "net/minecraft/unmapped/C_jmnzlycd":{ // ServerWorldAccess
+    local_name: "world",
+    exclusive: true,
+    fallback: [
+      "worldAccess",
+      "serverWorldAccess"
+    ]
+  },
   "net/minecraft/unmapped/C_peaveboq": { // BlockView
     local_name: "world",
     exclusive: true,

--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/unmapped/C_nvwxmqty net/minecraft/block/BedBlock
 		ARG 2 pos
 		ARG 3 possibleOffsets
 		ARG 4 ignoreInvalidPos
-	METHOD m_ycicexvn findWakeUpPosition (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;F)Ljava/util/Optional;
+	METHOD m_ycicexvn findWakeUpPos (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;F)Ljava/util/Optional;
 		ARG 0 type
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/RespawnAnchorBlock.mapping
+++ b/mappings/net/minecraft/block/RespawnAnchorBlock.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/unmapped/C_vokhdpnl net/minecraft/block/RespawnAnchorBlock
 		ARG 3 explodedPos
 	METHOD m_eocpbcbk isNether (Lnet/minecraft/unmapped/C_cdctfzbn;)Z
 		ARG 0 world
-	METHOD m_hmhyrgxt findRespawnPosition (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;)Ljava/util/Optional;
+	METHOD m_hmhyrgxt findSpawnDest (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;)Ljava/util/Optional;
 		ARG 0 entity
 		ARG 1 world
 		ARG 2 pos
@@ -28,7 +28,7 @@ CLASS net/minecraft/unmapped/C_vokhdpnl net/minecraft/block/RespawnAnchorBlock
 	METHOD m_iqfgpnwk hasStillWater (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cdctfzbn;)Z
 		ARG 0 pos
 		ARG 1 world
-	METHOD m_txupvrmd findRespawnPosition (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Z)Ljava/util/Optional;
+	METHOD m_txupvrmd findSpawnDestImpl (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Z)Ljava/util/Optional;
 		ARG 0 entity
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/client/gui/Drawable.mapping
+++ b/mappings/net/minecraft/client/gui/Drawable.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/unmapped/C_dtfldood net/minecraft/client/gui/Drawable
 	COMMENT Represents something that can be drawn.
 	METHOD m_ljhpujrm render (Lnet/minecraft/unmapped/C_sedilmty;IIF)V
+		ARG 2 mouseX
+		ARG 3 mouseY
+		ARG 4 delta

--- a/mappings/net/minecraft/client/gui/screen/TestBlockScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/TestBlockScreen.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/unmapped/C_wvmudpaf net/minecraft/client/gui/screen/TestBlockScreen
+	FIELD f_cbspuclr messageWidget Lnet/minecraft/unmapped/C_vopzcnhf;
+	FIELD f_dvhmzmfm mode Lnet/minecraft/unmapped/C_dgfvnzfk;
+	FIELD f_fnhkmgnr MESSAGE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_hljgjxmh message Ljava/lang/String;
+	FIELD f_nbnhzffi BLOCK_NAME Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_yqljwwhq MODES Ljava/util/List;
+	METHOD m_cgpwzpyv onDone ()V
+	METHOD m_cuicaztg close ()V
+	METHOD m_ewbjtdel (Lnet/minecraft/unmapped/C_buwziidm;)V
+		ARG 1 button
+	METHOD m_hlpadkru setMode (Lnet/minecraft/unmapped/C_dgfvnzfk;)V
+		ARG 1 mode
+	METHOD m_knzvchoo (Lnet/minecraft/unmapped/C_buwziidm;)V
+		ARG 1 button
+	METHOD m_xssiaeup (Lnet/minecraft/unmapped/C_ikfvpkkf;Lnet/minecraft/unmapped/C_dgfvnzfk;)V
+		ARG 1 button
+		ARG 2 mode

--- a/mappings/net/minecraft/client/gui/screen/TestInstanceBlockScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/TestInstanceBlockScreen.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_gstsrhel net/minecraft/client/gui/screen/TestInstanceBlockScreen
+	FIELD f_aukwaunb ROTATION Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_khgnyczb ENTITIES Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_kqbpajlo SIZE Lnet/minecraft/unmapped/C_rdaqiwdt;
+	FIELD f_pgbgzack TEST_ID Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_vtlyuhco toString (Lnet/minecraft/unmapped/C_mboglirk;)Lnet/minecraft/unmapped/C_rdaqiwdt;
+		ARG 0 rotation

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -23,6 +23,7 @@ CLASS net/minecraft/unmapped/C_kpvuxmkp net/minecraft/client/gui/widget/Clickabl
 		ARG 4 height
 		ARG 5 message
 	METHOD m_acsoyrbk updateNarration (Lnet/minecraft/unmapped/C_pofrkllk;)V
+		ARG 1 message
 	METHOD m_bhvsucly appendDefaultNarrations (Lnet/minecraft/unmapped/C_pofrkllk;)V
 		ARG 1 builder
 	METHOD m_cgsapias getXEnd ()I

--- a/mappings/net/minecraft/client/gui/widget/button/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/button/ButtonWidget.mapping
@@ -51,4 +51,8 @@ CLASS net/minecraft/unmapped/C_buwziidm net/minecraft/client/gui/widget/button/B
 		METHOD m_xttyxrzu narration (Lnet/minecraft/unmapped/C_buwziidm$C_gkkecayh;)Lnet/minecraft/unmapped/C_buwziidm$C_evfntova;
 			ARG 1 narrationFactory
 	CLASS C_gkkecayh NarrationFactory
+		METHOD createNarrationMessage (Ljava/util/function/Supplier;)Lnet/minecraft/unmapped/C_npqneive;
+			ARG 1 messageGetter
 	CLASS C_zlxjklbn PressAction
+		METHOD onPress (Lnet/minecraft/unmapped/C_buwziidm;)V
+			ARG 1 button

--- a/mappings/net/minecraft/client/gui/widget/button/CyclingButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/button/CyclingButtonWidget.mapping
@@ -108,6 +108,8 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/button/C
 			COMMENT <p>If this is not called, the initial value defaults to the first
 			COMMENT value in the values list supplied.
 			ARG 1 value
+		METHOD m_jzxbfgwv optionTextOmitted (Z)Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
+			ARG 1 omitted
 		METHOD m_kxxawnyf build (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_ikfvpkkf$C_hmzkrfiv;)Lnet/minecraft/unmapped/C_ikfvpkkf;
 			ARG 1 optionText
 			ARG 2 callback
@@ -164,10 +166,14 @@ CLASS net/minecraft/unmapped/C_ikfvpkkf net/minecraft/client/gui/widget/button/C
 		METHOD m_vahoyxin values ([Ljava/lang/Object;)Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 			COMMENT Sets the option values for this button.
 			ARG 1 values
+		METHOD m_zntukqxe optionTextOmitted ()Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 		METHOD m_zrnvdsew values (Lnet/minecraft/unmapped/C_ikfvpkkf$C_qjymjbvs;)Lnet/minecraft/unmapped/C_ikfvpkkf$C_djnbpyue;
 			COMMENT Sets the option values for this button.
 			ARG 1 values
 	CLASS C_hmzkrfiv UpdateCallback
+		METHOD onValueChange (Lnet/minecraft/unmapped/C_ikfvpkkf;Ljava/lang/Object;)V
+			ARG 1 button
+			ARG 2 value
 	CLASS C_qjymjbvs Values
 		METHOD m_btluuors of (Ljava/util/Collection;)Lnet/minecraft/unmapped/C_ikfvpkkf$C_qjymjbvs;
 			ARG 0 values

--- a/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/unmapped/C_sgyyxgui net/minecraft/client/network/AbstractClientPlayerEntity
 	FIELD f_brnlljdm elytraRoll F
+	FIELD f_bzzpopud travelDistance F
 	FIELD f_hkevncvl elytraYaw F
 	FIELD f_horcygha lastVelocity Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_kripswfx clientWorld Lnet/minecraft/unmapped/C_ghdnlrrw;
+	FIELD f_tituynsf prevTravelDistance F
 	FIELD f_xxfkyvkq elytraPitch F
 	FIELD f_zjtucwmu cachedScoreboardEntry Lnet/minecraft/unmapped/C_rdnfmxue;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ghdnlrrw;Lcom/mojang/authlib/GameProfile;)V

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_jlopmfei net/minecraft/client/network/ClientPlaye
 	FIELD f_awtfnari ticksToNextAutojump I
 	FIELD f_bfvigirz riding Z
 	FIELD f_bxbatcpa statHandler Lnet/minecraft/unmapped/C_udjcmsxa;
+	FIELD f_cqqhhszk USING_ITEM_SPEED_FACTOR F
 	FIELD f_cscipsrr mountJumpStrength F
 	FIELD f_ctxbxcto tickables Ljava/util/List;
 	FIELD f_dgnqpmdg recipeBook Lnet/minecraft/unmapped/C_sjlfgpfd;
@@ -19,6 +20,7 @@ CLASS net/minecraft/unmapped/C_jlopmfei net/minecraft/client/network/ClientPlaye
 	FIELD f_iqzqxmpg lastSprinting Z
 	FIELD f_irzjhfpc lastRenderPitch F
 	FIELD f_iuztugfq LOGGER Lorg/slf4j/Logger;
+	FIELD f_jfruariu portalEffectIntensity F
 	FIELD f_kkjehvrb ticksLeftToDoubleTapSprint I
 	FIELD f_lnothlou showsDeathScreen Z
 	FIELD f_lonrepuj inSneakingPose Z
@@ -26,53 +28,71 @@ CLASS net/minecraft/unmapped/C_jlopmfei net/minecraft/client/network/ClientPlaye
 	FIELD f_mxmeeeog jumpRidingTicks I
 	FIELD f_nbhshtxz activeHand Lnet/minecraft/unmapped/C_laxmzoqs;
 	FIELD f_niojzjyv underwaterVisibilityTicks I
+	FIELD f_ojhxqubk lastPortalEffectIntensity F
+	FIELD f_qopkbzvg dropItemCooldown Lnet/minecraft/unmapped/C_bjnewvkq;
+	FIELD f_rcgfrcgp lastHorizontalCollision Z
 	FIELD f_rdioexdo renderYaw F
 	FIELD f_rtneahro lastX D
 	FIELD f_rudpemlr usingItem Z
 	FIELD f_sauvdttc lastYaw F
 	FIELD f_sbnghqwd input Lnet/minecraft/unmapped/C_zcisasac;
+	FIELD f_scgekrvy lastY D
 	FIELD f_syjuhyvi networkHandler Lnet/minecraft/unmapped/C_nuofrxvi;
 	FIELD f_usxefjxe healthInitialized Z
 	FIELD f_uynrsldw lastOnGround Z
 	FIELD f_vebkyfkt WATER_VISION_QUICK_TIME I
 	FIELD f_weecdoml lastRenderYaw F
+	FIELD f_wwdrymzh experienceDisplayStartTick I
 	FIELD f_xryucszr lastZ D
+	FIELD f_zjxujerh lastInputFlags Lnet/minecraft/unmapped/C_lkjruazd;
 	FIELD f_zkrtgbyu falling Z
 	FIELD f_zxxybkqq ticksSinceLastPositionPacketSent I
 	METHOD m_bzkhmdji getStatHandler ()Lnet/minecraft/unmapped/C_udjcmsxa;
 	METHOD m_cawwfaef shouldSlowDown ()Z
+	METHOD m_ctnfzfwp foodAllowsSprinting ()Z
 	METHOD m_cxdlzmge isCamera ()Z
 	METHOD m_cyqhtqzg updateHealth (F)V
 		ARG 1 health
 	METHOD m_dvxttqkg dropSelectedItem (Z)Z
 		ARG 1 entireStack
+	METHOD m_eovnuked getDropItemCooldown ()Lnet/minecraft/unmapped/C_bjnewvkq;
 	METHOD m_fjkurxla getUnderwaterVisibility ()F
 		COMMENT {@return the color multiplier of vision in water} Visibility in
 		COMMENT water is reduced when the player just entered water.
 	METHOD m_gxezutim startRidingJump ()V
+	METHOD m_hbevrins getInputFlags ()Lnet/minecraft/unmapped/C_lkjruazd;
 	METHOD m_hcfpmyto wouldCollideAt (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 pos
 	METHOD m_hfpiizip onRecipeDisplayed (Lnet/minecraft/unmapped/C_tglmjehp;)V
+		ARG 1 id
 	METHOD m_iaefsihn getMoodPercentage ()F
 		COMMENT {@return the percentage for the biome mood sound for the debug HUD to
 		COMMENT display}
 	METHOD m_ibxwqidi getRecipeBook ()Lnet/minecraft/unmapped/C_sjlfgpfd;
+	METHOD m_irnuunup shouldStopSprinting ()Z
 	METHOD m_jnifxwux setDoLimitedCrafting (Z)V
 		ARG 1 doLimitedCrafting
 	METHOD m_jwqxefyk canStartSprinting ()Z
 	METHOD m_kdhhfsoy closeScreen ()V
 	METHOD m_kxlksird getJumpingMount ()Lnet/minecraft/unmapped/C_yerxgbau;
 	METHOD m_lusupfra openRidingInventory ()V
+	METHOD m_mmxuxjcb shouldStopSwimSprinting ()Z
 	METHOD m_mwnueopu isAutoJumpEnabled ()Z
 	METHOD m_nfwipcth trySendSprintingPacket ()V
 	METHOD m_nxuownoi shouldAutoJump ()Z
 	METHOD m_ohhpabab init ()V
+	METHOD m_pclvoaoc updatePortalEffectIntensity (Z)V
+		ARG 1 confusionEffect
 	METHOD m_qjxxuqlz pushOutOfBlocks (DD)V
 		ARG 1 x
 		ARG 3 z
 	METHOD m_qkbjfhbb setShowsDeathScreen (Z)V
 		ARG 1 shouldShow
+	METHOD m_qtvifjei getCameraMovementInputMagnitude (Lnet/minecraft/unmapped/C_krlwdsom;)F
+		ARG 0 normalizedInputMagnitudes
 	METHOD m_rlbaeyze sendMovementPackets ()V
+	METHOD m_robsbtzw adjustCameraMovementInputImpl (Lnet/minecraft/unmapped/C_krlwdsom;)Lnet/minecraft/unmapped/C_krlwdsom;
+		ARG 0 inputMagnitudes
 	METHOD m_sevuwqfe autoJump (FF)V
 		ARG 1 dx
 		ARG 2 dz
@@ -82,11 +102,17 @@ CLASS net/minecraft/unmapped/C_jlopmfei net/minecraft/client/network/ClientPlaye
 		ARG 1 gameMode
 	METHOD m_towrjxjq canVehicleSprint (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 entity
+	METHOD m_ujxrzxcp (Lnet/minecraft/unmapped/C_zscvhwbd;)Ljava/util/stream/Stream;
+		ARG 0 shape
+	METHOD m_ulvyuzjg hasBlindness ()Z
+	METHOD m_upnfcccr adjustCameraMovementInput (Lnet/minecraft/unmapped/C_krlwdsom;)Lnet/minecraft/unmapped/C_krlwdsom;
+		ARG 1 inputMagnitudes
 	METHOD m_upzlykxr setExperience (FII)V
 		ARG 1 progress
 		ARG 2 total
 		ARG 3 level
 	METHOD m_viqbkvwk getMountJumpStrength ()F
+	METHOD m_wavkxtkh getPortalEffect ()Lnet/minecraft/unmapped/C_teerivzm$C_budwrmur;
 	METHOD m_wnyjanfc isRiding ()Z
 	METHOD m_xfculten hasMovementInput ()Z
 		COMMENT {@return whether the player has movement input}

--- a/mappings/net/minecraft/client/render/SectionOcclusionGraph.mapping
+++ b/mappings/net/minecraft/client/render/SectionOcclusionGraph.mapping
@@ -28,7 +28,9 @@ CLASS net/minecraft/unmapped/C_jnliocmw net/minecraft/client/render/SectionOcclu
 		ARG 1 builtChunkStorage
 	METHOD m_mateoxjf queueSectionsWithNewNeighbors (Lnet/minecraft/unmapped/C_jnliocmw$C_limxhopi;)V
 		ARG 1 state
-	METHOD m_pabghxwa isInViewDistance (JJ)Z
+	METHOD m_pabghxwa areWithinViewDistance (JJ)Z
+		ARG 1 chunkSectionPos
+		ARG 3 chunkSection2
 	METHOD m_qeysollx runFullUpdate (Lnet/minecraft/unmapped/C_jnliocmw$C_bxmhdxlt;Lnet/minecraft/unmapped/C_vgpupfxx;Ljava/util/Queue;ZLjava/util/function/Consumer;Lit/unimi/dsi/fastutil/longs/LongOpenHashSet;)V
 		ARG 1 storage
 		ARG 2 cameraPos

--- a/mappings/net/minecraft/client/render/SectionOcclusionGraph.mapping
+++ b/mappings/net/minecraft/client/render/SectionOcclusionGraph.mapping
@@ -29,7 +29,7 @@ CLASS net/minecraft/unmapped/C_jnliocmw net/minecraft/client/render/SectionOcclu
 	METHOD m_mateoxjf queueSectionsWithNewNeighbors (Lnet/minecraft/unmapped/C_jnliocmw$C_limxhopi;)V
 		ARG 1 state
 	METHOD m_pabghxwa areWithinViewDistance (JJ)Z
-		ARG 1 chunkSectionPos
+		ARG 1 chunkSection1
 		ARG 3 chunkSection2
 	METHOD m_qeysollx runFullUpdate (Lnet/minecraft/unmapped/C_jnliocmw$C_bxmhdxlt;Lnet/minecraft/unmapped/C_vgpupfxx;Ljava/util/Queue;ZLjava/util/function/Consumer;Lit/unimi/dsi/fastutil/longs/LongOpenHashSet;)V
 		ARG 1 storage

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -105,7 +105,7 @@ CLASS net/minecraft/unmapped/C_sfkkabhx net/minecraft/client/render/WorldRendere
 	METHOD m_frxfkurs getCloudRenderer ()Lnet/minecraft/unmapped/C_jjygzmqz;
 	METHOD m_gtfdkthn addParticle (Lnet/minecraft/unmapped/C_nqucohct;ZDDDDDD)V
 		ARG 1 parameters
-		ARG 2 shouldAlwaysSpawn
+		ARG 2 alwaysSpawn
 		ARG 3 x
 		ARG 5 y
 		ARG 7 z
@@ -154,7 +154,7 @@ CLASS net/minecraft/unmapped/C_sfkkabhx net/minecraft/client/render/WorldRendere
 	METHOD m_krdmlhzv getCapturedFrustum ()Lnet/minecraft/unmapped/C_jwzjqevg;
 	METHOD m_lmslduiw addParticle (Lnet/minecraft/unmapped/C_nqucohct;ZZDDDDDD)V
 		ARG 1 parameters
-		ARG 2 shouldAlwaysSpawn
+		ARG 2 alwaysSpawn
 		ARG 3 important
 		ARG 4 x
 		ARG 6 y

--- a/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/unmapped/C_gdptvgng net/minecraft/client/render/entity/Displ
 		ARG 0 entity
 		ARG 1 tickDelta
 	METHOD m_btxyygsm renderInner (Lnet/minecraft/unmapped/C_eqtsncdp;Lnet/minecraft/unmapped/C_cnszsxvd;Lnet/minecraft/unmapped/C_igrgeffe;IF)V
+		ARG 1 state
+		ARG 5 interpolationProgress
 	METHOD m_qhbrndle calculateOrientation (Lnet/minecraft/unmapped/C_zdeutotk$C_fdgxcfnt;Lnet/minecraft/unmapped/C_eqtsncdp;Lorg/joml/Quaternionf;)Lorg/joml/Quaternionf;
 		ARG 1 renderState
 	METHOD m_zegdbvcy getLerpedPitch (Lnet/minecraft/unmapped/C_zdeutotk;F)F

--- a/mappings/net/minecraft/client/util/Input.mapping
+++ b/mappings/net/minecraft/client/util/Input.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_zcisasac net/minecraft/client/util/Input
+	FIELD f_jlsqbcuq magnitudes Lnet/minecraft/unmapped/C_krlwdsom;
+	FIELD f_ywxgimqb flags Lnet/minecraft/unmapped/C_lkjruazd;
+	METHOD m_clbqioid update ()V
+	METHOD m_jpymendx getMagnitudes ()Lnet/minecraft/unmapped/C_krlwdsom;
+	METHOD m_pzsckbqc hasForwardMagnitude ()Z
+	METHOD m_tgmdrojt jump ()V

--- a/mappings/net/minecraft/component/type/WeaponComponent.mapping
+++ b/mappings/net/minecraft/component/type/WeaponComponent.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_jsuianzi net/minecraft/component/type/WeaponComponent
+	FIELD f_mrtxibaa AXE_DISABLES_BLOCKING_FOR_SECONDS F

--- a/mappings/net/minecraft/enchantment/Enchantment.mapping
+++ b/mappings/net/minecraft/enchantment/Enchantment.mapping
@@ -98,6 +98,7 @@ CLASS net/minecraft/unmapped/C_jxtrubuh net/minecraft/enchantment/Enchantment
 	METHOD m_stvdursa modifyTridentSpinAttackStrength (Lnet/minecraft/unmapped/C_rlomrsco;ILorg/apache/commons/lang3/mutable/MutableFloat;)V
 	METHOD m_tdrqsuwy modifyTridentReturnAcceleration (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
 	METHOD m_tehyavah modifyKnockback (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+		ARG 4 knockee
 		ARG 6 value
 	METHOD m_tfnzpqjx modifyBlockExperience (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_sddaxwyk;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
 	METHOD m_tiaspbpv getEquipment (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/util/Map;

--- a/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
@@ -16,9 +16,9 @@ CLASS net/minecraft/unmapped/C_jakrppis net/minecraft/enchantment/EnchantmentHel
 		ARG 2 enchantment
 		ARG 3 level
 		ARG 4 context
-	METHOD m_cjzxcjvw applyAttributeModifiers (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_qfoqahef;Ljava/util/function/BiConsumer;)V
+	METHOD m_cjzxcjvw forEachModifier (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_qfoqahef;Ljava/util/function/BiConsumer;)V
 		ARG 1 group
-		ARG 2 applicator
+		ARG 2 action
 	METHOD m_cnuszkat createEnchantedBook (Lnet/minecraft/unmapped/C_gsnkkurc;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 0 enchantment
 	METHOD m_cnvzaghn (Lnet/minecraft/unmapped/C_pscqxfcs;Lorg/apache/commons/lang3/mutable/MutableBoolean;Lnet/minecraft/unmapped/C_cjzoxshv;I)V
@@ -281,9 +281,9 @@ CLASS net/minecraft/unmapped/C_jakrppis net/minecraft/enchantment/EnchantmentHel
 	METHOD m_yolmdyfp onProjectileSpawned (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_ltpsyvhj;Ljava/util/function/Consumer;)V
 		ARG 2 projectile
 		ARG 3 onBreak
-	METHOD m_zkmvjzhi applyAttributeModifiers (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_yuycoehb;Ljava/util/function/BiConsumer;)V
+	METHOD m_zkmvjzhi forEachModifier (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_yuycoehb;Ljava/util/function/BiConsumer;)V
 		ARG 1 slot
-		ARG 2 applicator
+		ARG 2 action
 	METHOD m_zrsoxtbx getTridentReturnAcceleration (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;)I
 		ARG 2 entity
 	METHOD m_zzbecydw enchant (Lnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_sddaxwyk;ILnet/minecraft/unmapped/C_wqxmvzdq;Ljava/util/Optional;)Lnet/minecraft/unmapped/C_sddaxwyk;

--- a/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
@@ -82,7 +82,7 @@ CLASS net/minecraft/unmapped/C_jakrppis net/minecraft/enchantment/EnchantmentHel
 	METHOD m_hkpckyyg getHighestLevel (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_pscqxfcs;)Lcom/mojang/datafixers/util/Pair;
 		ARG 1 componentType
 	METHOD m_hsagtbhc getProjectileCount (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;I)I
-		ARG 2 entity
+		ARG 2 shooter
 		ARG 3 baseCount
 	METHOD m_hvxyojnz (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners;Lorg/apache/commons/lang3/mutable/MutableFloat;Lnet/minecraft/unmapped/C_cjzoxshv;ILnet/minecraft/unmapped/C_pjrjvgrp;)V
 		ARG 3 enchantment
@@ -91,7 +91,7 @@ CLASS net/minecraft/unmapped/C_jakrppis net/minecraft/enchantment/EnchantmentHel
 	METHOD m_iefpfmdo applyEnchantments (Lnet/minecraft/unmapped/C_sddaxwyk;Ljava/util/function/Consumer;)Lnet/minecraft/unmapped/C_qlclfxvn;
 		ARG 1 applier
 	METHOD m_imfnnaau getKnockback (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;F)F
-		ARG 2 entity
+		ARG 2 knockee
 		ARG 3 source
 		ARG 4 baseKnockback
 	METHOD m_jfbiswcz getDamageProtection (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sbxfkpyv;)F
@@ -103,9 +103,9 @@ CLASS net/minecraft/unmapped/C_jakrppis net/minecraft/enchantment/EnchantmentHel
 	METHOD m_kvkboaps forEachEquippedEnchantment (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_jakrppis$C_wtxpyhvg;)V
 		ARG 0 entity
 		ARG 1 action
-	METHOD m_lkbuzftr getProjectileSpeed (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;F)F
-		ARG 2 entity
-		ARG 3 baseSpeed
+	METHOD m_lkbuzftr getProjectileSpread (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;F)F
+		ARG 2 shooter
+		ARG 3 baseSpread
 	METHOD m_lphekcyk (ILjava/util/List;Lnet/minecraft/unmapped/C_cjzoxshv;)V
 		ARG 2 enchantment
 	METHOD m_lwyqyolk (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_astfners;Lorg/apache/commons/lang3/mutable/MutableFloat;Lnet/minecraft/unmapped/C_cjzoxshv;I)V

--- a/mappings/net/minecraft/entity/Dismounting.mapping
+++ b/mappings/net/minecraft/entity/Dismounting.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/unmapped/C_zdxaswsa net/minecraft/entity/Dismounting
 	METHOD m_mbenxxcc getCollisionShape (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 0 world
 		ARG 1 pos
-	METHOD m_oshnlenr findRespawnPos (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Z)Lnet/minecraft/unmapped/C_vgpupfxx;
+	METHOD m_oshnlenr findDismountPos (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vxzrjtdu;Lnet/minecraft/unmapped/C_hynzadkk;Z)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 0 entityType
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_hyixntpo submergedInWater Z
 	FIELD f_hzlmaqrc removalReason Lnet/minecraft/unmapped/C_astfners$C_emmohndu;
 	FIELD f_idqxcmak DELTA_AFFECTED_BY_BLOCKS_BELOW_1_0 D
-	FIELD f_ihpdejin prevY D
+	FIELD f_ihpdejin lastY D
 	FIELD f_ilwbyicy velocity Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_iskwetjb CUSTOM_NAME Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_jaapvywi YXZ_AXES Lcom/google/common/collect/ImmutableList;
@@ -78,7 +78,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_oritxgsn crystalSoundIntensity F
 	FIELD f_oysssbsf ridingCooldown I
 	FIELD f_pebbtyzx NO_GRAVITY Lnet/minecraft/unmapped/C_rinmcaxy;
-	FIELD f_pfezymmj prevYaw F
+	FIELD f_pfezymmj lastYaw F
 	FIELD f_pfgaedzm MIN_TICKS_TO_FREEZE I
 	FIELD f_psantzmq AIR_KEY Ljava/lang/String;
 	FIELD f_qazqhmfv SNEAKING_FLAG_INDEX I
@@ -107,14 +107,14 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_trtwybfg YZX_AXES Lcom/google/common/collect/ImmutableList;
 	FIELD f_ujsjgylb fallDistance D
 	FIELD f_ulxrtxuh FIRE_KEY Ljava/lang/String;
-	FIELD f_vdsiqqmt prevPitch F
+	FIELD f_vdsiqqmt lastPitch F
 	FIELD f_vettyvgp hasVisualFire Z
 	FIELD f_vlasppic pistonMovementTick J
 	FIELD f_vqbkceyr PASSENGERS_KEY Ljava/lang/String;
 	FIELD f_vwokuaty yaw F
 	FIELD f_vzixfazc ID_KEY Ljava/lang/String;
 	FIELD f_waoxjimm alwaysSyncPosition Z
-	FIELD f_waxazwex prevZ D
+	FIELD f_waxazwex lastZ D
 	FIELD f_wphccfzk GLOWING_FLAG_INDEX I
 	FIELD f_wqxxdylj ON_FIRE_FLAG_INDEX I
 	FIELD f_wtzimzjs bounds Lnet/minecraft/unmapped/C_hbcjzgoe;
@@ -127,7 +127,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	FIELD f_yqhkkypy currentCollisionChecks Ljava/util/List;
 	FIELD f_yqjyujwv SILENT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_yxegongc ROTATION_KEY Ljava/lang/String;
-	FIELD f_yyonjapw prevX D
+	FIELD f_yyonjapw lastX D
 	FIELD f_yyqamqtt verticalCollision Z
 	FIELD f_zesrveqd pitch F
 	FIELD f_zntizrau AIR Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -637,7 +637,6 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 1 event
 	METHOD m_oavmpfqe getAir ()I
 	METHOD m_obkzfysl readCustomData (Lnet/minecraft/unmapped/C_djkzhngg;)V
-		ARG 1 reader
 	METHOD m_obyhheyh handleDamagingEvent (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
 	METHOD m_odnkfosg getEyePos ()Lnet/minecraft/unmapped/C_vgpupfxx;
@@ -997,7 +996,6 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_xujkzfqh offsetZ (D)D
 		ARG 1 widthScale
 	METHOD m_xuwbpohg writeCustomData (Lnet/minecraft/unmapped/C_kespdwpv;)V
-		ARG 1 writer
 	METHOD m_xvflsbzg scheduleVelocityUpdate ()V
 	METHOD m_xwbgqvgs readData (Lnet/minecraft/unmapped/C_djkzhngg;)V
 		ARG 1 reader

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -290,6 +290,9 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_dsukauvx updateSubmergedInWaterState ()V
 	METHOD m_dtzgxqjr setRenderDistanceMultiplier (D)V
 		ARG 0 value
+	METHOD m_ducgrghl debugBlockCollision (Lnet/minecraft/unmapped/C_hynzadkk;ZZ)V
+		ARG 2 blockCollision
+		ARG 3 fluidCollision
 	METHOD m_duektjoe adjustMovementForPiston (Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 movement
 	METHOD m_dvrgqnea getInterpolator ()Lnet/minecraft/unmapped/C_sdgyrixf;
@@ -486,6 +489,8 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_iqvzwgkr canModifyAt (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 2 pos
 	METHOD m_iseshnfi isSpectator ()Z
+	METHOD m_iwygqrea queueCollisionCheck (Lnet/minecraft/unmapped/C_astfners$C_aipuagbw;)V
+		ARG 1 movement
 	METHOD m_ixqkofwo dropStack (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_uqpzijng;
 		COMMENT @return {@code null} if the passed {@code stack} is
 		COMMENT {@linkplain net.minecraft.item.ItemStack#isEmpty empty}, or the spawned
@@ -647,6 +652,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_oqjzpmsb setSwimming (Z)V
 		ARG 1 swimming
 	METHOD m_oryyldou isCustomNameVisible ()Z
+	METHOD m_otkcayod deQueueCollisionCheck ()V
 	METHOD m_ounwsonv isInvulnerable ()Z
 	METHOD m_owcsemrf doesNotCollide (DDD)Z
 		ARG 1 offsetX
@@ -724,6 +730,9 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 3 destY
 		ARG 5 destZ
 	METHOD m_qkqqfrjy getLastPos ()Lnet/minecraft/unmapped/C_vgpupfxx;
+	METHOD m_qlyjsjoc handleBlockCollisionEffects (Ljava/util/List;Lnet/minecraft/unmapped/C_bummdtgu$C_ybqvbnjz;)V
+		ARG 1 movements
+		ARG 2 collisionManager
 	METHOD m_qmsqmnke doesRenderOnFire ()Z
 	METHOD m_qoreltrp getFreezingScale ()F
 	METHOD m_qpmhbrns extinguishWithEffects ()V
@@ -1036,6 +1045,10 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 		ARG 1 entity
 	METHOD m_ywnmbdjz getWeaponStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_yxossras getMaxAir ()I
+	METHOD m_yzkgfwgp handleBlockCollisionEffects (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_bummdtgu$C_ybqvbnjz;Lit/unimi/dsi/fastutil/longs/LongSet;)V
+		ARG 2 to
+		ARG 3 collisionManager
+		ARG 4 collidingBlockPositions
 	METHOD m_yzuahesn getPrimaryStepSoundPos (Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_zbffjahn refreshPosition ()V
 	METHOD m_zcvlfcid move (Lnet/minecraft/unmapped/C_eojqvxuw;Lnet/minecraft/unmapped/C_vgpupfxx;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -542,7 +542,7 @@ CLASS net/minecraft/unmapped/C_astfners net/minecraft/entity/Entity
 	METHOD m_kmweazye getZ ()D
 	METHOD m_kqxvnqqn getWorld ()Lnet/minecraft/unmapped/C_cdctfzbn;
 		COMMENT {@return the world this entity is in}
-	METHOD m_krfnmqpx updateKilledAdvancementCriterion (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+	METHOD m_krfnmqpx updateKillStats (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 killer
 		ARG 2 score
 	METHOD m_ksoidzkr collides (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Ljava/util/List;)Z

--- a/mappings/net/minecraft/entity/EntityAttachments.mapping
+++ b/mappings/net/minecraft/entity/EntityAttachments.mapping
@@ -9,6 +9,8 @@ CLASS net/minecraft/unmapped/C_pubtmkke net/minecraft/entity/EntityAttachments
 		ARG 1 height
 	METHOD m_mhnyqnyc getPoint (Lnet/minecraft/unmapped/C_biqpbxns;IF)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 attachmentType
+	METHOD m_mlrtuvkw (FFFLnet/minecraft/unmapped/C_biqpbxns;)Ljava/util/List;
+		ARG 4 type
 	METHOD m_rfotkcao getPointNullable (Lnet/minecraft/unmapped/C_biqpbxns;IF)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 type
 		ARG 2 index
@@ -19,9 +21,15 @@ CLASS net/minecraft/unmapped/C_pubtmkke net/minecraft/entity/EntityAttachments
 		ARG 1 xScale
 		ARG 2 yScale
 		ARG 3 zScale
+	METHOD m_ydjfvvuh getAverage (Lnet/minecraft/unmapped/C_biqpbxns;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		ARG 1 type
 	CLASS C_qexjibym Builder
 		FIELD f_nxsujgne points Ljava/util/Map;
 		METHOD m_awxtqxkn attach (Lnet/minecraft/unmapped/C_biqpbxns;FFF)Lnet/minecraft/unmapped/C_pubtmkke$C_qexjibym;
+		METHOD m_hblfwmxq (FFLnet/minecraft/unmapped/C_biqpbxns;)Ljava/util/List;
+			ARG 3 type
+		METHOD m_hsxrcfvm (Lnet/minecraft/unmapped/C_biqpbxns;)Ljava/util/List;
+			ARG 0 ignored
 		METHOD m_wgusdhab attach (Lnet/minecraft/unmapped/C_biqpbxns;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_pubtmkke$C_qexjibym;
 			ARG 1 type
 			ARG 2 point

--- a/mappings/net/minecraft/entity/EntityConversionType.mapping
+++ b/mappings/net/minecraft/entity/EntityConversionType.mapping
@@ -1,5 +1,10 @@
 CLASS net/minecraft/unmapped/C_bsnhfrwa net/minecraft/entity/EntityConversionType
+	FIELD f_bcigdhmd COPYABLE_COMPONENT_TYPES Ljava/util/Set;
 	FIELD f_znjpjvio discardOldEntity Z
+	METHOD m_lmeuvplo copyComponent (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_pscqxfcs;)V
+		ARG 0 from
+		ARG 1 to
+		ARG 2 type
 	METHOD m_nsgenfpv shouldDiscardOldEntity ()Z
 	METHOD m_pajsecbl convert (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_pkxijcfk;)V
 		ARG 1 oldMob

--- a/mappings/net/minecraft/entity/EntityReference.mapping
+++ b/mappings/net/minecraft/entity/EntityReference.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/unmapped/C_xolbcmjn net/minecraft/entity/EntityReference
 	METHOD m_akgsfies getUuid ()Ljava/util/UUID;
 	METHOD m_alygzfbh (Lnet/minecraft/unmapped/C_cdctfzbn;Ljava/lang/String;)Ljava/util/UUID;
 		ARG 1 playerName
+	METHOD m_emyrhazo writeUuid (Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
+		ARG 1 writer
 	METHOD m_ftuivyez getEntity (Lnet/minecraft/unmapped/C_cwthlthi;Ljava/lang/Class;)Lnet/minecraft/unmapped/C_fbmwdlsj;
 		ARG 1 lookup
 		ARG 2 entityClass
@@ -21,3 +23,5 @@ CLASS net/minecraft/unmapped/C_xolbcmjn net/minecraft/entity/EntityReference
 	METHOD m_qpclguyf readTryPlayer (Lnet/minecraft/unmapped/C_djkzhngg;Ljava/lang/String;Lnet/minecraft/unmapped/C_cdctfzbn;)Lnet/minecraft/unmapped/C_xolbcmjn;
 		ARG 0 reader
 		ARG 1 key
+	METHOD m_vakxkivg writeUuid (Lnet/minecraft/unmapped/C_xolbcmjn;Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
+		ARG 0 reference

--- a/mappings/net/minecraft/entity/EntityReference.mapping
+++ b/mappings/net/minecraft/entity/EntityReference.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/unmapped/C_xolbcmjn net/minecraft/entity/EntityReference
 	METHOD m_akgsfies getUuid ()Ljava/util/UUID;
 	METHOD m_alygzfbh (Lnet/minecraft/unmapped/C_cdctfzbn;Ljava/lang/String;)Ljava/util/UUID;
 		ARG 1 playerName
-	METHOD m_emyrhazo writeUuid (Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
+	METHOD m_emyrhazo write (Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
 		ARG 1 writer
 	METHOD m_ftuivyez getEntity (Lnet/minecraft/unmapped/C_cwthlthi;Ljava/lang/Class;)Lnet/minecraft/unmapped/C_fbmwdlsj;
 		ARG 1 lookup
@@ -23,5 +23,5 @@ CLASS net/minecraft/unmapped/C_xolbcmjn net/minecraft/entity/EntityReference
 	METHOD m_qpclguyf readTryPlayer (Lnet/minecraft/unmapped/C_djkzhngg;Ljava/lang/String;Lnet/minecraft/unmapped/C_cdctfzbn;)Lnet/minecraft/unmapped/C_xolbcmjn;
 		ARG 0 reader
 		ARG 1 key
-	METHOD m_vakxkivg writeUuid (Lnet/minecraft/unmapped/C_xolbcmjn;Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
+	METHOD m_vakxkivg write (Lnet/minecraft/unmapped/C_xolbcmjn;Lnet/minecraft/unmapped/C_kespdwpv;Ljava/lang/String;)V
 		ARG 0 reference

--- a/mappings/net/minecraft/entity/EntityStatuses.mapping
+++ b/mappings/net/minecraft/entity/EntityStatuses.mapping
@@ -58,3 +58,4 @@ CLASS net/minecraft/unmapped/C_vuauwont net/minecraft/entity/EntityStatuses
 	FIELD f_ypuulpqv ADD_SPRINTING_PARTICLES_OR_RESET_SPAWNER_MINECART_SPAWN_DELAY B
 	FIELD f_yvtyvphf SONIC_CHARGE B
 	FIELD f_zvwxxfqe ADD_VILLAGER_ANGRY_PARTICLES B
+	FIELD f_zybqxgnb RAVAGER_ROAR B

--- a/mappings/net/minecraft/entity/EquipmentUser.mapping
+++ b/mappings/net/minecraft/entity/EquipmentUser.mapping
@@ -11,4 +11,4 @@ CLASS net/minecraft/unmapped/C_fxfvcivl net/minecraft/entity/EquipmentUser
 	METHOD m_udqbhpxg equipStack (Lnet/minecraft/unmapped/C_yuycoehb;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 	METHOD m_ybivtegh equipRandomly (Lnet/minecraft/unmapped/C_fiwnwrrf;Lnet/minecraft/unmapped/C_nzsnkdtl;)V
 		ARG 1 equipmentTable
-	METHOD m_zwvabaox getEquippedStack (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_zwvabaox getEquipment (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_sddaxwyk;

--- a/mappings/net/minecraft/entity/ExperienceOrbEntity.mapping
+++ b/mappings/net/minecraft/entity/ExperienceOrbEntity.mapping
@@ -20,10 +20,14 @@ CLASS net/minecraft/unmapped/C_vcliofjo net/minecraft/entity/ExperienceOrbEntity
 		ARG 4 y
 		ARG 6 z
 		ARG 8 amount
-	METHOD m_aatvaora spawn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;I)V
+	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;I)V
+		ARG 2 pos
+		ARG 3 bounce
+		ARG 4 value
+	METHOD m_aatvaora spawnOrbs (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;I)V
 		ARG 0 world
 		ARG 1 pos
-		ARG 2 amount
+		ARG 2 totalValue
 	METHOD m_aqllcbet repairEquipment (Lnet/minecraft/unmapped/C_mxrobsgg;I)I
 		COMMENT @return the remaining experience after the repair
 	METHOD m_bdfuzmlr wasMergedIntoExistingOrb (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;I)Z
@@ -32,9 +36,19 @@ CLASS net/minecraft/unmapped/C_vcliofjo net/minecraft/entity/ExperienceOrbEntity
 		ARG 2 amount
 	METHOD m_bsjymiql roundToOrbSize (I)I
 		ARG 0 value
+	METHOD m_fbouyyyn spawnOrbs (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;I)V
+		ARG 1 pos
+		ARG 2 bounce
+		ARG 3 totalValue
 	METHOD m_ghsyhojn merge (Lnet/minecraft/unmapped/C_vcliofjo;)V
 		ARG 1 other
+	METHOD m_jsfddsbm (IILnet/minecraft/unmapped/C_vcliofjo;)Z
+		ARG 2 orb
 	METHOD m_kareqjyw getValue ()I
+	METHOD m_kcqzxhrj (Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 1 collisionPos
+	METHOD m_mviirmqn moveOutOfCollision (D)V
+		ARG 1 size
 	METHOD m_ncnlpwky isMergeable (Lnet/minecraft/unmapped/C_vcliofjo;II)Z
 		ARG 0 orb
 		ARG 1 seed

--- a/mappings/net/minecraft/entity/InventoryOwner.mapping
+++ b/mappings/net/minecraft/entity/InventoryOwner.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_ypdbycnu net/minecraft/entity/InventoryOwner
 	FIELD f_mfztyjcg INVENTORY_KEY Ljava/lang/String;
+	METHOD m_ekrcttxt (Lnet/minecraft/unmapped/C_djkzhngg$C_knzjfpbq;)V
+		ARG 1 inventoryReader
 	METHOD m_gkvbhjtf readInventory (Lnet/minecraft/unmapped/C_djkzhngg;)V
+		ARG 1 reader
 	METHOD m_hvqynloo putInventory (Lnet/minecraft/unmapped/C_kespdwpv;)V
+		ARG 1 writer
 	METHOD m_jezpqywh getInventory ()Lnet/minecraft/unmapped/C_rsloiwzx;
 	METHOD m_lhfmuakv pickUpItem (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_ypdbycnu;Lnet/minecraft/unmapped/C_uqpzijng;)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/Leashable.mapping
+++ b/mappings/net/minecraft/entity/Leashable.mapping
@@ -13,6 +13,8 @@ CLASS net/minecraft/unmapped/C_gbavazgo net/minecraft/entity/Leashable
 	METHOD m_agcvyesn tickLeashed (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 holder
 	METHOD m_brbnwutv dropLeash ()V
+	METHOD m_clmmucml getHolderMovement (Lnet/minecraft/unmapped/C_astfners;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		ARG 0 holder
 	METHOD m_damipxvm applyLeashPulls (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_gbavazgo$C_trsxpkpu;)Z
 		ARG 1 leashHolder
 		ARG 2 leashData
@@ -21,6 +23,7 @@ CLASS net/minecraft/unmapped/C_gbavazgo net/minecraft/entity/Leashable
 	METHOD m_epgfrqcc attachLeash (Lnet/minecraft/unmapped/C_astfners;Z)V
 	METHOD m_feakufat hasLeashData ()Z
 	METHOD m_fmujdyoh readLeashData (Lnet/minecraft/unmapped/C_djkzhngg;)V
+		ARG 1 reader
 	METHOD m_frfgxbsb onLooseLeashTick (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 entity
 	METHOD m_gnmtyuso createQuadLeashOffsets (Lnet/minecraft/unmapped/C_astfners;DDDD)[Lnet/minecraft/unmapped/C_vgpupfxx;
@@ -77,6 +80,7 @@ CLASS net/minecraft/unmapped/C_gbavazgo net/minecraft/entity/Leashable
 	METHOD m_ydkqpzwu tickLeash (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 leashable
 	METHOD m_ydrqybvl writeLeashData (Lnet/minecraft/unmapped/C_kespdwpv;Lnet/minecraft/unmapped/C_gbavazgo$C_trsxpkpu;)V
+		ARG 1 writer
 		ARG 2 data
 	METHOD m_yvbpzuud resolveLeashData (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_gbavazgo$C_trsxpkpu;)V
 		ARG 1 data

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -426,7 +426,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 3 toEquip
 	METHOD m_nwomssgw getOffHandStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_oafzlopj getSoundVolume ()F
-	METHOD m_ojlaryxr hasStackEquipped (Lnet/minecraft/unmapped/C_yuycoehb;)Z
+	METHOD m_ojlaryxr hasEquipment (Lnet/minecraft/unmapped/C_yuycoehb;)Z
 		ARG 1 slot
 	METHOD m_okzjzswg getClimbingPos ()Ljava/util/Optional;
 	METHOD m_onvfjcen tickFallFlying ()V
@@ -730,7 +730,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 1 loot
 	METHOD m_zwmydvfv playHurtSound (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
-	METHOD m_zwvabaox getEquippedStack (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_zwvabaox getEquipment (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_zybxrwui getBlockedDamage (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;F)F
 		COMMENT @return the amount of damage blocked by this entity's
 		COMMENT {@linkplain #getBlockingItem() blocking item}, if any

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -49,7 +49,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_lzsyjpdn lastEquipment Ljava/util/Map;
 	FIELD f_mawomqmy LIVING_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_mcoacjpn SWING_DURATION I
-	FIELD f_mcoihohf itemUseTimeLeft I
+	FIELD f_mcoihohf remainingItemUseTicks I
 	FIELD f_mfltnpor effectsChanged Z
 	FIELD f_mikwhxdg skipExperienceDrop Z
 	FIELD f_mjweoijp POTION_SWIRLS Lnet/minecraft/unmapped/C_rinmcaxy;
@@ -177,7 +177,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 2 slot
 	METHOD m_dickaawl getPrimeAdversary ()Lnet/minecraft/unmapped/C_usxaxydn;
 	METHOD m_dionfoih getWeaponDisableBlockForSeconds ()F
-	METHOD m_dutssgsv getItemUseTime ()I
+	METHOD m_dutssgsv getItemUseTicks ()I
 	METHOD m_dwgcrvhr getBoundingBox (Lnet/minecraft/unmapped/C_ufdjspmk;)Lnet/minecraft/unmapped/C_hbcjzgoe;
 		ARG 1 pose
 	METHOD m_eajivoso isUndead ()Z
@@ -532,7 +532,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_sephwywk dropCustomLoot (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;Z)V
 		ARG 2 source
 		ARG 3 playerKill
-	METHOD m_sffkfemm getItemUseTimeLeft ()I
+	METHOD m_sffkfemm getRemainingItemUseTicks ()I
 	METHOD m_sgvyoptc getFallSound (I)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 1 distance
 	METHOD m_slpipvix isSleepingInBed ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -66,7 +66,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		COMMENT The value is {@value} ticks.
 	FIELD f_ourybxnm EQUIPMENT_KEY Ljava/lang/String;
 	FIELD f_oyncoeen MIN_MOVEMENT_DISTANCE D
-	FIELD f_phnacmet prevBodyYaw F
+	FIELD f_phnacmet lastBodyYaw F
 	FIELD f_pldzhgrb baseAccelerationFactor F
 	FIELD f_prubtnbt activeStatusEffects Ljava/util/Map;
 	FIELD f_pxramaew forwardSpeed F
@@ -92,7 +92,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_uwmbnrvv SLEEPING_POSITION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_uylcptjp TICKS_PER_ELYTRA_FREE_FALL_EVENT I
 	FIELD f_vqbwittz HURT_TIME_KEY Ljava/lang/String;
-	FIELD f_vyoqjjtg prevHeadYaw F
+	FIELD f_vyoqjjtg lastHeadYaw F
 	FIELD f_whufmniy POTION_SWIRLS_AMBIENT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_wpgupxxp upwardSpeed F
 	FIELD f_wziooxmp limbData Lnet/minecraft/unmapped/C_okagbxbh;
@@ -332,7 +332,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_iraseeho getStuckArrowCount ()I
 	METHOD m_isvuhvoe isPartOfGame ()Z
 	METHOD m_itkmziir getMainArm ()Lnet/minecraft/unmapped/C_njjnizsa;
-	METHOD m_itpbamzo playerSecondaryHurtSound (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+	METHOD m_itpbamzo playSecondaryHurtSound (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
 	METHOD m_ixaetezv getEquipSound (Lnet/minecraft/unmapped/C_yuycoehb;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_duiqsjgf;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 1 slot
@@ -617,7 +617,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		COMMENT Returns whether the equipment has changed based on the previous and new values.
 		COMMENT
 		COMMENT @return {@code true} if the equipment has changed, or {@code false} otherwise
-		ARG 1 previousEquipment
+		ARG 1 lastEquipment
 			COMMENT the previous equipment item stack
 		ARG 2 newEquipment
 			COMMENT the new equipment item stack

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -12,11 +12,13 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_ebbqhmet riptideAttackDamage F
 	FIELD f_ebtfxbod stuckArrowTimer I
 	FIELD f_eoqnrfuf SADDLE_SLOT_ID I
+	FIELD f_esgfwzsi LAST_ATTACKED_TIME_KEY Ljava/lang/String;
 	FIELD f_euqvtgsv interpolator Lnet/minecraft/unmapped/C_sdgyrixf;
 	FIELD f_fchmphst defaultMaxHealth I
 	FIELD f_figrybhh noDrag Z
 	FIELD f_fqazkkvr BODY_ARMOR_SLOT_ID I
 	FIELD f_fqkpwpyn handSwingProgress F
+	FIELD f_fymrllzt FALL_FLYING_KEY Ljava/lang/String;
 	FIELD f_gikugpix lastAttackedTicks I
 	FIELD f_gkgtpexp MAX_MOVEMENT_DISTANCE D
 	FIELD f_glylybzo lastDamageTime J
@@ -25,6 +27,9 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_hhueawxl attackingPlayer Lnet/minecraft/unmapped/C_xolbcmjn;
 	FIELD f_hkjqagmp DEFAULT_BABY_SCALE F
 	FIELD f_hoaujqhj handSwingTicks I
+	FIELD f_hzrzyirg BRAIN_KEY Ljava/lang/String;
+	FIELD f_ibzzmlne SLEEPING_POS_KEY Ljava/lang/String;
+	FIELD f_icnsrlwb ATTRIBUTES_KEY Ljava/lang/String;
 	FIELD f_iiiqnngu SPRINTING_SPEED_BOOST Lnet/minecraft/unmapped/C_hdbqsqsm;
 	FIELD f_iismerxm ACTIVE_EFFECTS_KEY Ljava/lang/String;
 	FIELD f_isuahutr jumpingCooldown I
@@ -49,6 +54,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_mikwhxdg skipExperienceDrop Z
 	FIELD f_mjweoijp POTION_SWIRLS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_mlsykvgi absorptionAmount F
+	FIELD f_nbuqorzq DEATH_TIME_KEY Ljava/lang/String;
 	FIELD f_noitvgvb LARGE_HAT_RENDER_CULLING_SIZE F
 	FIELD f_noizhvzb BASE_JUMP_COEFFICIENT F
 	FIELD f_obgdercz HAND_SLOT_ID_OFFSET I
@@ -58,6 +64,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_oqcyctiq DEATH_DURATION I
 		COMMENT Represents the duration in ticks before this entity is removed due to death.
 		COMMENT The value is {@value} ticks.
+	FIELD f_ourybxnm EQUIPMENT_KEY Ljava/lang/String;
 	FIELD f_oyncoeen MIN_MOVEMENT_DISTANCE D
 	FIELD f_phnacmet prevBodyYaw F
 	FIELD f_pldzhgrb baseAccelerationFactor F
@@ -80,8 +87,11 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_tzduhzwg SPRINTING_SPEED_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_uaqhrjbe maxHurtTime I
 	FIELD f_ubbibrmk brain Lnet/minecraft/unmapped/C_rjqjaxef;
+	FIELD f_uobaqaic HEALTH_KEY Ljava/lang/String;
+	FIELD f_urwjjisr attackingPlayerCooldown I
 	FIELD f_uwmbnrvv SLEEPING_POSITION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_uylcptjp TICKS_PER_ELYTRA_FREE_FALL_EVENT I
+	FIELD f_vqbwittz HURT_TIME_KEY Ljava/lang/String;
 	FIELD f_vyoqjjtg prevHeadYaw F
 	FIELD f_whufmniy POTION_SWIRLS_AMBIENT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_wpgupxxp upwardSpeed F
@@ -97,12 +107,17 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	FIELD f_zzxchzob equipment Lnet/minecraft/unmapped/C_okmgcumg;
 	FIELD f_zzzdmler OFF_HAND_ACTIVE_FLAG I
 	METHOD m_aabhytmz clearSleepingPosition ()V
+	METHOD m_aegnyfmv (Lnet/minecraft/unmapped/C_cohbwqne;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 attribute
+		ARG 2 modifier
 	METHOD m_almxocpv hasNoDrag ()Z
 	METHOD m_alyudxll tickMovement ()V
 	METHOD m_anszxika getSoundPitch ()F
+	METHOD m_anwgpyrb getAttackingPlayerCooldown ()I
 	METHOD m_armeddpk getDamageTracker ()Lnet/minecraft/unmapped/C_xkhemiqp;
 	METHOD m_astmyzdc getHand (Lnet/minecraft/unmapped/C_laxmzoqs;)Lnet/minecraft/unmapped/C_yuycoehb;
 		ARG 0 hand
+	METHOD m_awjjnbkg isJumping ()Z
 	METHOD m_awmtskvv getAccelerationFactor (F)F
 		ARG 1 slipperiness
 	METHOD m_axkhmdzu getDeathSound ()Lnet/minecraft/unmapped/C_avavozay;
@@ -128,10 +143,12 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_bkfxmcie damageArmor (Lnet/minecraft/unmapped/C_sbxfkpyv;F)V
 		ARG 1 source
 		ARG 2 amount
+	METHOD m_bnkehtdf setAttackingPlayer (Lnet/minecraft/unmapped/C_jzrpycqo;I)V
 	METHOD m_bowysnou applyStatusEffectToPassengers (Lnet/minecraft/unmapped/C_wpfizwve;)V
 		ARG 1 effect
 	METHOD m_bqffyrlc consumeItem ()V
 	METHOD m_btxmjhfy clearPotionSwirls ()V
+	METHOD m_bvcwrmzc stopFallFlying ()V
 	METHOD m_bwbyqdts getLeaningPitch (F)F
 		ARG 1 tickDelta
 	METHOD m_bxkzqslp getArrowType (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
@@ -144,6 +161,8 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_cnzsqyai jump ()V
 	METHOD m_crvwylmv setAbsorptionAmount (F)V
 		ARG 1 amount
+	METHOD m_ctanrimv takeKnockbackFrom (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)V
+		ARG 2 knocker
 	METHOD m_ctdiailf containsOnlyAmbientEffects (Ljava/util/Collection;)Z
 		ARG 0 effects
 	METHOD m_cwcitqpe canPickUpLoot ()Z
@@ -152,10 +171,12 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 1 attackedEntity
 	METHOD m_ddtvzuuf getStackInHand (Lnet/minecraft/unmapped/C_laxmzoqs;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 1 hand
+	METHOD m_dfzdmnfp addDrownParticles ()V
 	METHOD m_dgbunafc onEquippedItemBroken (Lnet/minecraft/unmapped/C_vorddnax;Lnet/minecraft/unmapped/C_yuycoehb;)V
 		ARG 1 item
 		ARG 2 slot
 	METHOD m_dickaawl getPrimeAdversary ()Lnet/minecraft/unmapped/C_usxaxydn;
+	METHOD m_dionfoih getWeaponDisableBlockForSeconds ()F
 	METHOD m_dutssgsv getItemUseTime ()I
 	METHOD m_dwgcrvhr getBoundingBox (Lnet/minecraft/unmapped/C_ufdjspmk;)Lnet/minecraft/unmapped/C_hbcjzgoe;
 		ARG 1 pose
@@ -163,6 +184,8 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_eehgexpm travelInAir (Lnet/minecraft/unmapped/C_vgpupfxx;)V
 		ARG 1 movementInput
 	METHOD m_eerxjifd removePowderSnowSlow ()V
+	METHOD m_egorimwe (Ljava/lang/String;)V
+		ARG 1 team
 	METHOD m_ejiuyguk isFallFlying ()Z
 	METHOD m_eljjwntg setStatusEffect (Lnet/minecraft/unmapped/C_wpfizwve;Lnet/minecraft/unmapped/C_astfners;)V
 		COMMENT Sets a status effect in this entity.
@@ -179,6 +202,24 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 			COMMENT the effect to set
 		ARG 2 source
 			COMMENT the source entity or {@code null} for non-entity sources
+	METHOD m_emvhacmb isSeenBy (Lnet/minecraft/unmapped/C_usxaxydn;DZZ[D)Z
+		COMMENT @return {@code true} if the passed {@code entity} sees this entity,
+		COMMENT or {@code false} otherwise
+		ARG 1 entity
+			COMMENT the entity to check
+		ARG 2 tolerance
+			COMMENT the maximum allowable angle between the passed {@code entity}'s
+			COMMENT rotation and the vector between the entities
+		ARG 4 accountForDistance
+			COMMENT whether to reduce the {@code tolerance} based on distance
+		ARG 5 visualShape
+			COMMENT whether to check the passed {@code entity}'s
+			COMMENT {@link net.minecraft.world.RaycastContext.ShapeType#VISUAL VISUAL} shape
+			COMMENT instead of its
+			COMMENT {@link net.minecraft.world.RaycastContext.ShapeType#COLLIDER COLLIDER} shape
+		ARG 6 eyeYsToCheck
+			COMMENT eye Ys that should be checked;
+			COMMENT the first that results in a vector within the tolerance will be used
 	METHOD m_eobwecax dropXp (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 2 attacker
 	METHOD m_epkzhkqg deserializeBrain (Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/unmapped/C_rjqjaxef;
@@ -192,6 +233,8 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_fdrozcta getFallSounds ()Lnet/minecraft/unmapped/C_usxaxydn$C_krioeiaq;
 	METHOD m_fgegzwmf canFallFly ()Z
 	METHOD m_fgldaguj getActiveHand ()Lnet/minecraft/unmapped/C_laxmzoqs;
+	METHOD m_fjswixhk (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_nzsnkdtl$C_oqhigtaq;)Lnet/minecraft/unmapped/C_nzsnkdtl;
+		ARG 2 loot
 	METHOD m_fnlaimtj tickActiveItemStack ()V
 	METHOD m_fpapzmyw onRemoval (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_astfners$C_emmohndu;)V
 		ARG 2 reason
@@ -243,14 +286,21 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_hbdaqklu canBreatheInWater ()Z
 	METHOD m_hcwncupw setJumping (Z)V
 		ARG 1 jumping
+	METHOD m_hcxskeix knockBack (Lnet/minecraft/unmapped/C_usxaxydn;)V
+		ARG 1 knockee
 	METHOD m_hgmzgyvy shouldAlwaysDropXp ()Z
 		COMMENT Returns if this entity may always drop experience, skipping any
 		COMMENT other checks.
 		COMMENT
 		COMMENT @see #dropXp(ServerWorld, Entity)
 		COMMENT @see #getXpToDrop(ServerWorld, Entity)
+	METHOD m_hiejfrku setAttackingPlayer (Ljava/util/UUID;I)V
+		ARG 1 player
 	METHOD m_hiwasxnu shouldDropLoot ()Z
 	METHOD m_hljdomqx canTakeDamage ()Z
+	METHOD m_hmhyfumi trySetAttackingPlayer (Lnet/minecraft/unmapped/C_sbxfkpyv;)Lnet/minecraft/unmapped/C_jzrpycqo;
+		COMMENT @return the attacking player, or {@code null} if there isn't one
+		ARG 1 source
 	METHOD m_hnmeqaaj applyEnchantmentsToDamage (Lnet/minecraft/unmapped/C_sbxfkpyv;F)F
 		ARG 1 source
 		ARG 2 amount
@@ -278,9 +328,12 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 2 amount
 	METHOD m_ikaguqst getStingerCount ()I
 	METHOD m_ikpxdkmx stopUsingItem ()V
+	METHOD m_ilaqqhpm flyTravel (Lnet/minecraft/unmapped/C_vgpupfxx;F)V
 	METHOD m_iraseeho getStuckArrowCount ()I
 	METHOD m_isvuhvoe isPartOfGame ()Z
 	METHOD m_itkmziir getMainArm ()Lnet/minecraft/unmapped/C_njjnizsa;
+	METHOD m_itpbamzo playerSecondaryHurtSound (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+		ARG 1 source
 	METHOD m_ixaetezv getEquipSound (Lnet/minecraft/unmapped/C_yuycoehb;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_duiqsjgf;)Lnet/minecraft/unmapped/C_cjzoxshv;
 		ARG 1 slot
 		ARG 3 component
@@ -351,6 +404,9 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		COMMENT
 		COMMENT <p>This checks both the entity's main and off hand.
 		ARG 1 predicate
+	METHOD m_mqcthciu (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 attribute
+		ARG 2 modifier
 	METHOD m_mzepiaxw getControlledMovementInput (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		COMMENT Returns the movement input when this entity is controlled by a player.
 		COMMENT
@@ -414,7 +470,10 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_pljlrlsh generateShearingLoot (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_sddaxwyk;Ljava/util/function/BiConsumer;)V
 	METHOD m_pumlpncf getJumpBoostVelocityModifier ()F
 	METHOD m_pusvfpox createBrainProfile ()Lnet/minecraft/unmapped/C_rjqjaxef$C_liifzsnq;
+	METHOD m_pwaxmdsu getEffectBlendFactor (Lnet/minecraft/unmapped/C_cjzoxshv;F)F
 	METHOD m_qhbjdevp getMaxRelativeHeadRotation ()F
+	METHOD m_qhfzlnma hasLineOfSight (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_uyikqwzv$C_kuslmwpu;Lnet/minecraft/unmapped/C_uyikqwzv$C_krdrvutw;D)Z
+		ARG 4 entityEyeY
 	METHOD m_qjawpswz getBaseXpDropped (Lnet/minecraft/unmapped/C_bdwnwhiu;)I
 	METHOD m_qlumoklh onDismounted (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 vehicle
@@ -440,10 +499,18 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 		ARG 1 oldSpeed
 		ARG 3 newSpeed
 	METHOD m_redjlchk wakeUp ()V
+	METHOD m_rgsrpqxm (Lnet/minecraft/unmapped/C_oivssbvb;)Lcom/mojang/serialization/Dynamic;
+		ARG 0 nbt
 	METHOD m_rimpghsg getArmorVisibility ()F
+	METHOD m_rjyswvye flyTravel (Lnet/minecraft/unmapped/C_vgpupfxx;FFF)V
+		ARG 1 movementInput
+		ARG 2 waterAccelerationFactor
+		ARG 3 lavaAccelerationFactor
+		ARG 4 defaultAccelerationFactor
 	METHOD m_rkacnhvq generateLoot (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Function;Ljava/util/function/BiConsumer;)Z
 		ARG 3 buildParameters
 		ARG 4 lootAction
+	METHOD m_rnhwpyqp tickMovementInput ()V
 	METHOD m_rtgyxdad shouldDropXp ()Z
 		COMMENT Returns if this entity should drop experience on death when the {@linkplain
 		COMMENT net.minecraft.world.GameRules#DO_MOB_LOOT doMobLoot} game rule is
@@ -518,13 +585,18 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_unmnupmt applyDamage (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;F)V
 		ARG 2 source
 		ARG 3 amount
+		ARG 10 unabsorbedAmount
 	METHOD m_urjobhnr tickHandSwing ()V
+	METHOD m_uscjkqfc setAttackingPlayerImpl (Lnet/minecraft/unmapped/C_xolbcmjn;I)V
+		ARG 1 player
+		ARG 2 cooldown
 	METHOD m_uuypiexz isClimbing ()Z
 	METHOD m_uwysofda updateLimbs (Z)V
 		ARG 1 flutter
 	METHOD m_uytukmik isSleeping ()Z
 	METHOD m_uzfdrlrs clampScale (F)F
 		ARG 1 scale
+	METHOD m_vcfkshuj getLuck ()F
 	METHOD m_vchrqjlb addStatusEffect (Lnet/minecraft/unmapped/C_wpfizwve;)Z
 		COMMENT Adds a status effect to this entity without specifying a source entity.
 		COMMENT
@@ -564,13 +636,18 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_wdmfvspp getMaxHealth ()F
 	METHOD m_wehlnhpj getHandSwingProgress (F)F
 		ARG 1 tickDelta
+	METHOD m_wgfxiyby (DLnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		ARG 2 collisionPos
 	METHOD m_whvujbsh dropInventory (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
 	METHOD m_widuipxk getAttributes ()Lnet/minecraft/unmapped/C_cohbwqne;
+	METHOD m_wjttxona getAttackingPlayer ()Lnet/minecraft/unmapped/C_jzrpycqo;
 	METHOD m_wjvypezh getFallFlyingTicks ()I
 	METHOD m_wkgrdcha fallFlyTravel (Lnet/minecraft/unmapped/C_vgpupfxx;)V
 	METHOD m_wmvelibz isHoldingOntoLadder ()Z
 		COMMENT @return {@code true} if this entity should not lose height while in a climbing state
 		COMMENT @see net.minecraft.entity.LivingEntity
+	METHOD m_wnnqsiaa setAttackerIfAngering (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+		ARG 1 source
 	METHOD m_wpnkklez travelControlled (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_vgpupfxx;)V
 		ARG 1 player
 		ARG 2 input
@@ -649,9 +726,15 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_ztpokzjz getDamageTiltStrength ()F
 	METHOD m_zuisxtbe setStingerCount (I)V
 		ARG 1 stingerCount
+	METHOD m_zvydeaaf (Lnet/minecraft/unmapped/C_nzsnkdtl$C_oqhigtaq;)Lnet/minecraft/unmapped/C_nzsnkdtl;
+		ARG 1 loot
 	METHOD m_zwmydvfv playHurtSound (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
 	METHOD m_zwvabaox getEquippedStack (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_zybxrwui getBlockedDamage (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;F)F
+		COMMENT @return the amount of damage blocked by this entity's
+		COMMENT {@linkplain #getBlockingItem() blocking item}, if any
+		ARG 3 damage
 	CLASS C_krioeiaq FallSounds
 		FIELD f_cuuwofzo big Lnet/minecraft/unmapped/C_avavozay;
 		FIELD f_tnrqvskw small Lnet/minecraft/unmapped/C_avavozay;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -585,6 +585,7 @@ CLASS net/minecraft/unmapped/C_usxaxydn net/minecraft/entity/LivingEntity
 	METHOD m_unmnupmt applyDamage (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;F)V
 		ARG 2 source
 		ARG 3 amount
+		ARG 8 postAbsorptionAmount
 		ARG 10 unabsorbedAmount
 	METHOD m_urjobhnr tickHandSwing ()V
 	METHOD m_uscjkqfc setAttackingPlayerImpl (Lnet/minecraft/unmapped/C_xolbcmjn;I)V

--- a/mappings/net/minecraft/entity/ReportingTask.mapping
+++ b/mappings/net/minecraft/entity/ReportingTask.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/unmapped/C_yfpegcpm net/minecraft/entity/ReportingTask
+	FIELD f_hcebkdbk status Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;

--- a/mappings/net/minecraft/entity/ReportingTaskControl.mapping
+++ b/mappings/net/minecraft/entity/ReportingTaskControl.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/unmapped/C_yfpegcpm net/minecraft/entity/ReportingTaskControl
-	FIELD f_hcebkdbk status Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;

--- a/mappings/net/minecraft/entity/ai/FuzzyPositions.mapping
+++ b/mappings/net/minecraft/entity/ai/FuzzyPositions.mapping
@@ -24,10 +24,9 @@ CLASS net/minecraft/unmapped/C_fizxcftr net/minecraft/entity/ai/FuzzyPositions
 		ARG 0 pos
 		ARG 1 maxY
 		ARG 2 condition
-	METHOD m_ihlsjtgu towardTarget (Lnet/minecraft/unmapped/C_hqdayibh;ILnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_ihlsjtgu towardHome (Lnet/minecraft/unmapped/C_hqdayibh;ILnet/minecraft/unmapped/C_rlomrsco;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
 		COMMENT Adjusts the input {@code fuzz} slightly toward the given {@code entity}'s
-		COMMENT {@link net.minecraft.entity.mob.MobEntity#getPositionTarget() position target}
-		COMMENT if it exists.
+		COMMENT {@link net.minecraft.entity.mob.MobEntity#getHome() home} if it exists.
 		ARG 0 entity
 		ARG 1 horizontalRange
 		ARG 3 fuzz

--- a/mappings/net/minecraft/entity/ai/brain/Brain.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/Brain.mapping
@@ -72,7 +72,7 @@ CLASS net/minecraft/unmapped/C_rjqjaxef net/minecraft/entity/ai/brain/Brain
 		ARG 2 entity
 	METHOD m_iispjiqw tickMemories ()V
 	METHOD m_ivmteovz getFirstPossibleNonCoreActivity ()Ljava/util/Optional;
-	METHOD m_izdwevme getOptionalMemory (Lnet/minecraft/unmapped/C_vbbyoqyw;)Ljava/util/Optional;
+	METHOD m_izdwevme getMemoryOrEmpty (Lnet/minecraft/unmapped/C_vbbyoqyw;)Ljava/util/Optional;
 		ARG 1 type
 	METHOD m_labrylud setSchedule (Lnet/minecraft/unmapped/C_txyttymj;)V
 		ARG 1 schedule
@@ -183,6 +183,11 @@ CLASS net/minecraft/unmapped/C_rjqjaxef net/minecraft/entity/ai/brain/Brain
 	CLASS C_ptnuukko
 		METHOD decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
 			ARG 2 map
+		METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 brain
+			ARG 3 builder
+		METHOD m_ftierlki (Lnet/minecraft/unmapped/C_rjqjaxef;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 brain
 		METHOD m_gkpmtevg (Lnet/minecraft/unmapped/C_vbbyoqyw;Lnet/minecraft/unmapped/C_oudplusw;)Lnet/minecraft/unmapped/C_rjqjaxef$C_cxpzmffb;
 			ARG 1 memory
 		METHOD m_oobvoeay (Lnet/minecraft/unmapped/C_vbbyoqyw;)Ljava/util/stream/Stream;

--- a/mappings/net/minecraft/entity/ai/brain/EntityLookTarget.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/EntityLookTarget.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_xardpbul net/minecraft/entity/ai/brain/EntityLookTarget
 	FIELD f_mazkrbvl useEyeHeight Z
+	FIELD f_mechtdph useEyeHeightForBlockPos Z
 	FIELD f_ugnpapwv entity Lnet/minecraft/unmapped/C_astfners;
 	METHOD <init> (Lnet/minecraft/unmapped/C_astfners;Z)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/ai/brain/MemoryCondition.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/MemoryCondition.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_brqsauyi net/minecraft/entity/ai/brain/MemoryCond
 	METHOD m_cyqhacmu memory ()Lnet/minecraft/unmapped/C_vbbyoqyw;
 	METHOD m_hpvhaael getState ()Lnet/minecraft/unmapped/C_nbxzedfr;
 	METHOD m_jpmatyzp createAccessor (Lnet/minecraft/unmapped/C_rjqjaxef;Ljava/util/Optional;)Lnet/minecraft/unmapped/C_ujlmiamh;
+		ARG 2 value
 	CLASS C_hgylnsbj Registered
 	CLASS C_kkgwskag Absent
 	CLASS C_svzyywmd Present

--- a/mappings/net/minecraft/entity/ai/brain/sensor/NearestVisibleLivingEntitySensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/NearestVisibleLivingEntitySensor.mapping
@@ -1,7 +1,13 @@
 CLASS net/minecraft/unmapped/C_fujyrqpk net/minecraft/entity/ai/brain/sensor/NearestVisibleLivingEntitySensor
 	METHOD m_asbxzxwc getNearestVisibleLivingEntity (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/util/Optional;
 		ARG 2 entity
+	METHOD m_bmsoiqff (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_bfzvfpbw;)Ljava/util/Optional;
+		ARG 3 visibles
+	METHOD m_bqlvnvav (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 3 visible
 	METHOD m_hzuzyjjb getOutputMemoryModule ()Lnet/minecraft/unmapped/C_vbbyoqyw;
 	METHOD m_kxxhvjsc getVisibleLivingEntities (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/util/Optional;
 		ARG 1 entity
 	METHOD m_yivtvstz matches (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 entity
+		ARG 3 other

--- a/mappings/net/minecraft/entity/ai/brain/task/AdmireItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/AdmireItemTask.mapping
@@ -1,8 +1,7 @@
 CLASS net/minecraft/unmapped/C_hgldlkgv net/minecraft/entity/ai/brain/task/AdmireItemTask
-	METHOD m_ggqndzeg run (I)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_ggqndzeg create (I)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 duration
 	METHOD m_hjvkwdro (ILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 builder
 	METHOD m_nkarzwny (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
 		ARG 5 entity
 		ARG 6 time

--- a/mappings/net/minecraft/entity/ai/brain/task/AdmireItemTimeLimitTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/AdmireItemTimeLimitTask.mapping
@@ -1,12 +1,11 @@
 CLASS net/minecraft/unmapped/C_ewjlpjzq net/minecraft/entity/ai/brain/task/AdmireItemTimeLimitTask
-	METHOD m_kwfdtpqu run (II)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_kwfdtpqu create (II)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 cooldown
 		ARG 1 timeLimit
 	METHOD m_scrkzomw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
 		ARG 7 entity
 		ARG 8 time
 	METHOD m_sfrvvmai (IILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 builder
 	METHOD m_vjlbrppb (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;IILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
 		ARG 3 admiringItem
 		ARG 4 nearestVisibleWantedItem

--- a/mappings/net/minecraft/entity/ai/brain/task/AttackTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/AttackTask.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/unmapped/C_bkmohoxx net/minecraft/entity/ai/brain/task/AttackTask
+	METHOD m_duzvnuyj (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 walkTarget
+		ARG 4 lookTarget
+		ARG 5 attackTarget
+		ARG 6 visibleMobs
+	METHOD m_hthfeekd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
+		ARG 8 time
 	METHOD m_rqysdgvh create (IF)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 distance
 		ARG 1 forwardMovement
 	METHOD m_zuhehwza (IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/BreezeLongJumpTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/BreezeLongJumpTask.mapping
@@ -25,3 +25,5 @@ CLASS net/minecraft/unmapped/C_eadqehug net/minecraft/entity/ai/brain/task/Breez
 		ARG 1 target
 	METHOD m_xkiobfxg canJumpFromPos (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_nqresjkz;)Z
 		ARG 1 breeze
+	METHOD m_zosgcaeb (DLnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		ARG 2 jumpVelocity

--- a/mappings/net/minecraft/entity/ai/brain/task/BreezeShootTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/BreezeShootTask.mapping
@@ -9,3 +9,5 @@ CLASS net/minecraft/unmapped/C_jqoprjuo net/minecraft/entity/ai/brain/task/Breez
 	METHOD m_uhzxmrhj isTargetWithinRange (Lnet/minecraft/unmapped/C_nqresjkz;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 breeze
 		ARG 1 target
+	METHOD m_zodyfnzz (Lnet/minecraft/unmapped/C_nqresjkz;Ljava/lang/Boolean;)Ljava/lang/Boolean;
+		ARG 1 inRange

--- a/mappings/net/minecraft/entity/ai/brain/task/CompositeTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/CompositeTask.mapping
@@ -33,5 +33,19 @@ CLASS net/minecraft/unmapped/C_qokdffvy net/minecraft/entity/ai/brain/task/Compo
 			ARG 3 listModifier
 		METHOD m_cfvpqbid apply (Lnet/minecraft/unmapped/C_zcaovjhs;)V
 			ARG 1 list
+		METHOD m_rjlrigir (Lnet/minecraft/unmapped/C_zcaovjhs;)V
+			ARG 0 list
 	CLASS C_mvwnxrlj RunMode
 		METHOD m_zufaooom run (Ljava/util/stream/Stream;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
+			ARG 1 controls
+			ARG 4 time
+		CLASS C_eapepcvh
+			METHOD m_mffacnuo (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;JLnet/minecraft/unmapped/C_mdnathub;)V
+				ARG 4 control
+			METHOD m_pzuqfcqr (Lnet/minecraft/unmapped/C_mdnathub;)Z
+				ARG 0 control
+		CLASS C_jwxfzjby
+			METHOD m_lztkpeyo (Lnet/minecraft/unmapped/C_mdnathub;)Z
+				ARG 0 control
+			METHOD m_zmoftbkb (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;JLnet/minecraft/unmapped/C_mdnathub;)Z
+				ARG 4 control

--- a/mappings/net/minecraft/entity/ai/brain/task/CompositeTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/CompositeTask.mapping
@@ -37,15 +37,15 @@ CLASS net/minecraft/unmapped/C_qokdffvy net/minecraft/entity/ai/brain/task/Compo
 			ARG 0 list
 	CLASS C_mvwnxrlj RunMode
 		METHOD m_zufaooom run (Ljava/util/stream/Stream;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-			ARG 1 controls
+			ARG 1 tasks
 			ARG 4 time
 		CLASS C_eapepcvh
 			METHOD m_mffacnuo (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;JLnet/minecraft/unmapped/C_mdnathub;)V
-				ARG 4 control
+				ARG 4 task
 			METHOD m_pzuqfcqr (Lnet/minecraft/unmapped/C_mdnathub;)Z
-				ARG 0 control
+				ARG 0 task
 		CLASS C_jwxfzjby
 			METHOD m_lztkpeyo (Lnet/minecraft/unmapped/C_mdnathub;)Z
-				ARG 0 control
+				ARG 0 task
 			METHOD m_zmoftbkb (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;JLnet/minecraft/unmapped/C_mdnathub;)Z
-				ARG 4 control
+				ARG 4 task

--- a/mappings/net/minecraft/entity/ai/brain/task/ContinuableTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ContinuableTask.mapping
@@ -1,0 +1,40 @@
+CLASS net/minecraft/unmapped/C_wbtjxfbq net/minecraft/entity/ai/brain/task/ContinuableTask
+	FIELD f_kbnpijts minRunTime I
+	FIELD f_nutokbfq DEFAULT_RUN_TIME I
+	FIELD f_obmumrdg requiredMemoryStates Ljava/util/Map;
+	FIELD f_rfkjmatw endTime J
+	FIELD f_slgvphcl maxRunTime I
+	FIELD f_tijqdxos status Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 requiredMemoryState
+	METHOD <init> (Ljava/util/Map;I)V
+		ARG 1 requiredMemoryState
+		ARG 2 runTime
+	METHOD <init> (Ljava/util/Map;II)V
+		ARG 1 requiredMemoryState
+		ARG 2 minRunTime
+		ARG 3 maxRunTime
+	METHOD m_copsxmjv finishRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 time
+	METHOD m_eghfkoeo isTimeLimitExceeded (J)Z
+		ARG 1 time
+	METHOD m_jiotgmjk keepRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 time
+	METHOD m_pwowjghk shouldRun (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 world
+		ARG 2 entity
+	METHOD m_thxoqxcz run (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 time
+	METHOD m_tzzxzprb hasRequiredMemoryState (Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 entity
+	METHOD m_xvrvizlg shouldKeepRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 time
+	CLASS C_sqbcjfsz Status

--- a/mappings/net/minecraft/entity/ai/brain/task/DefeatTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/DefeatTargetTask.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/unmapped/C_hmsywjnp net/minecraft/entity/ai/brain/task/DefeatTargetTask
+	METHOD m_dtimtqhm (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 9 time
+	METHOD m_osstxyiv (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/BiPredicate;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 attackTarget
+		ARG 4 angryAt
+		ARG 5 celebrateLocation
+		ARG 6 dancing
 	METHOD m_oxvjyrzg (Ljava/util/function/BiPredicate;ILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 instance
 	METHOD m_pwvgjftm create (ILjava/util/function/BiPredicate;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 celebrationDuration
 		ARG 1 predicate

--- a/mappings/net/minecraft/entity/ai/brain/task/EndRaidTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/EndRaidTask.mapping
@@ -1,7 +1,5 @@
 CLASS net/minecraft/unmapped/C_shyxioch net/minecraft/entity/ai/brain/task/EndRaidTask
 	METHOD m_naysbdzt (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 1 entity
 		ARG 2 time
 	METHOD m_onjftzng (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_vzdpqinm create ()Lnet/minecraft/unmapped/C_mdnathub;

--- a/mappings/net/minecraft/entity/ai/brain/task/FindEntityTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindEntityTask.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_vqdfssau net/minecraft/entity/ai/brain/task/FindEntityTask
+	METHOD m_dkvlizpn (Lnet/minecraft/unmapped/C_usxaxydn;ILjava/util/function/Predicate;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 3 visibleEntity
 	METHOD m_dtlwshua create (Lnet/minecraft/unmapped/C_ogavsvbr;ILjava/util/function/Predicate;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;FI)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 type
 		ARG 1 maxDistance
@@ -7,13 +9,18 @@ CLASS net/minecraft/unmapped/C_vqdfssau net/minecraft/entity/ai/brain/task/FindE
 		ARG 4 target
 		ARG 5 speed
 		ARG 6 completionRange
+	METHOD m_edewnxzd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;Ljava/util/function/Predicate;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 12 time
+	METHOD m_hdjuuocg (Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_usxaxydn;)V
+		ARG 5 visibleEntity
 	METHOD m_jimlvide (Lnet/minecraft/unmapped/C_ogavsvbr;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 2 entity
-	METHOD m_lbnphhlh run (Lnet/minecraft/unmapped/C_ogavsvbr;ILnet/minecraft/unmapped/C_vbbyoqyw;FI)Lnet/minecraft/unmapped/C_mdnathub;
-		ARG 0 create
+	METHOD m_lbnphhlh create (Lnet/minecraft/unmapped/C_ogavsvbr;ILnet/minecraft/unmapped/C_vbbyoqyw;FI)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_rzvmcemc (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;Ljava/util/function/Predicate;IFILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 6 targetMemory
+		ARG 7 lookTarget
+		ARG 8 walkTarget
+		ARG 9 visibleMobs
 	METHOD m_tlmatsbx (Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 0 entity
 	METHOD m_ttqiijvp (Lnet/minecraft/unmapped/C_vbbyoqyw;Ljava/util/function/Predicate;Ljava/util/function/Predicate;IFILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 		ARG 6 instance
 	METHOD m_xontlhqp (Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 0 entity

--- a/mappings/net/minecraft/entity/ai/brain/task/FindEntityTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindEntityTask.mapping
@@ -22,5 +22,4 @@ CLASS net/minecraft/unmapped/C_vqdfssau net/minecraft/entity/ai/brain/task/FindE
 		ARG 9 visibleMobs
 	METHOD m_tlmatsbx (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 	METHOD m_ttqiijvp (Lnet/minecraft/unmapped/C_vbbyoqyw;Ljava/util/function/Predicate;Ljava/util/function/Predicate;IFILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 6 instance
 	METHOD m_xontlhqp (Lnet/minecraft/unmapped/C_usxaxydn;)Z

--- a/mappings/net/minecraft/entity/ai/brain/task/FindInteractionTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindInteractionTargetTask.mapping
@@ -1,6 +1,13 @@
 CLASS net/minecraft/unmapped/C_doxrjtcf net/minecraft/entity/ai/brain/task/FindInteractionTargetTask
+	METHOD m_dkngexhr (Lnet/minecraft/unmapped/C_usxaxydn;ILnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 3 visibleEntity
 	METHOD m_gvbzrnbg create (Lnet/minecraft/unmapped/C_ogavsvbr;I)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 type
 		ARG 1 maxDistance
+	METHOD m_jdbpmjir (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 8 time
+	METHOD m_uefgabbw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 lookTarget
+		ARG 4 interactionTarget
+		ARG 5 visibleMobs
 	METHOD m_xqghkjzu (ILnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/FindLandNearWaterTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindLandNearWaterTask.mapping
@@ -3,4 +3,9 @@ CLASS net/minecraft/unmapped/C_ixqqkgne net/minecraft/entity/ai/brain/task/FindL
 		ARG 0 range
 		ARG 1 speed
 	METHOD m_sprzxkhq (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
+	METHOD m_tgknlpfn (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 attackTarget
+		ARG 4 walkTarget
+		ARG 5 lookTarget
+	METHOD m_wslfhnwa (Lorg/apache/commons/lang3/mutable/MutableLong;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 7 time

--- a/mappings/net/minecraft/entity/ai/brain/task/FindLandTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindLandTask.mapping
@@ -1,7 +1,12 @@
 CLASS net/minecraft/unmapped/C_kohupgpp net/minecraft/entity/ai/brain/task/FindLandTask
 	FIELD f_qcdommed SEARCH_COOLDOWN_TICKS I
-	METHOD m_qjvvcudh run (IF)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_laskxqwd (Lorg/apache/commons/lang3/mutable/MutableLong;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 7 time
+	METHOD m_qegzwilp (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 attackTarget
+		ARG 4 walkTarget
+		ARG 5 lookTarget
+	METHOD m_qjvvcudh create (IF)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 range
 		ARG 1 speed
 	METHOD m_vvhptbro (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/FindPointOfInterestTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindPointOfInterestTask.mapping
@@ -1,10 +1,39 @@
 CLASS net/minecraft/unmapped/C_qbrxxpsd net/minecraft/entity/ai/brain/task/FindPointOfInterestTask
 	FIELD f_okuvailp POI_SORTING_RADIUS I
+	METHOD m_cildspxo (Lnet/minecraft/unmapped/C_vbbyoqyw;Lnet/minecraft/unmapped/C_yfpegcpm;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
+		ARG 2 instance
+	METHOD m_eugjqtmu create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;ZLjava/util/Optional;Ljava/util/function/BiPredicate;)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 1 poiPosition
+	METHOD m_fmpndpxn (JLit/unimi/dsi/fastutil/longs/Long2ObjectMap$Entry;)Z
+		ARG 2 entry
+	METHOD m_gaafkemy (Lnet/minecraft/unmapped/C_uegwgivt;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/util/Optional;Lnet/minecraft/unmapped/C_hqdayibh;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 8 type
+	METHOD m_ikkgtcaj (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;Ljava/lang/Byte;)V
+		ARG 2 status
+	METHOD m_kqqcpbzp (Lnet/minecraft/unmapped/C_vbbyoqyw;ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Ljava/util/Optional;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 	METHOD m_ktqnxtbb create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;ZLjava/util/Optional;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 1 poiPosition
+	METHOD m_mcxtafbd (Lnet/minecraft/unmapped/C_bdwnwhiu;JJ)Lnet/minecraft/unmapped/C_qbrxxpsd$C_rmyfchlj;
+		ARG 3 ignored
 	METHOD m_ptkjaiyi findPathToPoi (Lnet/minecraft/unmapped/C_dxkfswlz;Ljava/util/Set;)Lnet/minecraft/unmapped/C_motipebf;
 		ARG 0 entity
 		ARG 1 pois
+	METHOD m_pymxkvzh create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;Lnet/minecraft/unmapped/C_vbbyoqyw;ZLjava/util/Optional;Ljava/util/function/BiPredicate;)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 0 typePredicate
+		ARG 1 poiPosition
+		ARG 2 potentialPoiPosition
+		ARG 3 requireAdult
+		ARG 4 foundStatus
+		ARG 5 posPredicate
+	METHOD m_tahjpjtg (Lnet/minecraft/unmapped/C_yfpegcpm;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 ignored
+	METHOD m_tqxbqzdg (ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/Optional;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 9 time
+	METHOD m_wlpjeznq (ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Ljava/util/Optional;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 6 potentialPoPositionMemory
+	METHOD m_yoxutktg (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		ARG 1 ignored
+		ARG 2 blockPos
 	CLASS C_rmyfchlj RetryMarker
 		FIELD f_cjiifgsn previousAttemptAt J
 		FIELD f_muxpyqdq random Lnet/minecraft/unmapped/C_rlomrsco;

--- a/mappings/net/minecraft/entity/ai/brain/task/FindPointOfInterestTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindPointOfInterestTask.mapping
@@ -10,7 +10,6 @@ CLASS net/minecraft/unmapped/C_qbrxxpsd net/minecraft/entity/ai/brain/task/FindP
 		ARG 8 type
 	METHOD m_ikkgtcaj (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;Ljava/lang/Byte;)V
 		ARG 2 status
-	METHOD m_kqqcpbzp (Lnet/minecraft/unmapped/C_vbbyoqyw;ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Ljava/util/Optional;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 	METHOD m_ktqnxtbb create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;ZLjava/util/Optional;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 1 poiPosition
 	METHOD m_mcxtafbd (Lnet/minecraft/unmapped/C_bdwnwhiu;JJ)Lnet/minecraft/unmapped/C_qbrxxpsd$C_rmyfchlj;
@@ -30,7 +29,7 @@ CLASS net/minecraft/unmapped/C_qbrxxpsd net/minecraft/entity/ai/brain/task/FindP
 	METHOD m_tqxbqzdg (ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/Optional;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
 		ARG 9 time
 	METHOD m_wlpjeznq (ZLorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Ljava/util/Optional;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
-		ARG 6 potentialPoPositionMemory
+		ARG 6 potentialPoiPositionMemory
 	METHOD m_yoxutktg (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 ignored
 		ARG 2 blockPos

--- a/mappings/net/minecraft/entity/ai/brain/task/FindWalkTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FindWalkTargetTask.mapping
@@ -2,8 +2,13 @@ CLASS net/minecraft/unmapped/C_sidddyqp net/minecraft/entity/ai/brain/task/FindW
 	FIELD f_datddztc MIN_RUN_TIME I
 	FIELD f_wrlvhemy MAX_RUN_TIME I
 	METHOD m_eyadkjfn (IIFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
 	METHOD m_jsdyxmyl create (F)Lnet/minecraft/unmapped/C_yfpegcpm;
+	METHOD m_rbuvmpzo (IILnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 6 time
+	METHOD m_wdvzroze (IIFLnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 walkTarget
+	METHOD m_wlgpsoxg (FLnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_ajnxjhqd;
+		ARG 1 pos
 	METHOD m_xqtsekmk create (FII)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 walkSpeed
 		ARG 1 horizontalRange

--- a/mappings/net/minecraft/entity/ai/brain/task/FollowMobTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/FollowMobTask.mapping
@@ -1,16 +1,19 @@
 CLASS net/minecraft/unmapped/C_oqkjspff net/minecraft/entity/ai/brain/task/FollowMobTask
+	METHOD m_afhovabp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 lookTarget
+		ARG 4 visibleMobs
+	METHOD m_agtnnnhc (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 7 time
 	METHOD m_ecixlrjd (Lnet/minecraft/unmapped/C_ormqdxci;Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 1 entity
 	METHOD m_enqpbjhi (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 1 entity
 	METHOD m_hjvosmzc createMatchingSpawnGroup (Lnet/minecraft/unmapped/C_ormqdxci;F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 group
+	METHOD m_llusesjm (Lnet/minecraft/unmapped/C_usxaxydn;FLnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 visibleEntity
 	METHOD m_mxhqnvzy createMatchingType (Lnet/minecraft/unmapped/C_ogavsvbr;F)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 type
 	METHOD m_plzzqcfn (Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 instance
 	METHOD m_twvrmuue (Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 0 entity
 	METHOD m_vwwtwkqe create (F)Lnet/minecraft/unmapped/C_yfpegcpm;
 	METHOD m_xtjussog create (Ljava/util/function/Predicate;F)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 predicate

--- a/mappings/net/minecraft/entity/ai/brain/task/ForgetAngryAtTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ForgetAngryAtTargetTask.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/unmapped/C_todddzvp net/minecraft/entity/ai/brain/task/ForgetAngryAtTargetTask
 	METHOD m_cjyqnutb run ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_hwzqpyhi (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 angryAt
+	METHOD m_qhwbgttq (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 4 time

--- a/mappings/net/minecraft/entity/ai/brain/task/ForgetAttackTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ForgetAttackTargetTask.mapping
@@ -6,12 +6,10 @@ CLASS net/minecraft/unmapped/C_gaizicad net/minecraft/entity/ai/brain/task/Forge
 		ARG 2 forgetIfUnreachable
 	METHOD m_agdthaky cannotReachTarget (Lnet/minecraft/unmapped/C_usxaxydn;Ljava/util/Optional;)Z
 		ARG 0 entity
-		ARG 1 reason
+		ARG 1 since
 	METHOD m_etbjnyqt (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ZLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_gaizicad$C_wwmivdow;Lnet/minecraft/unmapped/C_gaizicad$C_xlpqahis;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
-		ARG 7 entity
 		ARG 8 time
 	METHOD m_gtxqnaiw (ZLnet/minecraft/unmapped/C_gaizicad$C_wwmivdow;Lnet/minecraft/unmapped/C_gaizicad$C_xlpqahis;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
 	METHOD m_nyujuwga create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_pgzxguti (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 entity
@@ -20,9 +18,12 @@ CLASS net/minecraft/unmapped/C_gaizicad net/minecraft/entity/ai/brain/task/Forge
 	METHOD m_tjydfjsu create (Lnet/minecraft/unmapped/C_gaizicad$C_xlpqahis;)Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_vrgvjiup (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ZLnet/minecraft/unmapped/C_gaizicad$C_wwmivdow;Lnet/minecraft/unmapped/C_gaizicad$C_xlpqahis;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
 		ARG 4 attackTarget
-		ARG 5 cannotReachWalkTargetReason
+		ARG 5 cannotReachWalkTargetSince
 	METHOD m_vxfuuftx (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 entity
 		ARG 2 target
 	CLASS C_wwmivdow AttackEndPredicate
 	CLASS C_xlpqahis ForgottenCallback
+		METHOD accept (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/lang/Object;Lnet/minecraft/unmapped/C_usxaxydn;)V
+			ARG 2 forgetter
+			ARG 3 target

--- a/mappings/net/minecraft/entity/ai/brain/task/ForgetBellRingTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ForgetBellRingTask.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_rywbzjic net/minecraft/entity/ai/brain/task/ForgetBellRingTask
 	FIELD f_jewwuxyw MIN_HEARD_BELL_TIME I
+	METHOD m_asqqzfub (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lorg/apache/commons/lang3/mutable/MutableInt;IILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 hidingPlace
+		ARG 5 heardBellTime
+	METHOD m_euctxiyt (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lorg/apache/commons/lang3/mutable/MutableInt;ILnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 8 time
 	METHOD m_kezpbpyb (Lorg/apache/commons/lang3/mutable/MutableInt;IILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
-	METHOD m_saavfyfp run (II)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_saavfyfp create (II)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 maxHiddenSeconds
 		ARG 1 distance

--- a/mappings/net/minecraft/entity/ai/brain/task/ForgetCompletedPointOfInterestTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ForgetCompletedPointOfInterestTask.mapping
@@ -1,9 +1,15 @@
 CLASS net/minecraft/unmapped/C_ydgrguwg net/minecraft/entity/ai/brain/task/ForgetCompletedPointOfInterestTask
 	FIELD f_ugtvjsbq MAX_RANGE I
+	METHOD m_klkwinhk (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 posMemory
 	METHOD m_kvvhxoht isBedOccupiedByOthers (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 entity
-	METHOD m_zavkqnbm run (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_looiwpmp isSleepingVillagerAt (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	METHOD m_pklpwwdz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 5 time
+	METHOD m_wjfbrwmp (Lnet/minecraft/unmapped/C_vbbyoqyw;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
+	METHOD m_zavkqnbm create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 predicate
 		ARG 1 pos

--- a/mappings/net/minecraft/entity/ai/brain/task/ForgetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ForgetTask.mapping
@@ -2,3 +2,7 @@ CLASS net/minecraft/unmapped/C_xfnsqgyk net/minecraft/entity/ai/brain/task/Forge
 	METHOD m_dbbopzeq run (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 predicate
 		ARG 1 run
+	METHOD m_gonqjndh (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 4 time
+	METHOD m_iumycmma (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 runMemory

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToIfNearbyTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToIfNearbyTask.mapping
@@ -7,4 +7,10 @@ CLASS net/minecraft/unmapped/C_brehefpy net/minecraft/entity/ai/brain/task/GoToI
 		ARG 1 walkSpeed
 		ARG 2 maxDistance
 	METHOD m_bjbgzsiq (Lnet/minecraft/unmapped/C_vbbyoqyw;ILorg/apache/commons/lang3/mutable/MutableLong;FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 4 instance
+	METHOD m_mwaqtgvz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILorg/apache/commons/lang3/mutable/MutableLong;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 walkTarget
+		ARG 5 posMemory
+	METHOD m_niwbvcjs (FLnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_ajnxjhqd;
+		ARG 1 target
+	METHOD m_uylrdtgp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILorg/apache/commons/lang3/mutable/MutableLong;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 8 time

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToNearbyPositionTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToNearbyPositionTask.mapping
@@ -1,8 +1,12 @@
 CLASS net/minecraft/unmapped/C_ozzddznn net/minecraft/entity/ai/brain/task/GoToNearbyPositionTask
-	METHOD m_ivikwldh run (Lnet/minecraft/unmapped/C_vbbyoqyw;FII)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_hyamwkjj (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILorg/apache/commons/lang3/mutable/MutableLong;Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 9 time
+	METHOD m_ivikwldh create (Lnet/minecraft/unmapped/C_vbbyoqyw;FII)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 pos
 		ARG 1 speed
 		ARG 2 completionRange
 		ARG 3 maxDistance
+	METHOD m_qkqarohq (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILorg/apache/commons/lang3/mutable/MutableLong;FILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 5 walkTarget
+		ARG 6 posMemory
 	METHOD m_vgddwpaf (Lnet/minecraft/unmapped/C_vbbyoqyw;ILorg/apache/commons/lang3/mutable/MutableLong;FILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 5 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToPointOfInterestTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToPointOfInterestTask.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/unmapped/C_aofhkhvj net/minecraft/entity/ai/brain/task/GoToPointOfInterestTask
+	METHOD m_cgpdzxgr (FILnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 walkTarget
+	METHOD m_pswnyzgs (Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 4 villager
+		ARG 5 time
 	METHOD m_uxiprkky create (FI)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed
 		ARG 1 completionRange

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToRememberedPositionTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToRememberedPositionTask.mapping
@@ -1,19 +1,23 @@
 CLASS net/minecraft/unmapped/C_htymbopt net/minecraft/entity/ai/brain/task/GoToRememberedPositionTask
+	METHOD m_fpkxgsos (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ZLjava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;IFLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 9 time
+	METHOD m_hwtjktgd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ZLjava/util/function/Function;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 5 walkTarget
+		ARG 6 destinationMemory
 	METHOD m_jyuzurxd create (Lnet/minecraft/unmapped/C_vbbyoqyw;FIZLjava/util/function/Function;)Lnet/minecraft/unmapped/C_yfpegcpm;
-		ARG 0 memoryType
+		ARG 0 destination
 		ARG 1 speed
 		ARG 2 range
 		ARG 3 requiresWalkTarget
 		ARG 4 targetPositionGetter
 	METHOD m_krcrejjx (Lnet/minecraft/unmapped/C_vbbyoqyw;ZLjava/util/function/Function;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 5 instance
-	METHOD m_lacjjlmd toBlock (Lnet/minecraft/unmapped/C_vbbyoqyw;FIZ)Lnet/minecraft/unmapped/C_mdnathub;
-		ARG 0 memoryType
+	METHOD m_lacjjlmd createToPos (Lnet/minecraft/unmapped/C_vbbyoqyw;FIZ)Lnet/minecraft/unmapped/C_mdnathub;
+		ARG 0 pos
 		ARG 1 speed
 		ARG 2 range
 		ARG 3 requiresWalkTarget
-	METHOD m_ymnqcwoq toEntity (Lnet/minecraft/unmapped/C_vbbyoqyw;FIZ)Lnet/minecraft/unmapped/C_yfpegcpm;
-		ARG 0 memoryType
+	METHOD m_ymnqcwoq createToEntity (Lnet/minecraft/unmapped/C_vbbyoqyw;FIZ)Lnet/minecraft/unmapped/C_yfpegcpm;
+		ARG 0 entity
 		ARG 1 speed
 		ARG 2 range
 		ARG 3 requiresWalkTarget

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToSecondaryPositionTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToSecondaryPositionTask.mapping
@@ -1,7 +1,14 @@
 CLASS net/minecraft/unmapped/C_klqpupjq net/minecraft/entity/ai/brain/task/GoToSecondaryPositionTask
+	METHOD m_ilifwbfi (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILorg/apache/commons/lang3/mutable/MutableLong;FILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 5 walkTarget
+		ARG 6 secondaryPositionsMemory
+		ARG 7 primaryPositionsMemory
 	METHOD m_jdsyhtbe create (Lnet/minecraft/unmapped/C_vbbyoqyw;FIILnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 secondaryPositions
 		ARG 1 speed
 		ARG 2 completionRange
 		ARG 3 primaryPositionActivationDistance
 		ARG 4 primaryPosition
+	METHOD m_nwewcydm (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;ILorg/apache/commons/lang3/mutable/MutableLong;Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 9 villager
+		ARG 10 time

--- a/mappings/net/minecraft/entity/ai/brain/task/GoToWorkTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoToWorkTask.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/unmapped/C_gklwpqcg net/minecraft/entity/ai/brain/task/GoToWorkTask
+	METHOD m_aicbdsgq (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 potentialJobSite
+		ARG 2 jobSite
+	METHOD m_anhlqtio (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)V
+		ARG 2 profession
+	METHOD m_dptcjvmg (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 4 villager
+		ARG 5 time
 	METHOD m_fooeqyuy (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_spmbrihr (Lnet/minecraft/unmapped/C_cjzoxshv;)Ljava/util/Optional;
+		ARG 0 poiType
 	METHOD m_tnlvczom create ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_vitjpsqk (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_cjzoxshv$C_rjzpeyec;)Z
+		ARG 1 profession

--- a/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTarget.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTarget.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/unmapped/C_iyiccpwt net/minecraft/entity/ai/brain/task/GoTowardsLookTarget
-	METHOD m_dgrcrase create (Ljava/util/function/Predicate;Ljava/util/function/Function;I)Lnet/minecraft/unmapped/C_yfpegcpm;
-		ARG 0 predicate
-		ARG 1 entitySpeedGetter
-		ARG 2 completionRange
-	METHOD m_ftybsvym create (FI)Lnet/minecraft/unmapped/C_yfpegcpm;
-		ARG 0 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTargetTask.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/unmapped/C_iyiccpwt net/minecraft/entity/ai/brain/task/GoTowardsLookTargetTask
+	METHOD m_dgrcrase create (Ljava/util/function/Predicate;Ljava/util/function/Function;I)Lnet/minecraft/unmapped/C_yfpegcpm;
+		ARG 0 predicate
+		ARG 1 entitySpeedGetter
+		ARG 2 completionRange
+	METHOD m_ftybsvym create (FI)Lnet/minecraft/unmapped/C_yfpegcpm;
+		ARG 0 speed
+	METHOD m_gwjxdqgi (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Function;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 walkTarget
+		ARG 5 lookTarget
+	METHOD m_ycopibiu (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Function;ILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 8 time

--- a/mappings/net/minecraft/entity/ai/brain/task/HideInHomeTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HideInHomeTask.mapping
@@ -1,5 +1,19 @@
 CLASS net/minecraft/unmapped/C_xggcofzf net/minecraft/entity/ai/brain/task/HideInHomeTask
+	METHOD m_dbkonmke (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
 	METHOD m_frsalpsy create (IFI)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 maxDistance
 		ARG 1 speed
 		ARG 2 preferredDistance
+	METHOD m_gdorecds (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
+	METHOD m_mvajoufp (IILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 13 time
+	METHOD m_rkbvwvsm (IILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 walkTarget
+		ARG 5 home
+		ARG 6 hidingPlace
+		ARG 7 path
+		ARG 8 lookTarget
+		ARG 9 breedTarget
+		ARG 10 interactionTarget

--- a/mappings/net/minecraft/entity/ai/brain/task/HideWhenBellRingsTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HideWhenBellRingsTask.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/unmapped/C_mqkwrleq net/minecraft/entity/ai/brain/task/HideWhenBellRingsTask
+	METHOD m_fsxmurfx (Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 0 heardBellTime
+	METHOD m_wqibeijl (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 2 time
 	METHOD m_wtgzjqff create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_zlwiidgm (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/HuntFinishTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HuntFinishTask.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/unmapped/C_eijgiivc net/minecraft/entity/ai/brain/task/HuntFinishTask
+	METHOD m_hxgkuput (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 5 time
 	METHOD m_miccftlt create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_tcihverk (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_vhkyhvsm (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 attackTarget
+		ARG 2 huntedRecently

--- a/mappings/net/minecraft/entity/ai/brain/task/HuntHoglinTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HuntHoglinTask.mapping
@@ -1,6 +1,17 @@
 CLASS net/minecraft/unmapped/C_lsxdngih net/minecraft/entity/ai/brain/task/HuntHoglinTask
 	METHOD m_aigctfck (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_lfndeqov create ()Lnet/minecraft/unmapped/C_yfpegcpm;
 	METHOD m_mtjtzise hasHuntedRecently (Lnet/minecraft/unmapped/C_imddhoxf;)Z
 		ARG 0 piglin
+	METHOD m_mxztilai (Ljava/util/List;)Ljava/lang/Boolean;
+		ARG 0 nearestAdults
+	METHOD m_rglyssuq (Ljava/util/List;)V
+		ARG 0 nearestAdults
+	METHOD m_rnxhsvbz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_lkhqndnb;J)Z
+		ARG 4 piglin
+		ARG 5 time
+	METHOD m_wdkqinbv (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 nearestVisibleHuntableHoglin
+		ARG 2 angryAt
+		ARG 3 huntedRecently
+		ARG 4 nearestVisibleAdultPiglins

--- a/mappings/net/minecraft/entity/ai/brain/task/InvestigateDisturbanceTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/InvestigateDisturbanceTask.mapping
@@ -4,9 +4,15 @@ CLASS net/minecraft/unmapped/C_uzxeblbb net/minecraft/entity/ai/brain/task/Inves
 		ARG 1 completionRange
 		ARG 2 speed
 	METHOD m_buxsytxl (Lnet/minecraft/unmapped/C_vbbyoqyw;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
 	METHOD m_oydfrgrb getVibrationDisturbancePosition (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hynzadkk;
 		ARG 0 warden
 		ARG 1 actualLocation
 	METHOD m_thyjyrdo getPositionOffset (Lnet/minecraft/unmapped/C_rlomrsco;)I
 		ARG 0 random
+	METHOD m_weeknkjx (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 posMemory
+		ARG 4 attackTarget
+		ARG 5 walkTarget
+		ARG 6 lookTarget
+	METHOD m_wxrlsnjq (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;IFLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
+		ARG 6 time

--- a/mappings/net/minecraft/entity/ai/brain/task/LayFrogSpawnTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/LayFrogSpawnTask.mapping
@@ -1,3 +1,9 @@
 CLASS net/minecraft/unmapped/C_eeocmegr net/minecraft/entity/ai/brain/task/LayFrogSpawnTask
+	METHOD m_ntvsazhh (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 attackTarget
+		ARG 2 walkTarget
+		ARG 3 isPregnant
 	METHOD m_rlgbgizw create (Lnet/minecraft/unmapped/C_mmxmpdoq;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 target
+	METHOD m_rupgaqrm (Lnet/minecraft/unmapped/C_mmxmpdoq;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 4 time

--- a/mappings/net/minecraft/entity/ai/brain/task/LongJumpTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/LongJumpTask.mapping
@@ -29,12 +29,16 @@ CLASS net/minecraft/unmapped/C_lorklvui net/minecraft/entity/ai/brain/task/LongJ
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 time
+	METHOD m_imbhoucf (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		ARG 1 pos
 	METHOD m_jnajycle canJumpTo (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 	METHOD m_lhfkbmlb findTarget (Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
 		ARG 1 world
 	METHOD m_uruzcoyz getRammingVelocity (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 entity
 		ARG 2 pos
+	METHOD m_yktlgrwn (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_lorklvui$C_egstzubu;
+		ARG 1 pos
 	CLASS C_egstzubu Target
 		METHOD <init> (Lnet/minecraft/unmapped/C_hynzadkk;I)V
 			ARG 1 pos

--- a/mappings/net/minecraft/entity/ai/brain/task/LookAroundTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/LookAroundTask.mapping
@@ -2,3 +2,7 @@ CLASS net/minecraft/unmapped/C_rmxkqame net/minecraft/entity/ai/brain/task/LookA
 	METHOD <init> (II)V
 		ARG 1 minRunTime
 		ARG 2 maxRunTime
+	METHOD m_djqsspaw (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_upikatuq;)Z
+		ARG 1 lookTarget
+	METHOD m_xssftwjj (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_upikatuq;)V
+		ARG 1 lookTarget

--- a/mappings/net/minecraft/entity/ai/brain/task/LookTargetUtil.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/LookTargetUtil.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/unmapped/C_glrklsny net/minecraft/entity/ai/brain/task/LookT
 		ARG 0 brain
 		ARG 1 memoryModuleType
 		ARG 2 entityType
+	METHOD m_fqhevsnd (Lnet/minecraft/unmapped/C_bdwnwhiu;ILnet/minecraft/unmapped/C_zubvmeye;)Z
+		ARG 2 pos
 	METHOD m_hmyszgwx isVisibleInMemory (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 source
 		ARG 1 target

--- a/mappings/net/minecraft/entity/ai/brain/task/LoseJobOnSiteLossTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/LoseJobOnSiteLossTask.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/unmapped/C_logdfkup net/minecraft/entity/ai/brain/task/LoseJobOnSiteLossTask
 	METHOD m_csxbsljg (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_lsevimdo (Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 0 jobSite
+	METHOD m_niwwxeoz (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 1 villager
+		ARG 2 time
 	METHOD m_okyonjrx create ()Lnet/minecraft/unmapped/C_mdnathub;

--- a/mappings/net/minecraft/entity/ai/brain/task/MeanderTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MeanderTask.mapping
@@ -4,7 +4,6 @@ CLASS net/minecraft/unmapped/C_knyoxtib net/minecraft/entity/ai/brain/task/Meand
 	FIELD f_vxdewoso SWIM_XY_DISTANCE_TIERS [[I
 	METHOD m_aziirjrs createFly (F)Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_bixbgfvt (Ljava/util/function/Predicate;Ljava/util/function/Function;FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
 	METHOD m_hjkccxus createSwim (F)Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_jtxnlepj create (FZ)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 speed
@@ -16,16 +15,19 @@ CLASS net/minecraft/unmapped/C_knyoxtib net/minecraft/entity/ai/brain/task/Meand
 		ARG 2 verticalRadius
 	METHOD m_ndxluswt (IILnet/minecraft/unmapped/C_hqdayibh;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 2 entity
+	METHOD m_pxatddba (FLnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_ajnxjhqd;
+		ARG 1 target
 	METHOD m_rzzpekwp (Lnet/minecraft/unmapped/C_hqdayibh;)Z
 		ARG 0 entity
 	METHOD m_sehqmidp create (FLjava/util/function/Function;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 speed
 		ARG 1 targetGetter
 		ARG 2 predicate
+	METHOD m_tuxkscew (Ljava/util/function/Predicate;Ljava/util/function/Function;FLnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 walkTarget
 	METHOD m_ukqjayuo findFlyTargetPos (Lnet/minecraft/unmapped/C_hqdayibh;II)Lnet/minecraft/unmapped/C_vgpupfxx;
 	METHOD m_uthnbfwy (Lnet/minecraft/unmapped/C_hqdayibh;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 0 entity
 	METHOD m_wuhievxg create (F)Lnet/minecraft/unmapped/C_yfpegcpm;
 	METHOD m_ztrebxsb (Ljava/util/function/Predicate;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
-		ARG 5 entity
 		ARG 6 time

--- a/mappings/net/minecraft/entity/ai/brain/task/MeetVillagerTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MeetVillagerTask.mapping
@@ -1,5 +1,14 @@
 CLASS net/minecraft/unmapped/C_nzixmipe net/minecraft/entity/ai/brain/task/MeetVillagerTask
 	FIELD f_lkqlmnnk WALK_SPEED F
 	METHOD m_bsalxkul create ()Lnet/minecraft/unmapped/C_yfpegcpm;
+	METHOD m_ezuxifwk (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 8 time
+	METHOD m_oeotaxmx (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 visibleEntity
 	METHOD m_qnbkdtow (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_zbmnqjdp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 walkTarget
+		ARG 2 lookTarget
+		ARG 3 meetingPoint
+		ARG 4 visibleMobs
+		ARG 5 interactionTarget

--- a/mappings/net/minecraft/entity/ai/brain/task/MeleeAttackTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MeleeAttackTask.mapping
@@ -4,6 +4,12 @@ CLASS net/minecraft/unmapped/C_gpxkysqi net/minecraft/entity/ai/brain/task/Melee
 		ARG 0 entity
 	METHOD m_pigmfdcu (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
 		ARG 0 instance
+		ARG 3 lookTarget
+		ARG 4 attackTarget
+		ARG 5 attackCoolingDown
+		ARG 6 visibleMobs
+	METHOD m_wbftfxxz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
+		ARG 9 time
 	METHOD m_yvkymmtj create (Ljava/util/function/Predicate;I)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 targetPredicate
 		ARG 1 cooldown

--- a/mappings/net/minecraft/entity/ai/brain/task/MemoryTransferTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MemoryTransferTask.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/unmapped/C_ylgoridw net/minecraft/entity/ai/brain/task/MemoryTransferTask
 	METHOD m_algmjnve create (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_vbbyoqyw;Lnet/minecraft/unmapped/C_vbbyoqyw;Lnet/minecraft/unmapped/C_hvilmtvi;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 predicate
-		ARG 1 sourceType
-		ARG 2 targetType
+		ARG 1 source
+		ARG 2 target
 		ARG 3 expiry
+	METHOD m_ddwyzkln (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_hvilmtvi;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 7 time
+	METHOD m_lhelytyy (Ljava/util/function/Predicate;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_hvilmtvi;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 sourceMemory
+		ARG 4 targetMemory

--- a/mappings/net/minecraft/entity/ai/brain/task/OpenDoorsTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/OpenDoorsTask.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/unmapped/C_mdkbucgk net/minecraft/entity/ai/brain/task/OpenD
 	FIELD f_meknrxex REACH_DISTANCE D
 	FIELD f_ojnabwwl RUN_TIME I
 	FIELD f_qkjzuduo PATHING_DISTANCE D
+	METHOD m_bmoayguf (Lnet/minecraft/unmapped/C_ovcqqyqp;Ljava/util/Set;)Ljava/util/Set;
+		ARG 1 positions
 	METHOD m_cgqfgfby hasReached (Lnet/minecraft/unmapped/C_rjqjaxef;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 pos
 	METHOD m_ggugtmce create ()Lnet/minecraft/unmapped/C_mdnathub;
@@ -16,25 +18,29 @@ CLASS net/minecraft/unmapped/C_mdkbucgk net/minecraft/entity/ai/brain/task/OpenD
 		ARG 3 currentNode
 		ARG 4 doors
 		ARG 5 otherMobs
+	METHOD m_mzebzlgv (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
+		ARG 0 state
 	METHOD m_ngzbroqt (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lorg/apache/commons/lang3/mutable/MutableObject;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
 		ARG 7 entity
 		ARG 8 time
 	METHOD m_ohsjfhrw (Lorg/apache/commons/lang3/mutable/MutableObject;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 2 instance
 	METHOD m_ptbjvbpp hasOtherMobReachedDoor (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_hynzadkk;Ljava/util/Optional;)Z
-		ARG 0 entity
 		ARG 1 pos
 		ARG 2 otherMobs
 	METHOD m_reglchmn (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
 		ARG 0 state
 	METHOD m_tqmpuzqm (Lnet/minecraft/unmapped/C_triydqro$C_eibemhky;)Z
 		ARG 0 state
+	METHOD m_txikrlty (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_dfzwsdmo;Lnet/minecraft/unmapped/C_dfzwsdmo;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/Set;)V
+		ARG 6 doorPositions
+	METHOD m_wyumjaoe (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 other
 	METHOD m_xjemttfa (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lorg/apache/commons/lang3/mutable/MutableObject;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
 		ARG 3 path
 		ARG 4 doorsToClose
 		ARG 5 mobs
-	METHOD m_xutscifj rememberToCloseDoor (Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/Optional;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;)Ljava/util/Optional;
+	METHOD m_xutscifj rememberToCloseDoorAt (Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/Optional;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;)Ljava/util/Optional;
 		ARG 0 memoryAccessor
-		ARG 1 doors
+		ARG 1 doorPositions
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/entity/ai/brain/task/PacifyTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/PacifyTask.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/unmapped/C_wykskpka net/minecraft/entity/ai/brain/task/PacifyTask
 	METHOD m_dlfrarsr create (Lnet/minecraft/unmapped/C_vbbyoqyw;I)Lnet/minecraft/unmapped/C_mdnathub;
-		ARG 0 requiredMemory
+		ARG 0 pacifier
 		ARG 1 duration
+	METHOD m_naznywno (Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 5 time
+	METHOD m_yajnddpo (ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 attackTarget
+		ARG 2 pacified
+		ARG 3 pacifierMemory

--- a/mappings/net/minecraft/entity/ai/brain/task/PlayDeadTimerTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/PlayDeadTimerTask.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/unmapped/C_nocxsmxi net/minecraft/entity/ai/brain/task/PlayDeadTimerTask
+	METHOD m_cutobghb (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 playDeadTicks
+		ARG 2 hurtByEntity
+	METHOD m_eujiqjlc (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 5 time
 	METHOD m_pgllasaj create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_vzmadlgd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/PlayWithVillagerBabiesTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/PlayWithVillagerBabiesTask.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/unmapped/C_pknbcifi net/minecraft/entity/ai/brain/task/PlayW
 	FIELD f_mgecents PLAYING_WALK_SPEED F
 	FIELD f_miehzkkz VERTICAL_RANGE I
 	FIELD f_uuzlemod WALK_SPEED F
+	METHOD m_ayehkgoa (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 7 time
 	METHOD m_ebfbnoua create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_ffmzprdu getBabyInteractionTargetCounts (Ljava/util/List;)Ljava/util/Map;
 		ARG 0 entities
@@ -16,13 +18,21 @@ CLASS net/minecraft/unmapped/C_pknbcifi net/minecraft/entity/ai/brain/task/PlayW
 	METHOD m_nkurvpyl isInteractionTargetOf (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 target
 		ARG 1 entity
+	METHOD m_nzvqsuph (Ljava/util/Map$Entry;)Z
+		ARG 0 entry
 	METHOD m_oeslmduv getInteractionTarget (Lnet/minecraft/unmapped/C_usxaxydn;)Lnet/minecraft/unmapped/C_usxaxydn;
 		ARG 0 entity
 	METHOD m_omsojhze (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_qlzbkmup getLeastPopularBabyInteractionTarget (Ljava/util/List;)Ljava/util/Optional;
 		ARG 0 entities
 	METHOD m_quwpjfba (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 checkedEntity
+	METHOD m_smcgnsrp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 visibleVillagerBabies
+		ARG 2 walkTarget
+		ARG 3 lookTarget
+		ARG 4 interactionTarget
 	METHOD m_ssifeeyh hasInteractionTarget (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 entity
+	METHOD m_zjhmnmzm (Lnet/minecraft/unmapped/C_usxaxydn;Ljava/lang/Integer;)Ljava/lang/Integer;
+		ARG 1 count

--- a/mappings/net/minecraft/entity/ai/brain/task/PrepareRamTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/PrepareRamTask.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/unmapped/C_efxxxmpi net/minecraft/entity/ai/brain/task/Prepa
 	METHOD m_ofglimlw (Lnet/minecraft/unmapped/C_atbvfjwi;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 start
 	METHOD m_qpyulvml (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_usxaxydn;)V
-		ARG 2 mob
+		ARG 2 visibleEntity
 	METHOD m_tamhuoqp findRamStart (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/util/Optional;
 		ARG 1 entity
 		ARG 2 target
@@ -49,7 +49,9 @@ CLASS net/minecraft/unmapped/C_efxxxmpi net/minecraft/entity/ai/brain/task/Prepa
 		ARG 1 entity
 		ARG 2 target
 	METHOD m_vjrsvfqv (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 3 mob
+		ARG 3 visibleEntity
+	METHOD m_zmeizdsl (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_bfzvfpbw;)Ljava/util/Optional;
+		ARG 3 visibleEntities
 	CLASS C_ridujtjn Ram
 		COMMENT A ram chosen during the preparation.
 		FIELD f_evyqbdfq end Lnet/minecraft/unmapped/C_hynzadkk;

--- a/mappings/net/minecraft/entity/ai/brain/task/RangedApproachTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RangedApproachTask.mapping
@@ -1,12 +1,15 @@
 CLASS net/minecraft/unmapped/C_goundjki net/minecraft/entity/ai/brain/task/RangedApproachTask
 	FIELD f_kbsfarrs WEAPON_REACH_REDUCTION I
 	METHOD m_coxzfnle (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
-		ARG 7 entity
 		ARG 8 time
 	METHOD m_lybdhlji create (F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed
 	METHOD m_muxbnoqr (Ljava/util/function/Function;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance
+	METHOD m_qpuqahvd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 walkTarget
+		ARG 3 lookTarget
+		ARG 4 attackTarget
+		ARG 5 visibleMobs
 	METHOD m_tlbtvjkw (FLnet/minecraft/unmapped/C_usxaxydn;)Ljava/lang/Float;
 		ARG 1 entity
 	METHOD m_utrmigiy create (Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_mdnathub;

--- a/mappings/net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/unmapped/C_vyvntkxx net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask
+	METHOD m_fgzgdkuc (Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 0 admiringItem
 	METHOD m_pydnghbw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_rueyfipx (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_lkhqndnb;J)Z
+		ARG 1 piglin
+		ARG 2 time
 	METHOD m_tddxntol create ()Lnet/minecraft/unmapped/C_mdnathub;

--- a/mappings/net/minecraft/entity/ai/brain/task/RidingTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RidingTask.mapping
@@ -1,7 +1,11 @@
 CLASS net/minecraft/unmapped/C_gvwpvxxk net/minecraft/entity/ai/brain/task/RidingTask
+	METHOD m_czxtyflj (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILjava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 6 time
 	METHOD m_emalcrce create (ILjava/util/function/BiPredicate;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 range
 		ARG 1 alternativeRidePredicate
+	METHOD m_lluypxar (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILjava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 rideTarget
 	METHOD m_mmnnxthn canRideTarget (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_astfners;I)Z
 		ARG 0 entity
 		ARG 1 target

--- a/mappings/net/minecraft/entity/ai/brain/task/RingBellTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RingBellTask.mapping
@@ -2,5 +2,8 @@ CLASS net/minecraft/unmapped/C_nivxeygp net/minecraft/entity/ai/brain/task/RingB
 	FIELD f_mxtlwjet MAX_DISTANCE I
 	FIELD f_vkpapdty RUN_CHANCE F
 	METHOD m_agirozlb create ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_booelmxp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 meetingPoint
+	METHOD m_nqypnyjj (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 4 time
 	METHOD m_oyaayjfs (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/RoarTargetSelectorTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RoarTargetSelectorTask.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/unmapped/C_oququeao net/minecraft/entity/ai/brain/task/RoarTargetSelectorTask
 	METHOD m_fgpmikzv (Ljava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_fynaplbn;J)Z
-		ARG 4 entity
+		ARG 4 warden
 		ARG 5 time
+	METHOD m_icqnsyib (Ljava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 roarTarget
+		ARG 2 attackTarget
+		ARG 3 cannotReachWalkTargetSince
 	METHOD m_quaditvu (Ljava/util/function/Function;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance
 	METHOD m_sdkgypjp create (Ljava/util/function/Function;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 targetGetter

--- a/mappings/net/minecraft/entity/ai/brain/task/ScheduleActivityTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/ScheduleActivityTask.mapping
@@ -1,7 +1,6 @@
 CLASS net/minecraft/unmapped/C_owbqddjg net/minecraft/entity/ai/brain/task/ScheduleActivityTask
 	METHOD m_ajwcvkyk create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_jhzsxcwo (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 1 entity
 		ARG 2 time
 	METHOD m_nsofrlby (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/SeekSkyTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/SeekSkyTask.mapping
@@ -2,12 +2,14 @@ CLASS net/minecraft/unmapped/C_ltxvialm net/minecraft/entity/ai/brain/task/SeekS
 	METHOD m_essunjsd create (F)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 speed
 	METHOD m_kybxfmey (FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance
+	METHOD m_mobfyprx (Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 2 nearbySky
 	METHOD m_snxmgwgu findNearbySky (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 0 world
 		ARG 1 entity
+	METHOD m_wsvphqmz (FLnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 walkTarget
 	METHOD m_wwicdvwf (Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 3 entity
 		ARG 4 time
 	METHOD m_yjonqbmw isSkyVisible (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 0 world

--- a/mappings/net/minecraft/entity/ai/brain/task/SeekWaterTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/SeekWaterTask.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/unmapped/C_humpmmnj net/minecraft/entity/ai/brain/task/SeekWaterTask
 	METHOD m_jkffcrtl (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 3 instance
+	METHOD m_kldtxriq (Lorg/apache/commons/lang3/mutable/MutableLong;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 attackTarget
+		ARG 4 walkTarget
+		ARG 5 lookTarget
 	METHOD m_kvczouyx (Lorg/apache/commons/lang3/mutable/MutableLong;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
-		ARG 6 entity
 		ARG 7 time
 	METHOD m_xugfnoic create (IF)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 range

--- a/mappings/net/minecraft/entity/ai/brain/task/SetLookTargetOnIntervalTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/SetLookTargetOnIntervalTask.mapping
@@ -1,7 +1,14 @@
 CLASS net/minecraft/unmapped/C_lygsomtd net/minecraft/entity/ai/brain/task/SetLookTargetOnIntervalTask
 	METHOD m_aecmvuxy create (Lnet/minecraft/unmapped/C_ogavsvbr;FLnet/minecraft/unmapped/C_hvilmtvi;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 validEntityType
+	METHOD m_ipziivps (Lnet/minecraft/unmapped/C_usxaxydn;FLnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 visibleEntity
+	METHOD m_nozcjkxz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 8 time
 	METHOD m_ouvkkubu create (FLnet/minecraft/unmapped/C_hvilmtvi;)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_uabosmqw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;FLnet/minecraft/unmapped/C_lygsomtd$C_gvxfhlod;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 lookTarget
+		ARG 5 visibleMobs
 	METHOD m_xpopbuma create (FLnet/minecraft/unmapped/C_hvilmtvi;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 maxDistance
 		ARG 1 interval

--- a/mappings/net/minecraft/entity/ai/brain/task/StartRaidTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StartRaidTask.mapping
@@ -1,7 +1,5 @@
 CLASS net/minecraft/unmapped/C_cqzopjwc net/minecraft/entity/ai/brain/task/StartRaidTask
 	METHOD m_hpsklqqe create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_nergiyuj (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_qzmdmlhg (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 1 entity
 		ARG 2 time

--- a/mappings/net/minecraft/entity/ai/brain/task/StartRidingTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StartRidingTask.mapping
@@ -3,7 +3,9 @@ CLASS net/minecraft/unmapped/C_xydhluxp net/minecraft/entity/ai/brain/task/Start
 	METHOD m_mxhhcnwc create (F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed
 	METHOD m_rixgjxon (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 6 entity
 		ARG 7 time
+	METHOD m_ttcxhdvl (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 lookTarget
+		ARG 3 walkTarget
+		ARG 4 rideTarget
 	METHOD m_zxkmlxfu (FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/StartSniffingTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StartSniffingTask.mapping
@@ -1,8 +1,12 @@
 CLASS net/minecraft/unmapped/C_widxnbrw net/minecraft/entity/ai/brain/task/StartSniffingTask
 	FIELD f_zyjbmbsw SNIFF_COOLDOWN Lnet/minecraft/unmapped/C_macfejbg;
 	METHOD m_cwoqvmja (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_gpfjpdmj (Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 4 entity
 		ARG 5 time
 	METHOD m_puxtqkbo create ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_vysaluoh (Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 0 isSniffing
+		ARG 1 walkTarget
+		ARG 2 sniffCooldown
+		ARG 3 nearestAttackable
+		ARG 4 disturbanceLocation

--- a/mappings/net/minecraft/entity/ai/brain/task/StayCloseToTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StayCloseToTargetTask.mapping
@@ -1,6 +1,5 @@
 CLASS net/minecraft/unmapped/C_xwbaenjp net/minecraft/entity/ai/brain/task/StayCloseToTargetTask
 	METHOD m_fvnlycos (Ljava/util/function/Function;Ljava/util/function/Predicate;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 8 entity
 		ARG 9 time
 	METHOD m_mxvxpsri create (Ljava/util/function/Function;Ljava/util/function/Predicate;IIF)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 lookTargetGetter
@@ -9,4 +8,6 @@ CLASS net/minecraft/unmapped/C_xwbaenjp net/minecraft/entity/ai/brain/task/StayC
 		ARG 3 searchRange
 		ARG 4 speed
 	METHOD m_zasfiuka (Ljava/util/function/Function;Ljava/util/function/Predicate;IFILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 5 instance
+	METHOD m_zzyzwelf (Ljava/util/function/Function;Ljava/util/function/Predicate;IFILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 5 lookTarget
+		ARG 6 walkTarget

--- a/mappings/net/minecraft/entity/ai/brain/task/StopPanickingTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StopPanickingTask.mapping
@@ -1,5 +1,12 @@
 CLASS net/minecraft/unmapped/C_qxrttckt net/minecraft/entity/ai/brain/task/StopPanickingTask
 	FIELD f_ybmkugmk MAX_DISTANCE I
+	METHOD m_fqxusvki (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 hurter
 	METHOD m_kmaaptia (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_kyphbbgv (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 hurtBy
+		ARG 2 hurtByEntity
+		ARG 3 nearestHostile
 	METHOD m_ocrzuroh create ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_rjqumhei (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 6 time

--- a/mappings/net/minecraft/entity/ai/brain/task/TakeJobSiteTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/TakeJobSiteTask.mapping
@@ -1,10 +1,19 @@
 CLASS net/minecraft/unmapped/C_husyniag net/minecraft/entity/ai/brain/task/TakeJobSiteTask
+	METHOD m_cqzhvjwd (Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_hynzadkk;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;)V
+		ARG 6 villager2
 	METHOD m_dknqospc (FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance
+	METHOD m_ejwmpbgo (Ljava/util/Optional;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_pdtkdbte;)Z
+		ARG 2 villager2
 	METHOD m_kyevwxrp canReachJobSite (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_voztdcrg;)Z
 		ARG 0 entity
 		ARG 1 pos
 		ARG 2 poiType
+	METHOD m_pcgkziuw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 potentialJobSite
+		ARG 3 jobSite
+		ARG 4 mobs
+		ARG 5 walkTarget
+		ARG 6 lookTarget
 	METHOD m_szrmsllv create (F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed
 	METHOD m_vzlstima canUseJobSite (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_hynzadkk;)Z
@@ -13,5 +22,5 @@ CLASS net/minecraft/unmapped/C_husyniag net/minecraft/entity/ai/brain/task/TakeJ
 		ARG 2 pos
 		ARG 3 pos
 	METHOD m_xouvifmi (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
-		ARG 7 entity
+		ARG 7 villager
 		ARG 8 time

--- a/mappings/net/minecraft/entity/ai/brain/task/TakeJobSiteTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/TakeJobSiteTask.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/unmapped/C_husyniag net/minecraft/entity/ai/brain/task/TakeJobSiteTask
 	METHOD m_cqzhvjwd (Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_hynzadkk;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;)V
-		ARG 6 villager2
+		ARG 6 villagerEntity
 	METHOD m_dknqospc (FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 	METHOD m_ejwmpbgo (Ljava/util/Optional;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_pdtkdbte;)Z
-		ARG 2 villager2
+		ARG 2 villagerEntity
 	METHOD m_kyevwxrp canReachJobSite (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_voztdcrg;)Z
 		ARG 0 entity
 		ARG 1 pos

--- a/mappings/net/minecraft/entity/ai/brain/task/Task.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/Task.mapping
@@ -1,40 +1,9 @@
-CLASS net/minecraft/unmapped/C_wbtjxfbq net/minecraft/entity/ai/brain/task/Task
-	FIELD f_kbnpijts minRunTime I
-	FIELD f_nutokbfq DEFAULT_RUN_TIME I
-	FIELD f_obmumrdg requiredMemoryStates Ljava/util/Map;
-	FIELD f_rfkjmatw endTime J
-	FIELD f_slgvphcl maxRunTime I
-	FIELD f_tijqdxos status Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;
-	METHOD <init> (Ljava/util/Map;)V
-		ARG 1 requiredMemoryState
-	METHOD <init> (Ljava/util/Map;I)V
-		ARG 1 requiredMemoryState
-		ARG 2 runTime
-	METHOD <init> (Ljava/util/Map;II)V
-		ARG 1 requiredMemoryState
-		ARG 2 minRunTime
-		ARG 3 maxRunTime
-	METHOD m_copsxmjv finishRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-		ARG 1 world
-		ARG 2 entity
+CLASS net/minecraft/unmapped/C_mdnathub net/minecraft/entity/ai/brain/task/Task
+	METHOD m_bmtrtesi stop (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
 		ARG 3 time
-	METHOD m_eghfkoeo isTimeLimitExceeded (J)Z
-		ARG 1 time
-	METHOD m_jiotgmjk keepRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-		ARG 1 world
-		ARG 2 entity
+	METHOD m_lzkdsoun getStatus ()Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;
+	METHOD m_miheqwub getDebugString ()Ljava/lang/String;
+	METHOD m_rsxmnjte tick (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
 		ARG 3 time
-	METHOD m_pwowjghk shouldRun (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 1 world
-		ARG 2 entity
-	METHOD m_thxoqxcz run (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-		ARG 1 world
-		ARG 2 entity
+	METHOD m_vipkpuce tryStart (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
 		ARG 3 time
-	METHOD m_tzzxzprb hasRequiredMemoryState (Lnet/minecraft/unmapped/C_usxaxydn;)Z
-		ARG 1 entity
-	METHOD m_xvrvizlg shouldKeepRunning (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 1 world
-		ARG 2 entity
-		ARG 3 time
-	CLASS C_sqbcjfsz Status

--- a/mappings/net/minecraft/entity/ai/brain/task/TaskBuilder.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/TaskBuilder.mapping
@@ -65,7 +65,7 @@ CLASS net/minecraft/unmapped/C_rcqaryar net/minecraft/entity/ai/brain/task/TaskB
 			ARG 1 memoryAccessor
 		METHOD m_mzwocaxv registeredMemory (Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_rcqaryar;
 		METHOD m_owejzxbp absentMemory (Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_rcqaryar;
-		METHOD m_oxjxfuhs getValueOptional (Lnet/minecraft/unmapped/C_ujlmiamh;)Ljava/util/Optional;
+		METHOD m_oxjxfuhs getValueOrEmpty (Lnet/minecraft/unmapped/C_ujlmiamh;)Ljava/util/Optional;
 			ARG 1 memoryAccessor
 		METHOD m_qgrmwbxe presentMemory (Lnet/minecraft/unmapped/C_vbbyoqyw;)Lnet/minecraft/unmapped/C_rcqaryar;
 		METHOD m_qwhsuzug trigger (Lnet/minecraft/unmapped/C_smovfozc;)Lnet/minecraft/unmapped/C_rcqaryar;

--- a/mappings/net/minecraft/entity/ai/brain/task/TaskControl.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/TaskControl.mapping
@@ -1,9 +1,0 @@
-CLASS net/minecraft/unmapped/C_mdnathub net/minecraft/entity/ai/brain/task/TaskControl
-	METHOD m_bmtrtesi stop (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-		ARG 3 time
-	METHOD m_lzkdsoun getStatus ()Lnet/minecraft/unmapped/C_wbtjxfbq$C_sqbcjfsz;
-	METHOD m_miheqwub debugString ()Ljava/lang/String;
-	METHOD m_rsxmnjte tick (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)V
-		ARG 3 time
-	METHOD m_vipkpuce tryStart (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 3 time

--- a/mappings/net/minecraft/entity/ai/brain/task/TemptTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/TemptTask.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_jazltyri net/minecraft/entity/ai/brain/task/TemptTask
+	FIELD f_diydsgnq useEyeHeight Z
 	FIELD f_gctmighe stopDistanceGetter Ljava/util/function/Function;
 	FIELD f_pdruibeh TEMPTATION_COOLDOWN_TICKS I
 	FIELD f_sgggdzsq DEFAULT_STOP_DISTANCE D

--- a/mappings/net/minecraft/entity/ai/brain/task/UpdateAttackTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/UpdateAttackTargetTask.mapping
@@ -4,7 +4,14 @@ CLASS net/minecraft/unmapped/C_ulrbltvh net/minecraft/entity/ai/brain/task/Updat
 		ARG 0 startPredicate
 		ARG 1 targetFinder
 	METHOD m_msxejphh (Lnet/minecraft/unmapped/C_ulrbltvh$C_dpbnwfid;Lnet/minecraft/unmapped/C_ulrbltvh$C_fewmraou;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_dxkfswlz;J)Z
-		ARG 5 entity
 		ARG 6 time
+	METHOD m_nllubmbg (Lnet/minecraft/unmapped/C_ulrbltvh$C_dpbnwfid;Lnet/minecraft/unmapped/C_ulrbltvh$C_fewmraou;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 attackTarget
+		ARG 3 cannotReachWalkTargetSince
+	METHOD m_qaocffso (Lnet/minecraft/unmapped/C_ulrbltvh$C_dpbnwfid;Lnet/minecraft/unmapped/C_ulrbltvh$C_fewmraou;Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
 	CLASS C_dpbnwfid AttackStartPredicate
+		METHOD test (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/lang/Object;)Z
+			ARG 2 attacker
 	CLASS C_fewmraou TargetFinder
+		METHOD get find (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/lang/Object;)Ljava/util/Optional;
+			ARG 2 attacker

--- a/mappings/net/minecraft/entity/ai/brain/task/VillagerBreedTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/VillagerBreedTask.mapping
@@ -16,6 +16,12 @@ CLASS net/minecraft/unmapped/C_hybbuxke net/minecraft/entity/ai/brain/task/Villa
 		ARG 1 world
 		ARG 2 first
 		ARG 3 second
+	METHOD m_ndyhmcvq (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 poiType
+	METHOD m_nwklbhes (Lnet/minecraft/unmapped/C_jvojbnla;)Z
+		ARG 0 target
+	METHOD m_qpchrjlw (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+		ARG 2 poiType
 	METHOD m_tiqyskkp getReachableHome (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;)Ljava/util/Optional;
 		ARG 1 world
 		ARG 2 villager

--- a/mappings/net/minecraft/entity/ai/brain/task/VillagerTaskListProvider.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/VillagerTaskListProvider.mapping
@@ -3,29 +3,47 @@ CLASS net/minecraft/unmapped/C_nnvgypzk net/minecraft/entity/ai/brain/task/Villa
 	FIELD f_hcwjqxxn INTERACT_SPEED_MODIFIER F
 	FIELD f_ktculwgn INTERACT_DISTANCE_SQUARE I
 	FIELD f_mlxgobtd INTERACT_WALK_UP_DISTANCE I
+	METHOD m_aiochhhk (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
 	METHOD m_cvulgfyw createIdleTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
+	METHOD m_fdpuhziz (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
+	METHOD m_iyoahiym (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
 	METHOD m_jsmlpkkk createPanicTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
 	METHOD m_kiupapdp createHideTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
 	METHOD m_ksqjhvns createPlayTasks (F)Lcom/google/common/collect/ImmutableList;
 		ARG 0 speed
 	METHOD m_mqeccfcy createWorkTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
 	METHOD m_nospjuhz createCoreTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
+	METHOD m_pdzmmhdf (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 type
 	METHOD m_tfcgmnac createPreRaidTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
+	METHOD m_tqiyicpz hasUnoccupiedBed (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hynzadkk;)Z
 	METHOD m_uqrujxkm hasActiveRaid (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
 	METHOD m_utnmlskg createBusyFollowTask ()Lcom/mojang/datafixers/util/Pair;
 	METHOD m_wmjhkzvy createMeetTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
 	METHOD m_yltipasg hasWonRaid (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
 	METHOD m_ynpvnlqa createFreeFollowTask ()Lcom/mojang/datafixers/util/Pair;
 	METHOD m_zeujnumd createRestTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed
 	METHOD m_zlxyxoak createRaidTasks (Lnet/minecraft/unmapped/C_cjzoxshv;F)Lcom/google/common/collect/ImmutableList;
+		ARG 0 profession
 		ARG 1 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/VillagerWalkTowardsTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/VillagerWalkTowardsTask.mapping
@@ -1,4 +1,11 @@
 CLASS net/minecraft/unmapped/C_ijlmbbmn net/minecraft/entity/ai/brain/task/VillagerWalkTowardsTask
+	METHOD m_exclrypm (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILnet/minecraft/unmapped/C_vbbyoqyw;IFILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 6 cannotReachWalkTargetSince
+		ARG 7 walkTarget
+		ARG 8 destinationMemory
+	METHOD m_rejvkhyk (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_vbbyoqyw;ILnet/minecraft/unmapped/C_ujlmiamh;FILnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 10 villager
+		ARG 11 time
 	METHOD m_totgigfc create (Lnet/minecraft/unmapped/C_vbbyoqyw;FIII)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 destination
 		ARG 1 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/WakeUpTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WakeUpTask.mapping
@@ -1,7 +1,5 @@
 CLASS net/minecraft/unmapped/C_qanaobzy net/minecraft/entity/ai/brain/task/WakeUpTask
 	METHOD m_idvvbczh create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_mjretofw (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
 	METHOD m_mzwuhjtj (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
-		ARG 1 entity
 		ARG 2 time

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkHomeTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkHomeTask.mapping
@@ -5,5 +5,16 @@ CLASS net/minecraft/unmapped/C_gkabiwep net/minecraft/entity/ai/brain/task/WalkH
 		COMMENT Represents the number of ticks ({@value}) that this task will
 		COMMENT remember a point of interest after starting to move towards it.
 	FIELD f_yjgrgwbv MAX_DISTANCE I
+	METHOD m_cikvjymi (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 poiType
+	METHOD m_enupsddz (Lorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2LongMap;FLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 3 walkTarget
+		ARG 4 home
 	METHOD m_ptrptyvi create (F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed
+	METHOD m_pzrgslax (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 poiType
+	METHOD m_soupzfeh (Lorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2LongMap$Entry;)Z
+		ARG 1 entry
+	METHOD m_tjssmiip (Lorg/apache/commons/lang3/mutable/MutableLong;Lit/unimi/dsi/fastutil/longs/Long2LongMap;Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 6 time

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkTask.mapping
@@ -4,12 +4,19 @@ CLASS net/minecraft/unmapped/C_uuyjertq net/minecraft/entity/ai/brain/task/WalkT
 	FIELD f_iynajoye MAX_RUN_TIME I
 	FIELD f_rcpxgapc damageTypeGetter Ljava/util/function/Function;
 	FIELD f_trxuqcna VERTICAL_RANGE I
+	FIELD f_vmspnrib targetFinder Ljava/util/function/Function;
 	FIELD f_wcvudbwu MIN_RUN_TIME I
 	METHOD <init> (F)V
 		ARG 1 speed
+	METHOD <init> (FI)V
+		ARG 2 searchStartHeight
 	METHOD m_dbqqkxir findClosestWater (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_astfners;)Ljava/util/Optional;
 		ARG 1 world
 		ARG 2 entity
+	METHOD m_hyruvptj (Lnet/minecraft/unmapped/C_hqdayibh;)Lnet/minecraft/unmapped/C_ednuhnnn;
 	METHOD m_ihbbxfox findTarget (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_bdwnwhiu;)Lnet/minecraft/unmapped/C_vgpupfxx;
 		ARG 1 entity
 		ARG 2 world
+	METHOD m_rjmrxawb (Lnet/minecraft/unmapped/C_hqdayibh;Lnet/minecraft/unmapped/C_sbxfkpyv;)Ljava/lang/Boolean;
+		ARG 2 source
+	METHOD m_sdaevhno (Lnet/minecraft/unmapped/C_hqdayibh;)Lnet/minecraft/unmapped/C_vgpupfxx;

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkToNearestVisibleWantedItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkToNearestVisibleWantedItemTask.mapping
@@ -1,7 +1,13 @@
 CLASS net/minecraft/unmapped/C_rmejpnsf net/minecraft/entity/ai/brain/task/WalkToNearestVisibleWantedItemTask
 	METHOD m_fwikqmwv create (FZI)Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_jauynsgc (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Ljava/util/function/Predicate;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 lookTarget
+		ARG 5 walkTarget
+		ARG 6 nearestVisibleWantedItem
+		ARG 7 itemPickupCooldownTicks
+	METHOD m_pgcykntt (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Ljava/util/function/Predicate;IFLnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 10 time
 	METHOD m_ubweidii (ZLjava/util/function/Predicate;IFLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 4 instance
 	METHOD m_xkulsdab create (Ljava/util/function/Predicate;FZI)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 startPredicate
 		ARG 1 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkTowardClosestAdultTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkTowardClosestAdultTask.mapping
@@ -1,3 +1,14 @@
 CLASS net/minecraft/unmapped/C_mmfqblba net/minecraft/entity/ai/brain/task/WalkTowardClosestAdultTask
-	METHOD m_ngwtqsza create (Lnet/minecraft/unmapped/C_hvilmtvi;F)Lnet/minecraft/unmapped/C_yfpegcpm;
+	METHOD m_kpnmuyep create (Lnet/minecraft/unmapped/C_hvilmtvi;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_vbbyoqyw;Z)Lnet/minecraft/unmapped/C_yfpegcpm;
+		ARG 0 rangeProvider
+		ARG 1 speedGetter
+		ARG 2 nearestVisibleModule
+		ARG 3 useEyeHeight
+	METHOD m_ngwtqsza createNearestVisibleAdult (Lnet/minecraft/unmapped/C_hvilmtvi;F)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 1 speed
+	METHOD m_twidblmp (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_hvilmtvi;ZLjava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 4 nearestVisibleMemory
+		ARG 5 lookTargetMemory
+		ARG 6 walkTargetMemory
+	METHOD m_xfqttcpz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_hvilmtvi;ZLjava/util/function/Function;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 9 time

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkTowardClosestAdultTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkTowardClosestAdultTask.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/unmapped/C_mmfqblba net/minecraft/entity/ai/brain/task/WalkT
 	METHOD m_kpnmuyep create (Lnet/minecraft/unmapped/C_hvilmtvi;Ljava/util/function/Function;Lnet/minecraft/unmapped/C_vbbyoqyw;Z)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 0 rangeProvider
 		ARG 1 speedGetter
-		ARG 2 nearestVisibleModule
+		ARG 2 nearestVisible
 		ARG 3 useEyeHeight
 	METHOD m_ngwtqsza createNearestVisibleAdult (Lnet/minecraft/unmapped/C_hvilmtvi;F)Lnet/minecraft/unmapped/C_yfpegcpm;
 		ARG 1 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/WalkTowardJobSiteTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WalkTowardJobSiteTask.mapping
@@ -3,3 +3,7 @@ CLASS net/minecraft/unmapped/C_bwyntfvi net/minecraft/entity/ai/brain/task/WalkT
 	FIELD f_jvzcoeuw speed F
 	METHOD <init> (F)V
 		ARG 1 speed
+	METHOD m_dimfialg (Lnet/minecraft/unmapped/C_gqmpgxlw;)Ljava/lang/Boolean;
+		ARG 0 activity
+	METHOD m_qtgklcpe (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 0 ignored

--- a/mappings/net/minecraft/entity/ai/brain/task/WanderIndoorsTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WanderIndoorsTask.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/unmapped/C_ujhjmchh net/minecraft/entity/ai/brain/task/WanderIndoorsTask
+	METHOD m_hbygrzih (Lnet/minecraft/unmapped/C_ujlmiamh;FLnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hqdayibh;J)Z
+		ARG 4 time
+	METHOD m_lxdzzchh (FLnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 walkTarget
 	METHOD m_szusqxxg (FLnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance
 	METHOD m_wlqapoji create (F)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 speed

--- a/mappings/net/minecraft/entity/ai/brain/task/WantNewItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WantNewItemTask.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/unmapped/C_byhswlbt net/minecraft/entity/ai/brain/task/WantNewItemTask
+	METHOD m_gontldbv (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 2 admiringItem
+		ARG 3 nearestVisibleWantedItem
+	METHOD m_hlwognuf (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;ILnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 6 time
 	METHOD m_kgzclozu create (I)Lnet/minecraft/unmapped/C_mdnathub;
 		ARG 0 radius
 	METHOD m_twqrwreh (ILnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 1 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/WardenLookAtEntityTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WardenLookAtEntityTask.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/unmapped/C_bwmyjvtm net/minecraft/entity/ai/brain/task/WardenLookAtEntityTask
+	METHOD m_eylunbca (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 lookTarget
+		ARG 2 disturbanceLocation
+		ARG 3 roarTarget
+		ARG 4 attackTarget
+	METHOD m_ezpawvis (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;J)Z
+		ARG 6 time
 	METHOD m_nxqouhrs create ()Lnet/minecraft/unmapped/C_mdnathub;
 	METHOD m_svqaytol (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance

--- a/mappings/net/minecraft/entity/ai/brain/task/WorkStationCompetitionTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/WorkStationCompetitionTask.mapping
@@ -1,7 +1,14 @@
 CLASS net/minecraft/unmapped/C_vxwwyzne net/minecraft/entity/ai/brain/task/WorkStationCompetitionTask
 	METHOD m_cmjxsknz (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance
+	METHOD m_fwcgzfkz (Lnet/minecraft/unmapped/C_ovcqqyqp;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_pdtkdbte;)Z
+		ARG 2 other
 	METHOD m_sqbnhmnw create ()Lnet/minecraft/unmapped/C_mdnathub;
+	METHOD m_tkyeykwa (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)Z
+		ARG 4 villager
+		ARG 5 time
+	METHOD m_udxeryxl (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 jobSite
+		ARG 2 mobs
 	METHOD m_wewjuzkg isUsingWorkStationAt (Lnet/minecraft/unmapped/C_ovcqqyqp;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_pdtkdbte;)Z
 		ARG 0 pos
 		ARG 1 poiType
@@ -9,6 +16,9 @@ CLASS net/minecraft/unmapped/C_vxwwyzne net/minecraft/entity/ai/brain/task/WorkS
 		ARG 3 villager
 	METHOD m_xmcctqkk isCompletedWorkStation (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 0 poiType
+		ARG 1 profession
+	METHOD m_xqeaucog (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_ovcqqyqp;Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 4 poiType
 	METHOD m_zbwohokk keepJobSiteForMoreExperiencedVillager (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_pdtkdbte;)Lnet/minecraft/unmapped/C_pdtkdbte;
 		ARG 0 first
 		ARG 1 second

--- a/mappings/net/minecraft/entity/ai/control/Control.mapping
+++ b/mappings/net/minecraft/entity/ai/control/Control.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/unmapped/C_yysmphmf net/minecraft/entity/ai/control/Control
+	METHOD m_mljvwuuu rotateTowards (FFF)F
+		ARG 1 from
+		ARG 2 to
+		ARG 3 maxStep

--- a/mappings/net/minecraft/entity/ai/control/LookControl.mapping
+++ b/mappings/net/minecraft/entity/ai/control/LookControl.mapping
@@ -32,6 +32,7 @@ CLASS net/minecraft/unmapped/C_lgufpcrf net/minecraft/entity/ai/control/LookCont
 		ARG 5 z
 		ARG 7 yawSpeed
 		ARG 8 pitchSpeed
+	METHOD m_uhdpzesr getLookY ()D
 	METHOD m_uwyzewdj getTargetYaw ()Ljava/util/Optional;
 	METHOD m_xtliwbwz lookAt (Lnet/minecraft/unmapped/C_astfners;FF)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/ai/control/MoveControl.mapping
+++ b/mappings/net/minecraft/entity/ai/control/MoveControl.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/unmapped/C_azhvkebm net/minecraft/entity/ai/control/MoveCont
 	FIELD f_xzliscof speed D
 	METHOD <init> (Lnet/minecraft/unmapped/C_dxkfswlz;)V
 		ARG 1 entity
+	METHOD m_bdejwsgq startWaiting ()V
 	METHOD m_gdnyncjr isWalkable (FF)Z
 		ARG 1 x
 		ARG 2 z

--- a/mappings/net/minecraft/entity/ai/goal/EatGrassGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/EatGrassGoal.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_krmsprar net/minecraft/entity/ai/goal/EatGrassGoal
+	FIELD f_nrxbqypr IS_EDIBLE_FOR_SHEEP Ljava/util/function/Predicate;
 	FIELD f_tclzhvfv MAX_TIMER I
 	FIELD f_xixjffhf world Lnet/minecraft/unmapped/C_cdctfzbn;
 	FIELD f_xjozqnyd timer I

--- a/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_klcypqlq net/minecraft/entity/ai/goal/TemptGoal
+	FIELD f_amfttubz stopRange D
 	FIELD f_arjvkkfc predicate Lnet/minecraft/unmapped/C_cjtyhinh;
 	FIELD f_bfzketot lastPlayerY D
 	FIELD f_fvikwscs cooldown I
@@ -13,7 +14,13 @@ CLASS net/minecraft/unmapped/C_klcypqlq net/minecraft/entity/ai/goal/TemptGoal
 	FIELD f_stwralen lastPlayerX D
 	FIELD f_tfwxptmo closestPlayer Lnet/minecraft/unmapped/C_jzrpycqo;
 	FIELD f_twlffgvx lastPlayerYaw D
+	FIELD f_vpimlgmo DEFAULT_STOP_RANGE D
+	METHOD <init> (Lnet/minecraft/unmapped/C_hqdayibh;DLjava/util/function/Predicate;ZD)V
+		ARG 6 stopRange
 	METHOD m_mgdyvbvj isActive ()Z
+	METHOD m_mwnvonnk haltNavigation ()V
+	METHOD m_ohrhmbtc startNavigation (Lnet/minecraft/unmapped/C_jzrpycqo;)V
 	METHOD m_prlymqhz isTemptedBy (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
 	METHOD m_qytkxnlv canBeScared ()Z
+	CLASS C_drbhjukl MoveControlled

--- a/mappings/net/minecraft/entity/ai/pathing/PathNodeMaker.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/PathNodeMaker.mapping
@@ -10,7 +10,17 @@ CLASS net/minecraft/unmapped/C_pbtgpvfg net/minecraft/entity/ai/pathing/PathNode
 	FIELD f_wviyrtdh canOpenDoors Z
 	FIELD f_xnzjvdtv canEnterOpenDoors Z
 	METHOD m_amhxcrvm getDefaultNodeType (Lnet/minecraft/unmapped/C_amrnepho;III)Lnet/minecraft/unmapped/C_hahxxnjs;
+		ARG 1 context
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD m_aquikxzw getNodeType (Lnet/minecraft/unmapped/C_amrnepho;IIILnet/minecraft/unmapped/C_dxkfswlz;)Lnet/minecraft/unmapped/C_hahxxnjs;
+		ARG 1 context
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD m_bnffgkdx (IIII)Lnet/minecraft/unmapped/C_dfzwsdmo;
+		ARG 3 ignored
 	METHOD m_caxdstpt getNode (III)Lnet/minecraft/unmapped/C_dfzwsdmo;
 		ARG 1 x
 		ARG 2 y
@@ -25,6 +35,8 @@ CLASS net/minecraft/unmapped/C_pbtgpvfg net/minecraft/entity/ai/pathing/PathNode
 	METHOD m_ntllflcn getStart ()Lnet/minecraft/unmapped/C_dfzwsdmo;
 	METHOD m_olsrqhxg canOpenDoors ()Z
 	METHOD m_oyhtoddn getSuccessors ([Lnet/minecraft/unmapped/C_dfzwsdmo;Lnet/minecraft/unmapped/C_dfzwsdmo;)I
+		ARG 1 successors
+		ARG 2 node
 	METHOD m_peyrvdzd getTargetPathNode (DDD)Lnet/minecraft/unmapped/C_srqeyrql;
 		ARG 1 x
 		ARG 3 y
@@ -32,6 +44,9 @@ CLASS net/minecraft/unmapped/C_pbtgpvfg net/minecraft/entity/ai/pathing/PathNode
 	METHOD m_qzaeyeqk canEnterOpenDoors ()Z
 	METHOD m_rhautiup clear ()V
 	METHOD m_tlossoni getNode (DDD)Lnet/minecraft/unmapped/C_srqeyrql;
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
 	METHOD m_tyumpkdm getDefaultNodeType (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_hahxxnjs;
 	METHOD m_wcwipmmd setCanSwim (Z)V
 		ARG 1 canSwim

--- a/mappings/net/minecraft/entity/attribute/AttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/AttributeContainer.mapping
@@ -5,6 +5,11 @@ CLASS net/minecraft/unmapped/C_cohbwqne net/minecraft/entity/attribute/Attribute
 	FIELD f_xwjysvew pendingUpdate Ljava/util/Set;
 	METHOD <init> (Lnet/minecraft/unmapped/C_sdjuuzrz;)V
 		ARG 1 defaultAttributes
+	METHOD m_axiszarw pack ()Ljava/util/List;
+	METHOD m_bgvtusrt (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_lzukavpx;
+		ARG 1 entityAttribute
+	METHOD m_bkjfkari resetBaseValue (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+		ARG 1 attribute
 	METHOD m_fkydwjmo addTemporaryModifiers (Lcom/google/common/collect/Multimap;)V
 		ARG 1 modifiers
 	METHOD m_furmwbsi getModifierValue (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_ncpywfca;)D
@@ -21,17 +26,33 @@ CLASS net/minecraft/unmapped/C_cohbwqne net/minecraft/entity/attribute/Attribute
 		ARG 1 attribute
 	METHOD m_jhklrcmp getAttributesToUpdate ()Ljava/util/Set;
 	METHOD m_kzjivbbd getAttributesToSync ()Ljava/util/Set;
+	METHOD m_lohzsyup unpack (Ljava/util/List;)V
+		ARG 1 packed
 	METHOD m_miiadyyh getAttributesToSend ()Ljava/util/Collection;
+	METHOD m_phqmkslb (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 attribute
+		ARG 2 modifier
 	METHOD m_pzbjebfw getValue (Lnet/minecraft/unmapped/C_cjzoxshv;)D
 		ARG 1 attribute
+	METHOD m_pzbylywb (Lnet/minecraft/unmapped/C_lzukavpx;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 modifier
 	METHOD m_qtoghhlr getBaseValue (Lnet/minecraft/unmapped/C_cjzoxshv;)D
 		ARG 1 attribute
 	METHOD m_qzikslsi setValuesFrom (Lnet/minecraft/unmapped/C_cohbwqne;)V
 		ARG 1 container
+	METHOD m_rmrvngqc (Lnet/minecraft/unmapped/C_lzukavpx;)V
+		ARG 1 attribute
+	METHOD m_tqvruxll (Lnet/minecraft/unmapped/C_lzukavpx;)V
+		ARG 1 attribute
+	METHOD m_tugmsqto (Lnet/minecraft/unmapped/C_lzukavpx;)V
+		ARG 1 attribute
 	METHOD m_txvwadfp hasAttribute (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 1 attribute
 	METHOD m_vfhqjskx addPersistentModifiersFrom (Lnet/minecraft/unmapped/C_cohbwqne;)V
 		ARG 1 container
+	METHOD m_yfaoegcj (Lnet/minecraft/unmapped/C_cjzoxshv;Ljava/util/Collection;)V
+		ARG 1 attribute
+		ARG 2 attributeModifiers
 	METHOD m_yortiwsq removeModifiers (Lcom/google/common/collect/Multimap;)V
 		ARG 1 modifiers
 	METHOD m_zswycxao updateTrackedStatus (Lnet/minecraft/unmapped/C_lzukavpx;)V

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
@@ -10,8 +10,11 @@ CLASS net/minecraft/unmapped/C_lzukavpx net/minecraft/entity/attribute/EntityAtt
 	FIELD f_ybqmfnir operationToModifiers Ljava/util/Map;
 	METHOD m_basvthgj removeModifier (Lnet/minecraft/unmapped/C_ncpywfca;)Z
 		ARG 1 id
+	METHOD m_bgzotehi unpack (Lnet/minecraft/unmapped/C_lzukavpx$C_gkutuzut;)V
+		ARG 1 packed
 	METHOD m_bsifaddn (Lnet/minecraft/unmapped/C_hdbqsqsm$C_pljpmmzs;Ljava/util/Map;)V
 		ARG 1 operation
+		ARG 2 modifiers
 	METHOD m_fcqlvfzc replacePersistentModifier (Lnet/minecraft/unmapped/C_hdbqsqsm;)V
 		ARG 1 modifier
 	METHOD m_gbtcpwti hasModifier (Lnet/minecraft/unmapped/C_ncpywfca;)Z
@@ -45,6 +48,7 @@ CLASS net/minecraft/unmapped/C_lzukavpx net/minecraft/entity/attribute/EntityAtt
 		COMMENT </ul>
 	METHOD m_ojdeprdt getModifiersByOperation (Lnet/minecraft/unmapped/C_hdbqsqsm$C_pljpmmzs;)Ljava/util/Collection;
 		ARG 1 operation
+	METHOD m_qlrxnufw pack ()Lnet/minecraft/unmapped/C_lzukavpx$C_gkutuzut;
 	METHOD m_rhfwxbjf addTemporaryModifier (Lnet/minecraft/unmapped/C_hdbqsqsm;)V
 		COMMENT Adds a temporary attribute modifier.
 		COMMENT The modifier will not be serialized.
@@ -61,3 +65,6 @@ CLASS net/minecraft/unmapped/C_lzukavpx net/minecraft/entity/attribute/EntityAtt
 	METHOD m_xdafakih (Lnet/minecraft/unmapped/C_hdbqsqsm$C_pljpmmzs;)Ljava/util/Map;
 		ARG 0 operation
 	METHOD m_zxnpgjts getValue ()D
+	CLASS C_gkutuzut Packed
+		FIELD f_hxhrlkgo CODEC Lcom/mojang/serialization/Codec;
+		FIELD f_ndkcndhm LIST_CODEC Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_izahjvwf net/minecraft/entity/boss/CommandBossBar
+	FIELD f_bnxcmlze DEFAULT_MAX_VALUE I
 	FIELD f_gaqqibjg value I
 	FIELD f_pyleymqg id Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_vuzdiekr maxValue I
@@ -8,6 +9,7 @@ CLASS net/minecraft/unmapped/C_izahjvwf net/minecraft/entity/boss/CommandBossBar
 		ARG 2 displayName
 	METHOD m_dctcsdyx onPlayerDisconnect (Lnet/minecraft/unmapped/C_mxrobsgg;)V
 		ARG 1 player
+	METHOD m_kphcbzql pack ()Lnet/minecraft/unmapped/C_izahjvwf$C_nnsogopg;
 	METHOD m_oupdsvel setMaxValue (I)V
 		ARG 1 maxValue
 	METHOD m_pntbdfvj getId ()Lnet/minecraft/unmapped/C_ncpywfca;
@@ -15,8 +17,9 @@ CLASS net/minecraft/unmapped/C_izahjvwf net/minecraft/entity/boss/CommandBossBar
 		ARG 1 uuid
 	METHOD m_qkafyrxa (Lnet/minecraft/unmapped/C_cpwnhism;)Lnet/minecraft/unmapped/C_cpwnhism;
 		ARG 1 style
-	METHOD m_sayczpmf fromNbt (Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_izahjvwf$C_nnsogopg;)Lnet/minecraft/unmapped/C_izahjvwf;
+	METHOD m_sayczpmf unpack (Lnet/minecraft/unmapped/C_ncpywfca;Lnet/minecraft/unmapped/C_izahjvwf$C_nnsogopg;)Lnet/minecraft/unmapped/C_izahjvwf;
 		ARG 0 id
+		ARG 1 packed
 	METHOD m_shcbnoqq getMaxValue ()I
 	METHOD m_sjepyxhx getValue ()I
 	METHOD m_udwgbkwv onPlayerConnect (Lnet/minecraft/unmapped/C_mxrobsgg;)V
@@ -26,3 +29,6 @@ CLASS net/minecraft/unmapped/C_izahjvwf net/minecraft/entity/boss/CommandBossBar
 		ARG 1 players
 	METHOD m_zhtoigik setValue (I)V
 		ARG 1 value
+	CLASS C_nnsogopg Packed
+		FIELD f_ewzyvdyc maxValue I
+		METHOD m_igmjwpes maxValue ()I

--- a/mappings/net/minecraft/entity/boss/WitherEntity.mapping
+++ b/mappings/net/minecraft/entity/boss/WitherEntity.mapping
@@ -1,10 +1,11 @@
 CLASS net/minecraft/unmapped/C_sggtxtfb net/minecraft/entity/boss/WitherEntity
 	FIELD f_bjoduoid CAN_ATTACK_PREDICATE Lnet/minecraft/unmapped/C_cjtyhinh$C_cqgaarcf;
-	FIELD f_dbpklypj DEFAULT_INVUL_TIMER I
+	FIELD f_dbpklypj SUMMON_INVULNERABILITY_TICKS I
 	FIELD f_deuiozmf TRACKED_ENTITY_ID_3 Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_eswsbgvn chargedSkullCooldowns [I
 	FIELD f_fqkraiyq blockBreakingCooldown I
 	FIELD f_gkmmafgl bossBar Lnet/minecraft/unmapped/C_fnaldpbu;
+	FIELD f_gymmfkst DEFAULT_INVULNERABILITY_TICKS I
 	FIELD f_jivuqxso skullCooldowns [I
 	FIELD f_lpobsupw HEAD_TARGET_PREDICATE Lnet/minecraft/unmapped/C_cjtyhinh;
 	FIELD f_qzkqrqlp TRACKED_ENTITY_IDS Ljava/util/List;
@@ -14,7 +15,7 @@ CLASS net/minecraft/unmapped/C_sggtxtfb net/minecraft/entity/boss/WitherEntity
 	FIELD f_valuttbg sideHeadPitches [F
 	FIELD f_xpkucahz prevSideHeadYaws [F
 	FIELD f_xzkijnyk TRACKED_ENTITY_ID_1 Lnet/minecraft/unmapped/C_rinmcaxy;
-	FIELD f_ypdfrirk INVUL_TIMER Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_ypdfrirk INVULNERABILITY_TICKS Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD m_djktfxfe getHeadX (I)D
 		ARG 1 headIndex
 	METHOD m_iebjalcb canDestroy (Lnet/minecraft/unmapped/C_txtbiemp;)Z
@@ -36,7 +37,7 @@ CLASS net/minecraft/unmapped/C_sggtxtfb net/minecraft/entity/boss/WitherEntity
 		ARG 1 headIndex
 		ARG 2 id
 	METHOD m_ozoswikq shouldRenderOverlay ()Z
-	METHOD m_qhkuvwyu getInvulnerableTimer ()I
+	METHOD m_qhkuvwyu getInvulnerabilityTicks ()I
 	METHOD m_qmyjaubp getSideHeadYaws ()[F
 	METHOD m_riwonxhm getHeadZ (I)D
 		ARG 1 headIndex
@@ -46,7 +47,7 @@ CLASS net/minecraft/unmapped/C_sggtxtfb net/minecraft/entity/boss/WitherEntity
 		ARG 1 prevAngle
 		ARG 2 desiredAngle
 		ARG 3 maxDifference
-	METHOD m_xxdbhdpd setInvulTimer (I)V
+	METHOD m_xxdbhdpd setInvulnerabilityTicks (I)V
 		ARG 1 ticks
 	METHOD m_zzpaardc shootSkullAt (ILnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 headIndex

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonEntity.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_bsmypcfq net/minecraft/entity/boss/dragon/EnderDragonEntity
 	FIELD f_amkaexbp leftWing Lnet/minecraft/unmapped/C_coyfpkdd;
+	FIELD f_bgyxygwk DEFAULT_DEATH_TIME I
 	FIELD f_boznzpxz pathNodeConnections [I
 		COMMENT An array of 24 bitflags, where node #i leads to #j if and only if
 		COMMENT {@code (pathNodeConnections[i] & (1 << j)) != 0}.
@@ -65,9 +66,12 @@ CLASS net/minecraft/unmapped/C_bsmypcfq net/minecraft/entity/boss/dragon/EnderDr
 		ARG 1 fight
 	METHOD m_nomlcuzj wrapYawChange (D)F
 		ARG 1 yawDegrees
+	METHOD m_nstdwgjc (Ljava/lang/Integer;)V
+		ARG 1 id
 	METHOD m_pamvmrhq setFightOrigin (Lnet/minecraft/unmapped/C_hynzadkk;)V
 	METHOD m_pmbrehqc damagePart (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_coyfpkdd;Lnet/minecraft/unmapped/C_sbxfkpyv;F)Z
 		ARG 2 part
+		ARG 4 amount
 	METHOD m_pzbmfkfv destroyBlocks (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hbcjzgoe;)Z
 		ARG 2 box
 	METHOD m_qrovnyxu damageCollidingEntities (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/util/List;)V

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonFight.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonFight.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/unmapped/C_hxzjzvro net/minecraft/entity/boss/dragon/EnderDr
 	FIELD f_vozrskjd skipChunksLoadedCheck Z
 	FIELD f_vpshgwjp gateways Lit/unimi/dsi/fastutil/objects/ObjectArrayList;
 	FIELD f_wjxdsjtq playerUpdateTimer I
-	FIELD f_xkcaplpq spawnStateTimer I
+	FIELD f_xkcaplpq spawnTicks I
 	FIELD f_xxqubfnu dragonSpawnState Lnet/minecraft/unmapped/C_ubwoswoy;
 	FIELD f_ymkjvclv GATEWAY_COUNT I
 	METHOD <init> (Lnet/minecraft/unmapped/C_bdwnwhiu;JLnet/minecraft/unmapped/C_hxzjzvro$C_tunbvwoo;Lnet/minecraft/unmapped/C_hynzadkk;)V

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonSpawnState.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonSpawnState.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/unmapped/C_ubwoswoy net/minecraft/entity/boss/dragon/EnderDragonSpawnState
 	METHOD m_ivvhzpnu run (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hxzjzvro;Ljava/util/List;ILnet/minecraft/unmapped/C_hynzadkk;)V
+		ARG 2 fight
+		ARG 3 crystals
+		ARG 4 spawnTicks

--- a/mappings/net/minecraft/entity/boss/dragon/phase/Phase.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/phase/Phase.mapping
@@ -5,8 +5,12 @@ CLASS net/minecraft/unmapped/C_rwrldqyd net/minecraft/entity/boss/dragon/phase/P
 	METHOD m_iavduduf getType ()Lnet/minecraft/unmapped/C_xxpourgx;
 	METHOD m_jqednpse getMaxYAcceleration ()F
 	METHOD m_khmdpwue modifyDamageTaken (Lnet/minecraft/unmapped/C_sbxfkpyv;F)F
+		ARG 1 source
+		ARG 2 originalAmount
 	METHOD m_kriacnhw isSittingOrHovering ()Z
 	METHOD m_sfbqljlr endPhase ()V
 	METHOD m_smozajbb clientTick ()V
 	METHOD m_tdkskrwn getYawAcceleration ()F
 	METHOD m_wivqauea crystalDestroyed (Lnet/minecraft/unmapped/C_akvrfxgg;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_sbxfkpyv;Lnet/minecraft/unmapped/C_jzrpycqo;)V
+		ARG 1 crystal
+		ARG 3 source

--- a/mappings/net/minecraft/entity/data/TrackedDataHandler.mapping
+++ b/mappings/net/minecraft/entity/data/TrackedDataHandler.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/unmapped/C_xrzqxzbg net/minecraft/entity/data/TrackedDataHandler
+	METHOD copy (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 source
 	METHOD m_eoamrvbe create (Lnet/minecraft/unmapped/C_qsrmwluu;)Lnet/minecraft/unmapped/C_xrzqxzbg;
 		ARG 0 codec
 	METHOD m_hkkrjyzt create (I)Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/data/TrackedDataHandlerRegistry.mapping
+++ b/mappings/net/minecraft/entity/data/TrackedDataHandlerRegistry.mapping
@@ -2,9 +2,11 @@ CLASS net/minecraft/unmapped/C_fegtripb net/minecraft/entity/data/TrackedDataHan
 	FIELD f_abgbckne SNIFFER_STATE Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_adnhcqal OPTIONAL_BLOCK_POS Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_aytkmhuo DIRECTION Lnet/minecraft/unmapped/C_xrzqxzbg;
+	FIELD f_beghruip PIG_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_bhjosbpm ROTATION Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_cdzoruas ENTITY_POSE Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_dhomndic BLOCK_STATE Lnet/minecraft/unmapped/C_xrzqxzbg;
+	FIELD f_flkmtauk COW_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_hdycstqt ITEM_STACK Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_huqcfqmn OPTIONAL_BLOCK_STATE Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_ibwlbgzc OPTIONAL_BLOCK_STATE_CODEC Lnet/minecraft/unmapped/C_qsrmwluu;
@@ -21,8 +23,10 @@ CLASS net/minecraft/unmapped/C_fegtripb net/minecraft/entity/data/TrackedDataHan
 	FIELD f_mzinrkcd INTEGER Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_qprbpdxq BLOCK_POS Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_qquxpqxb PARTICLE Lnet/minecraft/unmapped/C_xrzqxzbg;
+	FIELD f_sacbcurg OPTIONAL_ENTITY Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_ssxntddt TEXT_COMPONENT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_teokfohv VECTOR3F Lnet/minecraft/unmapped/C_xrzqxzbg;
+	FIELD f_tgdphxir WOLF_SOUND_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_uzqfcssr OPTIONAL_TEXT_COMPONENT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_vcohujss FROG_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_wgeyibzj BYTE Lnet/minecraft/unmapped/C_xrzqxzbg;
@@ -31,6 +35,7 @@ CLASS net/minecraft/unmapped/C_fegtripb net/minecraft/entity/data/TrackedDataHan
 	FIELD f_yjnqynva DATA_HANDLERS Lnet/minecraft/unmapped/C_pkvohekg;
 	FIELD f_ykhchcdb CAT_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_yoecocbx VILLAGER_DATA Lnet/minecraft/unmapped/C_xrzqxzbg;
+	FIELD f_zmahqeyz CHICKEN_VARIANT Lnet/minecraft/unmapped/C_xrzqxzbg;
 	FIELD f_zxvfivae ARMADILLO_STATE Lnet/minecraft/unmapped/C_xrzqxzbg;
 	METHOD m_bhodhirr register (Lnet/minecraft/unmapped/C_xrzqxzbg;)V
 		ARG 0 handler

--- a/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/unmapped/C_jkvbjfnw net/minecraft/entity/decoration/AbstractDecorationEntity
 	FIELD f_eycxoxbt PREDICATE Ljava/util/function/Predicate;
+	FIELD f_gvlrmhwu DIRECTION Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_kyypotqq DEFAULT_DIRECTION Lnet/minecraft/unmapped/C_xpuuihxf;
 	METHOD m_jpaijrhc (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 entity
 	METHOD m_lbdhqjli calculateBoundingBox (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Lnet/minecraft/unmapped/C_hbcjzgoe;
+	METHOD m_mwijirco setDirection (Lnet/minecraft/unmapped/C_xpuuihxf;)V
 	METHOD m_pjpwgxem setFacing (Lnet/minecraft/unmapped/C_xpuuihxf;)V
 		ARG 1 facing
 	METHOD m_rhbnmmyq calculateSupportBox ()Lnet/minecraft/unmapped/C_hbcjzgoe;

--- a/mappings/net/minecraft/entity/decoration/ArmorStandEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/ArmorStandEntity.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorStandEntity
 	FIELD f_auvsnpeu HEAD_OFFSET D
 	FIELD f_bakejrew disabledSlots I
+	FIELD f_bdjdtzas DEFAULT_SHOW_ARMS Z
+	FIELD f_cztaudgy DEFAULT_INVISIBLE Z
 	FIELD f_dygcmpso SMALL_FLAG I
 	FIELD f_eextqtfq ARMOR_STAND_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_eqjycsoi DEFAULT_LEFT_LEG_ROTATION Lnet/minecraft/unmapped/C_eocijcdh;
@@ -11,6 +13,7 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 	FIELD f_hledmzpc TRACKER_HEAD_ROTATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ihlpaimj HIDE_BASE_PLATE_FLAG I
 	FIELD f_jqsgttid FEET_OFFSET D
+	FIELD f_kxxwfmdq DEFAULT_DISABLED_SLOTS I
 	FIELD f_lsrlfled DISABLE_ITEM_TAKE_OFFSET I
 	FIELD f_ltzkfijb WOBBLE_DURATION I
 	FIELD f_mpsgxhqr SMALL_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
@@ -20,6 +23,7 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 	FIELD f_nzpnpxtw DEFAULT_LEFT_ARM_ROTATION Lnet/minecraft/unmapped/C_eocijcdh;
 	FIELD f_opgsiyvu TRACKER_LEFT_LEG_ROTATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_phnxsexj MARKER_FLAG I
+	FIELD f_psvihtwq DEFAULT_MARKER Z
 	FIELD f_qnhkdyut CHEST_OFFSET D
 	FIELD f_rzevixqb TRACKER_LEFT_ARM_ROTATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_srwmxyee RIDEABLE_MINECART_PREDICATE Ljava/util/function/Predicate;
@@ -30,6 +34,8 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 	FIELD f_wjlcjana MARKER_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_wlljxznk DEFAULT_BODY_ROTATION Lnet/minecraft/unmapped/C_eocijcdh;
 	FIELD f_xnsfjgdv lastHitTime J
+	FIELD f_yftkmlll DEFAULT_NO_BASE_PLATE Z
+	FIELD f_zxsofnag DEFAULT_SMALL Z
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;DDD)V
 		ARG 1 world
 		ARG 2 x
@@ -52,6 +58,7 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 		ARG 2 bitField
 		ARG 3 set
 	METHOD m_fjamjtjb showsArms ()Z
+	METHOD m_fkeapzvj createPose ()Lnet/minecraft/unmapped/C_nknvrhfn$C_cuiyqhcn;
 	METHOD m_foqjlatj setLeftLegRotation (Lnet/minecraft/unmapped/C_eocijcdh;)V
 		ARG 1 angle
 	METHOD m_fqivefvy isMarker ()Z
@@ -66,6 +73,8 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 		ARG 1 slot
 	METHOD m_nendfomc buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_npsgczto playBreakSound ()V
+	METHOD m_nvjbctcm setPose (Lnet/minecraft/unmapped/C_nknvrhfn$C_cuiyqhcn;)V
+		ARG 1 pose
 	METHOD m_pgcyrpjv spawnBreakParticles ()V
 	METHOD m_phaftboj getLeftLegRotation ()Lnet/minecraft/unmapped/C_eocijcdh;
 	METHOD m_qidmuyim setShowArms (Z)V
@@ -93,3 +102,5 @@ CLASS net/minecraft/unmapped/C_nknvrhfn net/minecraft/entity/decoration/ArmorSta
 	METHOD m_yrstsnkh slotFromPosition (Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_yuycoehb;
 		ARG 1 hitPos
 	METHOD m_zqjkpqot getLeftArmRotation ()Lnet/minecraft/unmapped/C_eocijcdh;
+	CLASS C_cuiyqhcn Pose
+		FIELD f_jritfhxt DEFAULT Lnet/minecraft/unmapped/C_nknvrhfn$C_cuiyqhcn;

--- a/mappings/net/minecraft/entity/decoration/Brightness.mapping
+++ b/mappings/net/minecraft/entity/decoration/Brightness.mapping
@@ -4,7 +4,15 @@ CLASS net/minecraft/unmapped/C_wzagqsft net/minecraft/entity/decoration/Brightne
 	FIELD f_rzgjknig CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_tpljmvtr sky I
 	FIELD f_vrlnmcco block I
+	METHOD m_ctuyjhpd packData ()I
 	METHOD m_jkvlrmey pack (I)Lnet/minecraft/unmapped/C_wzagqsft;
+		ARG 0 data
+	METHOD m_mibdyqum unpackBlock (I)I
+		ARG 0 data
+	METHOD m_mqhgxgwf packData (II)I
+		ARG 0 block
+		ARG 1 sky
+	METHOD m_uzzvgqqt unpackSky (I)I
 		ARG 0 data
 	METHOD m_zqrbrcyh (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance

--- a/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
@@ -24,10 +24,13 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	FIELD f_owzwxrlm GLOW_COLOR_OVERRIDE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_pcqrtoci VIEW_RANGE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_pebjmjqa updateInterpolationDuration Z
+	FIELD f_powhdosz DEFAULT_START_INTERPOLATION I
 	FIELD f_qawhpaou HEIGHT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_qfnokasi interpolationProgress F
 	FIELD f_qxpwolsf SHADOW_RADIUS_KEY Ljava/lang/String;
 	FIELD f_rrozolcg TRANSLATION Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_rsfepywv DEFAULT_INTERPOLATION_DURATION I
+	FIELD f_sxmonsvq INITIAL_HEIGHT F
 	FIELD f_tlzklppc SHADOW_STRENGTH_KEY Ljava/lang/String;
 	FIELD f_tqjbnsuz NO_BRIGHTNESS_OVERRIDE I
 	FIELD f_uaimxenm BRIGHTNESS_OVERRIDE Lnet/minecraft/unmapped/C_rinmcaxy;
@@ -35,15 +38,20 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	FIELD f_uwuepspo interpolationStart J
 	FIELD f_vayhsclz RIGHT_ROTATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_vmgxiagt RENDER_STATE_IDS Lit/unimi/dsi/fastutil/ints/IntSet;
+	FIELD f_vumfwpov INITIAL_VIEW_RANGE F
 	FIELD f_wfsednzd START_INTERPOLATION_KEY Ljava/lang/String;
+	FIELD f_wkculdhp INITIAL_POSITION_ROTATION_INTERPOLATION_DURATION I
 	FIELD f_wpcewhgi INITIAL_SHADOW_RADIUS F
 	FIELD f_xgnfhngl BILLBOARD_KEY Ljava/lang/String;
 	FIELD f_xlyoeing INTERPOLATION_DURATION Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_zflourbb INITIAL_WIDTH F
 	FIELD f_zfworekp interpolator Lnet/minecraft/unmapped/C_sdgyrixf;
 	FIELD f_zlrldkqq LOGGER Lorg/slf4j/Logger;
 	FIELD f_zmedthph HEIGHT_KEY Ljava/lang/String;
 	METHOD m_anrfuahp getViewRange ()F
 	METHOD m_cfgjadmn updateRenderData (ZF)V
+		ARG 1 interpolate
+		ARG 2 interpolationProgress
 	METHOD m_crsnfjzr setGlowColorOverride (I)V
 		ARG 1 override
 	METHOD m_ctwyttpa setInterpolationDuration (I)V
@@ -89,11 +97,13 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	METHOD m_ykgoueyp setShadowRadius (F)V
 		ARG 1 radius
 	METHOD m_zesirgas getGlowColorOverride ()I
-	CLASS C_aefytrhe AbstractInterpolator
+	CLASS C_aefytrhe Interpolator
 		METHOD constant (Ljava/lang/Object;)Lnet/minecraft/unmapped/C_zdeutotk$C_aefytrhe;
 			ARG 0 value
+		METHOD get interpolate (F)Ljava/lang/Object;
+			ARG 1 progress
 		METHOD m_xavndidf (Ljava/lang/Object;F)Ljava/lang/Object;
-			ARG 1 f
+			ARG 1 progress
 	CLASS C_btdrhauy LinearFloatInterpolator
 	CLASS C_cozbiatm BillboardRenderConstraints
 		FIELD f_afcfxjuf BY_ID Ljava/util/function/IntFunction;
@@ -112,17 +122,21 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 	CLASS C_eotnewog IntInterpolator
 		METHOD constant (I)Lnet/minecraft/unmapped/C_zdeutotk$C_eotnewog;
 			ARG 0 value
+		METHOD get interpolate (F)I
+			ARG 1 progress
 		METHOD m_vtnrumje (IF)I
-			ARG 1 i
+			ARG 1 progress
 	CLASS C_fdgxcfnt RenderState
 	CLASS C_kalfqsxh ARGB32Interpolator
 	CLASS C_mpyykwwj TransformationInterpolator
 	CLASS C_ncfzfjmg FloatInterpolator
 		METHOD constant (F)Lnet/minecraft/unmapped/C_zdeutotk$C_ncfzfjmg;
 			ARG 0 value
+		METHOD get interpolate (F)F
+			ARG 1 progress
 		METHOD m_nqtknbun (FF)F
-			ARG 1 f
-	CLASS C_ruprkvfh TextDisplayEntity
+			ARG 1 progress
+	CLASS C_ruprkvfh Text
 		FIELD f_bzbrolxv renderData Lnet/minecraft/unmapped/C_zdeutotk$C_ruprkvfh$C_mvidrtny;
 		FIELD f_cjxhpagy SEE_THROUGH_FLAG B
 		FIELD f_cxxrvjvt INITIAL_TEXT_OPACITY B
@@ -136,6 +150,7 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 		FIELD f_mblrkqbg DEFAULT_BACKGROUND_KEY Ljava/lang/String;
 		FIELD f_mcjpxhse TEXT_DISPLAY_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 		FIELD f_nrdyskvo BACKGROUND_KEY Ljava/lang/String;
+		FIELD f_oogftpgq INITIAL_LINE_WIDTH I
 		FIELD f_pdxvniyi TEXT Lnet/minecraft/unmapped/C_rinmcaxy;
 		FIELD f_pfyjwtvs cachedLine Lnet/minecraft/unmapped/C_zdeutotk$C_ruprkvfh$C_hkiddmgs;
 		FIELD f_pvhhpwoq SHADOW_KEY Ljava/lang/String;
@@ -194,6 +209,9 @@ CLASS net/minecraft/unmapped/C_zdeutotk net/minecraft/entity/decoration/DisplayE
 			METHOD m_wjjanlea width ()I
 		CLASS C_mvidrtny RenderData
 		CLASS C_stdatsys LineSplitter
+			METHOD split (Lnet/minecraft/unmapped/C_rdaqiwdt;I)Lnet/minecraft/unmapped/C_zdeutotk$C_ruprkvfh$C_hkiddmgs;
+				ARG 1 text
+				ARG 2 width
 	CLASS C_ukdbitoi LinearIntInterpolator
 	CLASS C_yooamzmm ItemDisplayEntity
 		FIELD f_cbyffnkw renderData Lnet/minecraft/unmapped/C_zdeutotk$C_yooamzmm$C_quljyame;

--- a/mappings/net/minecraft/entity/decoration/EndCrystalEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/EndCrystalEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_akvrfxgg net/minecraft/entity/decoration/EndCrystalEntity
 	FIELD f_huhszrgr SHOW_BOTTOM Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_srwrifuo DEFAULT_SHOW_BOTTOM Z
 	FIELD f_ucucjwgh endCrystalAge I
 	FIELD f_vjzgrtaf BEAM_TARGET Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;DDD)V

--- a/mappings/net/minecraft/entity/decoration/ItemFrameEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/ItemFrameEntity.mapping
@@ -1,9 +1,13 @@
 CLASS net/minecraft/unmapped/C_hywnolpn net/minecraft/entity/decoration/ItemFrameEntity
+	FIELD f_aqkqumbu DEFAULT_INVISIBLE Z
 	FIELD f_ccszafxh ITEM_STACK Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_cjgznogv DEFAULT_ROTATION B
 	FIELD f_dnmfuadb itemDropChance F
+	FIELD f_fboryzwo DEFAULT_ITEM_DROP_CHANCE F
 	FIELD f_hkngbiyl ROTATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_mitznpai HEIGHT F
 	FIELD f_nallonhx DEPTH F
+	FIELD f_phbzdkwz DEFAULT_FIXED Z
 	FIELD f_rdvivgoi ROTATIONS_COUNT I
 	FIELD f_xrplubwv WIDTH F
 	FIELD f_zsyuumcg fixed Z

--- a/mappings/net/minecraft/entity/decoration/painting/PaintingEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/painting/PaintingEntity.mapping
@@ -20,5 +20,7 @@ CLASS net/minecraft/unmapped/C_xypmuulf net/minecraft/entity/decoration/painting
 		ARG 1 pos
 		ARG 2 direction
 	METHOD m_vkqzwvap getVariant ()Lnet/minecraft/unmapped/C_cjzoxshv;
+	METHOD m_ydtbeyge setVariant (Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 1 variant
 	METHOD m_zksfobqk getOffset (I)D
 		ARG 1 width

--- a/mappings/net/minecraft/entity/effect/OozingStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/OozingStatusEffect.mapping
@@ -11,5 +11,11 @@ CLASS net/minecraft/unmapped/C_koniavnx net/minecraft/entity/effect/OozingStatus
 		ARG 1 counter
 		ARG 2 nearbySlimeCount
 	CLASS C_ehxlmbuh SlimeCounter
+		METHOD count (I)I
+			ARG 1 max
+		METHOD m_jxtxkxjh (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_evgtelyd;)Z
+			ARG 1 collected
 		METHOD m_ttqtxznn collectNearby (Lnet/minecraft/unmapped/C_usxaxydn;)Lnet/minecraft/unmapped/C_koniavnx$C_ehxlmbuh;
 			ARG 0 entity
+		METHOD m_vcpsytew (Lnet/minecraft/unmapped/C_usxaxydn;I)I
+			ARG 1 max

--- a/mappings/net/minecraft/entity/effect/PoisonStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/PoisonStatusEffect.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/unmapped/C_fradzqif net/minecraft/entity/effect/PoisonStatusEffect
+	FIELD f_ghjppwmp DAMAGE_INTERVAL I

--- a/mappings/net/minecraft/entity/effect/WitherStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/WitherStatusEffect.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/unmapped/C_gjaxwcua net/minecraft/entity/effect/WitherStatusEffect
+	FIELD f_takhmbif DAMAGE_INTERVAL I

--- a/mappings/net/minecraft/entity/mob/AbstractPiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/AbstractPiglinEntity.mapping
@@ -1,8 +1,13 @@
 CLASS net/minecraft/unmapped/C_imddhoxf net/minecraft/entity/mob/AbstractPiglinEntity
+	FIELD f_asqsiofy DEFAULT_TIME_IN_OVERWORLD I
 	FIELD f_ccdwqbtw timeInOverworld I
 	FIELD f_maubafqr IMMUNE_TO_ZOMBIFICATION Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_oqyfpktp TIME_TO_ZOMBIFY I
+	FIELD f_rlosvila DEFAULT_IMMUNE_TO_ZOMBIFICATION Z
+	FIELD f_vwjwjqkv DEFAULT_PICK_UP_LOOT Z
 	METHOD m_bmugrmhr canHunt ()Z
+	METHOD m_bulcqeeg (Lnet/minecraft/unmapped/C_vrkapiph;)V
+		ARG 0 zombifiedPiglin
 	METHOD m_cltstgpt isHoldingTool ()Z
 	METHOD m_ebjshjiv isImmuneToZombification ()Z
 	METHOD m_gpunyogc setCanPathThroughDoors ()V

--- a/mappings/net/minecraft/entity/mob/BoggedEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/BoggedEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_zsgzopda net/minecraft/entity/mob/BoggedEntity
 	FIELD f_rjtsvgat NORMAL_ATTACK_INTERVAL I
 	FIELD f_wcnzlqso SHEARED Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_wwspafil DEFAULT_SHEARED Z
 	FIELD f_xcdypokt SHEARED_KEY Ljava/lang/String;
 	FIELD f_zalggvqu HARD_ATTACK_INTERVAL I
 	METHOD m_hspcdijf buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;

--- a/mappings/net/minecraft/entity/mob/BreezeBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/BreezeBrain.mapping
@@ -6,12 +6,16 @@ CLASS net/minecraft/unmapped/C_gxdsshkk net/minecraft/entity/mob/BreezeBrain
 	FIELD f_usqhomax TICKS_BEFORE_FORGETTING_TARGET I
 	FIELD f_wjnamjhu MEMORY_MODULES Ljava/util/List;
 	FIELD f_ygzaeast JUMP_CIRCLE_MIDDLE_RADIUS F
+	METHOD m_bgkbclyc (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_nqresjkz;)Ljava/util/Optional;
+		ARG 1 breeze
 	METHOD m_inljbpxh addIdleTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	METHOD m_iwbteida addFightTasks (Lnet/minecraft/unmapped/C_nqresjkz;Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 breeze
 	METHOD m_srjsqfdn updateActivities (Lnet/minecraft/unmapped/C_nqresjkz;)V
 		ARG 0 breeze
-	METHOD m_tbkrmicx create (Lnet/minecraft/unmapped/C_nqresjkz;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_tbkrmicx init (Lnet/minecraft/unmapped/C_nqresjkz;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 		ARG 0 breeze
+	METHOD m_vlkavroj (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_nqresjkz;)Ljava/util/Optional;
+		ARG 1 breeze
 	METHOD m_xtdyigmi addCoreTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	CLASS C_zxrtsqua BreezeWanderTask

--- a/mappings/net/minecraft/entity/mob/CreakingBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/CreakingBrain.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/unmapped/C_nkqatzha net/minecraft/entity/mob/CreakingBrain
 		ARG 2 target
 	METHOD m_rhrbxoao (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vbugwmii;)Ljava/util/Optional;
 		ARG 1 creaking
-	METHOD m_rxjjsjcj create (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_rxjjsjcj init (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_suwefzcr addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	METHOD m_vpamiunc createProfile ()Lnet/minecraft/unmapped/C_rjqjaxef$C_liifzsnq;
 	METHOD m_wvhfkjve updateActivities (Lnet/minecraft/unmapped/C_vbugwmii;)V

--- a/mappings/net/minecraft/entity/mob/CreakingBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/CreakingBrain.mapping
@@ -2,9 +2,21 @@ CLASS net/minecraft/unmapped/C_nkqatzha net/minecraft/entity/mob/CreakingBrain
 	FIELD f_spaomsvc MEMORY_MODULES Lcom/google/common/collect/ImmutableList;
 	FIELD f_uavqxrpw SENSORS Lcom/google/common/collect/ImmutableList;
 	METHOD m_fdgcwgsd addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
+	METHOD m_fziipuhf remembers (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 0 creaking
+		ARG 1 target
 	METHOD m_hhynauwr addFightActivities (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_rjqjaxef;)V
+		ARG 0 creaking
+	METHOD m_oolwddfb (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vbugwmii;)Z
+		ARG 1 creaking
+	METHOD m_ozlouwhs (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 2 target
+	METHOD m_rhrbxoao (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vbugwmii;)Ljava/util/Optional;
+		ARG 1 creaking
 	METHOD m_rxjjsjcj create (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_suwefzcr addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	METHOD m_vpamiunc createProfile ()Lnet/minecraft/unmapped/C_rjqjaxef$C_liifzsnq;
 	METHOD m_wvhfkjve updateActivities (Lnet/minecraft/unmapped/C_vbugwmii;)V
 		ARG 0 creaking
+	METHOD m_yujzddod (Lnet/minecraft/unmapped/C_usxaxydn;Ljava/util/List;)Ljava/lang/Boolean;
+		ARG 1 players

--- a/mappings/net/minecraft/entity/mob/CreakingEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/CreakingEntity.mapping
@@ -6,31 +6,54 @@ CLASS net/minecraft/unmapped/C_vbugwmii net/minecraft/entity/mob/CreakingEntity
 	FIELD f_erznzcem CRUMBLING Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gnorwjlj invulnerabilityAnimationState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_iflztenn attackCooldown I
+	FIELD f_iunqojip DEATH_ANIMATION_DURATION I
+	FIELD f_izfbuckb stuckPlayerCount I
 	FIELD f_jujfnssl ACTIVE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_mtuothfq crumblingAnimationState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_mzkqzzle ATTACK_ANIMATION_DURATION I
 	FIELD f_nmjsivwg eyeFlickerTime I
+	FIELD f_odepcruq HEART_POS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ofciybzl eyesGlowing Z
+	FIELD f_ptguvdgz INVULNERABILITY_ANIMATION_DURATION I
 	FIELD f_rcowlgzl FOLLOW_RANGE F
+	FIELD f_roxbnmmr invulnerabilityTicks I
 	FIELD f_sdmnlrcu MAX_HEALTH I
 	FIELD f_sjorwcyp ORANGE I
 	FIELD f_sqbcuhao ATTACK_INTERVAL I
 	FIELD f_stkvvsxy attackAnimationState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_tocwldwq ACTIVATION_RANGE_SQUARED F
+	FIELD f_wypppkgp PLAYER_STUCK_THRESHOLD I
 	FIELD f_yaenaqzq FIGHTING_MOVEMENT_SPEED F
+	METHOD m_bhvjapqu getHeartPos ()Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_bntgyzgy finishDeathAnimation ()V
+	METHOD m_dxlqnntx hasHeart ()Z
+	METHOD m_dyypgakn trySetAttacker (Lnet/minecraft/unmapped/C_sbxfkpyv;)Lnet/minecraft/unmapped/C_jzrpycqo;
+		COMMENT @return the player attacking this creaking, or {@code null} if there isn't one
+		ARG 1 source
 	METHOD m_japnsene setActive (Z)V
 	METHOD m_jkvxeltg buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
-	METHOD m_jysxmfcv (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+	METHOD m_jysxmfcv onHeartDisconnected (Lnet/minecraft/unmapped/C_sbxfkpyv;)V
 		ARG 1 source
+	METHOD m_kyyxuuzo deactivate ()V
 	METHOD m_ohccomft animate ()V
+	METHOD m_pdevjnhk activate (Lnet/minecraft/unmapped/C_jzrpycqo;)V
+		ARG 1 target
 	METHOD m_qnnyojvb checkCanMove ()Z
+	METHOD m_rdyjwwcg isStuckByPlayers ()Z
 	METHOD m_rjsnoulh isCrumbling ()Z
+	METHOD m_ufybmgri setHeartPos (Lnet/minecraft/unmapped/C_hynzadkk;)V
+	METHOD m_vaxvtexl initHeartPos (Lnet/minecraft/unmapped/C_hynzadkk;)V
 	METHOD m_vbarudri areEyesGlowing ()Z
 	METHOD m_vhivxqyn setCrumbling ()V
 	METHOD m_vrawqntp updateEyeFlicker ()V
 	METHOD m_xchtvnyy canMove ()Z
 	METHOD m_xkvsljnw isActive ()Z
-	CLASS C_bhmfzyyn CreakingJumpControl
-	CLASS C_hkgbvofv CreakingMoveControl
-	CLASS C_hnlwfmab CreakingLookControl
-	CLASS C_pukuzfds CreakingBodyControl
+	CLASS C_bhmfzyyn JumpControl
+	CLASS C_hkgbvofv MoveControl
+	CLASS C_hmzakxgv Navigation
+		METHOD <init> (Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_vbugwmii;Lnet/minecraft/unmapped/C_cdctfzbn;)V
+			ARG 2 creaking
+	CLASS C_hnlwfmab LookControl
+	CLASS C_jxkkzdqe HomePathNodeMaker
+		FIELD f_rfjvbago MAX_HOME_DISTANCE_SQUARED I
+	CLASS C_pukuzfds BodyControl

--- a/mappings/net/minecraft/entity/mob/CreeperEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/CreeperEntity.mapping
@@ -3,10 +3,14 @@ CLASS net/minecraft/unmapped/C_ccephliv net/minecraft/entity/mob/CreeperEntity
 	FIELD f_atymnneu CHARGED Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ekoubqtp IGNITED Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_gjsbotpv currentFuseTime I
+	FIELD f_gmbqgdzm DEFAULT_IGNITED Z
 	FIELD f_jsejkuzn headsDropped I
+	FIELD f_kbvtrren DEFAULT_FUZE_TIME S
 	FIELD f_liphnvot explosionRadius I
 	FIELD f_miucwsoq FUSE_SPEED Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_skcczhuq fuseTime I
+	FIELD f_vjfuxogj DEFAULT_CHARGED Z
+	FIELD f_yvzkvusy DEFAULT_EXPLOSION_RADIUS B
 	METHOD m_astckkwi spawnEffectsCloud ()V
 	METHOD m_bsnfemxw explode ()V
 	METHOD m_gtvyrmxb isCharged ()Z

--- a/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
@@ -21,6 +21,7 @@ CLASS net/minecraft/unmapped/C_qujqqtsx net/minecraft/entity/mob/EndermanEntity
 	METHOD m_qkjqvawe isProvoked ()Z
 	METHOD m_qxprdwna hurtWithWaterPotion (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sbxfkpyv;Lnet/minecraft/unmapped/C_hnnjbqvi;F)Z
 		ARG 2 source
+		ARG 3 potion
 		ARG 4 amount
 	METHOD m_sozjchei buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_sqzfibwu teleportTo (DDD)Z

--- a/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_bgwbgrcg net/minecraft/entity/mob/EndermiteEntity
+	FIELD f_kzzwoily DEFAULT_LIFE_TIME I
 	FIELD f_lkxolrkw lifeTime I
 	FIELD f_zdwdamdg DESPAWN_TIME I
 	METHOD m_qtmdrqrq canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z

--- a/mappings/net/minecraft/entity/mob/EvokerFangsEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EvokerFangsEntity.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_qnwnelbf net/minecraft/entity/mob/EvokerFangsEnti
 	FIELD f_oqagfioa warmup I
 	FIELD f_szuljuev ticksLeft I
 	FIELD f_txwqanwv ATTACK_TRIGGER_TICKS I
+	FIELD f_xwhesayd DEFAULT_WARMUP I
 	FIELD f_ywyraczv LIFE_OFFSET I
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;DDDFILnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 world

--- a/mappings/net/minecraft/entity/mob/GhastEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/GhastEntity.mapping
@@ -1,11 +1,13 @@
 CLASS net/minecraft/unmapped/C_fdzgodmg net/minecraft/entity/mob/GhastEntity
 	FIELD f_paccnhak SHOOTING Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_tututexk fireballStrength I
+	FIELD f_vbmumaif DEFAULT_FIREBALL_STRENGTH B
 	METHOD m_fekrfazo wasReturnedToSender (Lnet/minecraft/unmapped/C_sbxfkpyv;)Z
 		COMMENT Checks whether the {@link DamageSource} was a fireball reflected by a player.
 		COMMENT @return {@code true} if the damage source was a fireball reflected by a player, or {@code false} otherwise
 		ARG 0 damageSource
 	METHOD m_jdowfhlp buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_kyqwyvgo updateYaw (Lnet/minecraft/unmapped/C_dxkfswlz;)V
 	METHOD m_sjhbwljk setShooting (Z)V
 		ARG 1 shooting
 	METHOD m_tksvcdnv getFireballStrength ()I
@@ -15,7 +17,16 @@ CLASS net/minecraft/unmapped/C_fdzgodmg net/minecraft/entity/mob/GhastEntity
 		ARG 1 world
 		ARG 3 pos
 	CLASS C_eguvynvm FlyRandomlyGoal
+		FIELD f_knlmomhw MAX_ATTEMPTS I
 		FIELD f_uvwslrbk ghast Lnet/minecraft/unmapped/C_dxkfswlz;
+		FIELD f_yharzaok maxTargetOffset I
+		METHOD m_cmlexuyc canTarget (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_vgpupfxx;I)Z
+			ARG 2 maxOffset
+		METHOD m_gspaecsq findTarget (Lnet/minecraft/unmapped/C_dxkfswlz;I)Lnet/minecraft/unmapped/C_vgpupfxx;
+			ARG 1 maxOffset
+		METHOD m_krgcwwjj randomizeWithinHome (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		METHOD m_tkskcrhk randomize (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_vgpupfxx;
+			ARG 0 pos
 	CLASS C_ncudatqk LookAtTargetGoal
 		FIELD f_hwvtysnh ghast Lnet/minecraft/unmapped/C_dxkfswlz;
 	CLASS C_uvsgpibh ShootFireballGoal
@@ -23,8 +34,17 @@ CLASS net/minecraft/unmapped/C_fdzgodmg net/minecraft/entity/mob/GhastEntity
 		FIELD f_sfnnyyxt ghast Lnet/minecraft/unmapped/C_fdzgodmg;
 		METHOD <init> (Lnet/minecraft/unmapped/C_fdzgodmg;)V
 			ARG 1 ghast
-	CLASS C_woknjlgn GhastMoveControl
+	CLASS C_woknjlgn MoveControl
+		FIELD f_drwajvyf happy Z
 		FIELD f_jwmswdmz ghast Lnet/minecraft/unmapped/C_dxkfswlz;
 		FIELD f_kjoknnoa collisionCheckCooldown I
+		FIELD f_ykpzvypj isStill Ljava/util/function/BooleanSupplier;
+		METHOD m_aifjbysy canPathTo (Lnet/minecraft/unmapped/C_peaveboq;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hynzadkk;ZZ)Z
+			ARG 2 ghastPos
+			ARG 3 target
+			ARG 5 touchingWater
+			ARG 6 inLava
+		METHOD m_lrziqvim (Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;ZZLnet/minecraft/unmapped/C_hynzadkk;I)Z
+			ARG 7 iteration
 		METHOD m_xdtybxya willCollide (Lnet/minecraft/unmapped/C_vgpupfxx;)Z
-			ARG 1 direction
+			ARG 1 targetOffset

--- a/mappings/net/minecraft/entity/mob/HoglinBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/HoglinBrain.mapping
@@ -23,8 +23,7 @@ CLASS net/minecraft/unmapped/C_hddicvsw net/minecraft/entity/mob/HoglinBrain
 		ARG 1 activity
 	METHOD m_elhufzgz (Lnet/minecraft/unmapped/C_fnzykddk;Lnet/minecraft/unmapped/C_gqmpgxlw;)Lnet/minecraft/unmapped/C_avavozay;
 		ARG 1 activity
-	METHOD m_ezizisnp create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_ezizisnp init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_fmovaocc getSoundEvent (Lnet/minecraft/unmapped/C_fnzykddk;)Ljava/util/Optional;
 		ARG 0 hoglin
 	METHOD m_frheotbl refreshActivities (Lnet/minecraft/unmapped/C_fnzykddk;)V

--- a/mappings/net/minecraft/entity/mob/HoglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/HoglinEntity.mapping
@@ -2,16 +2,21 @@ CLASS net/minecraft/unmapped/C_fnzykddk net/minecraft/entity/mob/HoglinEntity
 	FIELD f_emlqkcps ATTACK_KNOCKBACK I
 	FIELD f_gxtgevss timeInOverworld I
 	FIELD f_hewflnwa MEMORY_MODULE_TYPES Lcom/google/common/collect/ImmutableList;
+	FIELD f_kqvttbmc DEFAULT_TIME_IN_OVERWORLD I
 	FIELD f_kyuqnuyr cannotBeHunted Z
+	FIELD f_njkxoasz DEFAULT_IMMUNE_TO_ZOMBIFICATION Z
 	FIELD f_obslggle KNOCKBACK_RESISTANCE F
 	FIELD f_ojzheltu MAX_HEALTH I
 	FIELD f_qvafdtfm BABY_ATTACK_DAMAGE F
 	FIELD f_qvrctnyb SENSOR_TYPES Lcom/google/common/collect/ImmutableList;
+	FIELD f_stwgpqar DEFAULT_CANNOT_BE_HUNTED Z
 	FIELD f_tqecwjfe BABY Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_vfdklure FIGHTING_MOVEMENT_SPEED F
 	FIELD f_vsgooziv CONVERSION_TIME I
 	FIELD f_vzzufnvg ATTACK_DAMAGE I
 	FIELD f_yicrjrzo movementCooldownTicks I
+	METHOD m_bmwyjrtd (Lnet/minecraft/unmapped/C_lsverzlu;)V
+		ARG 0 zoglin
 	METHOD m_cbcfhojz canConvert ()Z
 	METHOD m_ljhxfqmt zombify ()V
 	METHOD m_mnmxbgxw canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	FIELD f_ajdoejzx MAX_PICKUP_LOOT_PROBABILITY F
 	FIELD f_bbapxczi persistent Z
 	FIELD f_chzsgmuy pickUpLoot Z
+	FIELD f_cytzxewp DEFAULT_PERSISTENCE_REQUIRED Z
 	FIELD f_cyzznzel MOB_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ddgktbfn target Lnet/minecraft/unmapped/C_usxaxydn;
 	FIELD f_efwglgie PICKUP_REACH I
@@ -11,24 +12,32 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	FIELD f_glqvyrmd lootTableSeed J
 	FIELD f_gpqxsoam experiencePoints I
 	FIELD f_hdjycqoz MAX_ENCHANTED_ARMOR_PROBABILITY F
+	FIELD f_hvqtkjiy DROP_CHANCES_KEY Ljava/lang/String;
 	FIELD f_icyyyrgv bodyControl Lnet/minecraft/unmapped/C_vofymfgv;
 	FIELD f_irlmhwzh navigation Lnet/minecraft/unmapped/C_atbvfjwi;
+	FIELD f_kgkkbuqg NO_AI_KEY Ljava/lang/String;
 	FIELD f_mulpcwks EQUIPMENT_INIT_ORDER Ljava/util/List;
 	FIELD f_nwzksedo goalSelector Lnet/minecraft/unmapped/C_qospjrjn;
 	FIELD f_nzzqwalu pathfindingPenalties Ljava/util/Map;
 	FIELD f_oigfymps MAX_ENCHANTED_WEAPON_PROBABILITY F
 	FIELD f_omqaaiuh visibilityCache Lnet/minecraft/unmapped/C_vyefybqz;
+	FIELD f_owvmggnm DEFAULT_LEFT_HANDED Z
 	FIELD f_pzxywady ambientSoundChance I
 	FIELD f_qsoplnyt ITEM_PICKUP_REACH Lnet/minecraft/unmapped/C_ceivtqhh;
+	FIELD f_rdhzdxlr CAN_PICK_UP_LOOT_KEY Ljava/lang/String;
 	FIELD f_sqjsiqdf jumpControl Lnet/minecraft/unmapped/C_tmduotiw;
 	FIELD f_srixsinn LEFT_HANDED_FLAG I
 	FIELD f_tcesvuol lookControl Lnet/minecraft/unmapped/C_lgufpcrf;
+	FIELD f_thbudfzd homeRadius I
+	FIELD f_tjqgdgni LEFT_HANDED_KEY Ljava/lang/String;
 	FIELD f_uushnomk targetSelector Lnet/minecraft/unmapped/C_qospjrjn;
+	FIELD f_vejnliqr DEFAULT_CAN_PICK_UP_LOOT Z
 	FIELD f_vuffzgdh lootTable Ljava/util/Optional;
 	FIELD f_wfwaeazd leashData Lnet/minecraft/unmapped/C_gbavazgo$C_trsxpkpu;
-	FIELD f_whkkgkyp positionTarget Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_whkkgkyp home Lnet/minecraft/unmapped/C_hynzadkk;
 	FIELD f_wkutgcpe DEFAULT_ATTACK_RANGE D
 	FIELD f_xjabburn equipmentDropChances Lnet/minecraft/unmapped/C_zkbnpubo;
+	FIELD f_xmiuejgm DEFAULT_NO_AI Z
 	FIELD f_yqqanohh RANDOM_SPAWN_BONUS_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_ziddtuje GOAL_SELECTOR_UPDATE_INTERVAL I
 	FIELD f_zwyrnqpo MAX_WEAR_ARMOR_PROBABILITY F
@@ -47,11 +56,20 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_dsykcsrd setAiDisabled (Z)V
 		ARG 1 aiDisabled
 	METHOD m_dwkutgwm playAttackSound ()V
+	METHOD m_eabfflhq preffersNewArmor (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_yuycoehb;)Z
+		ARG 1 newArmor
+		ARG 2 oldArmor
 	METHOD m_eeaedybm buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_epiypbqm clearHomeRadius ()V
 	METHOD m_erwclnrx setLeftHanded (Z)V
 		ARG 1 leftHanded
 	METHOD m_faldjosq getBodyArmor ()Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_farojbcm setHome (Lnet/minecraft/unmapped/C_hynzadkk;I)V
+		ARG 1 home
+		ARG 2 radius
 	METHOD m_fisapugx getJumpControl ()Lnet/minecraft/unmapped/C_tmduotiw;
+	METHOD m_fpirgiuj (Lnet/minecraft/unmapped/C_svjebams;)Z
+		ARG 0 goal
 	METHOD m_frolgtzg playAmbientSound ()V
 	METHOD m_galurjhs resetSoundDelay ()V
 	METHOD m_gdcidprz canMobSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
@@ -65,10 +83,15 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_gtwocchw updateGoalControls ()V
 	METHOD m_hykyexft setTarget (Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 target
+	METHOD m_iszwmkjh preffersNewWeapon (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_yuycoehb;)Z
+		ARG 1 newWeapon
+		ARG 2 oldWeapon
 	METHOD m_itjttsuo initGoals ()V
 	METHOD m_jdphaheu setSidewaysSpeed (F)V
 		ARG 1 sidewaysMovement
 	METHOD m_jjefzxbm getAmbientSound ()Lnet/minecraft/unmapped/C_avavozay;
+	METHOD m_jkyscsfv isInHome (Lnet/minecraft/unmapped/C_vgpupfxx;)Z
+		ARG 1 pos
 	METHOD m_jlsekxwk enchantEquipment (Lnet/minecraft/unmapped/C_jmnzlycd;Lnet/minecraft/unmapped/C_yuycoehb;Lnet/minecraft/unmapped/C_rlomrsco;FLnet/minecraft/unmapped/C_jiailwzt;)V
 		ARG 1 world
 		ARG 2 slot
@@ -95,6 +118,7 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 		ARG 1 entity
 	METHOD m_kxilreut canPickupItem (Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 stack
+	METHOD m_ldocmdgh createEquipmentInventory (Lnet/minecraft/unmapped/C_yuycoehb;)Lnet/minecraft/unmapped/C_pjtstjoq;
 	METHOD m_lfujztja getLookControl ()Lnet/minecraft/unmapped/C_lgufpcrf;
 	METHOD m_lofxmiwn setPersistent ()V
 	METHOD m_lpjmkwwe getMoveControl ()Lnet/minecraft/unmapped/C_azhvkebm;
@@ -109,11 +133,12 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_mrbrckqf isDisallowedInPeaceful ()Z
 	METHOD m_mztbwniz movesIndependently ()Z
 		COMMENT When true, causes this entity to take over pathfinding for its controlling passenger.
+	METHOD m_ntvgsokt getHomeRadius ()I
 	METHOD m_nzdowltt canGather (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 2 stack
 	METHOD m_nzxqjkay tryEquip (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
 		ARG 2 equipment
-	METHOD m_ocoscmiz getPositionTarget ()Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_ocoscmiz getHome ()Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_owfqcyjj changeAngle (FFF)F
 		ARG 1 oldAngle
 		ARG 2 newAngle
@@ -136,6 +161,7 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_rpistqzo isWearingBodyArmor ()Z
 	METHOD m_rpqyatoj convert (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_pkxijcfk;Lnet/minecraft/unmapped/C_pkxijcfk$C_olacbmtc;)Lnet/minecraft/unmapped/C_dxkfswlz;
 	METHOD m_ruuttiyq isPersistent ()Z
+	METHOD m_rxlmkyhd hasHome ()Z
 	METHOD m_rxurkduy getAttackTarget ()Lnet/minecraft/unmapped/C_usxaxydn;
 	METHOD m_saekgdkn stopMoving ()V
 	METHOD m_seslsqmb dropPreservedEquipment (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/util/function/Predicate;)Ljava/util/Set;
@@ -149,6 +175,8 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 		ARG 3 slot
 	METHOD m_szmqgzqm equipRandomly (Lnet/minecraft/unmapped/C_fiwnwrrf;)V
 		ARG 1 equipmentTable
+	METHOD m_tcqmwdcv clearLeashAngularMomentum ()V
+	METHOD m_thurzwcl isInHome ()Z
 	METHOD m_tjejbxzp canUseRangedWeapon (Lnet/minecraft/unmapped/C_axrfhndl;)Z
 		ARG 1 weapon
 	METHOD m_todoiyds clearGoalsAndTasks (Ljava/util/function/Predicate;)V
@@ -166,6 +194,7 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_uebjilbs equipRandomly (Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/Map;)V
 		ARG 1 lootTable
 		ARG 2 dropChances
+	METHOD m_ulpptnjs hasValidEquipment (Lnet/minecraft/unmapped/C_yuycoehb;)Z
 	METHOD m_uqccedlq canSpawn (Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;)Z
 		ARG 1 world
 	METHOD m_utndsklm equipBodyArmor (Lnet/minecraft/unmapped/C_sddaxwyk;)V
@@ -185,9 +214,12 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 		ARG 1 count
 	METHOD m_xipuyppw canSpawn (Lnet/minecraft/unmapped/C_eemzphbi;)Z
 		ARG 1 world
+	METHOD m_xjleopwq (Lnet/minecraft/unmapped/C_kespdwpv;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 loot
 	METHOD m_xmtehbhc setForwardSpeed (F)V
 		ARG 1 forwardSpeed
 	METHOD m_xozpkuaw sendAiDebugData ()V
+	METHOD m_ydtokxcc canShearEquipment (Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 	METHOD m_ymvczssz isAffectedByDaylight ()Z
 	METHOD m_yqlrvwhj setUpwardSpeed (F)V
 		ARG 1 upwardSpeed
@@ -197,3 +229,4 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 	METHOD m_zdjlhmwq getVisibilityCache ()Lnet/minecraft/unmapped/C_vyefybqz;
 	METHOD m_zjfgbeap isAiDisabled ()Z
 	METHOD m_zqkovfvg getPreferredWeapons ()Lnet/minecraft/unmapped/C_ednuhnnn;
+	METHOD m_zqzxvdjt isInHome (Lnet/minecraft/unmapped/C_hynzadkk;)Z

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -144,7 +144,6 @@ CLASS net/minecraft/unmapped/C_dxkfswlz net/minecraft/entity/mob/MobEntity
 		ARG 2 newAngle
 		ARG 3 maxChangeInAngle
 	METHOD m_oxrxxqyz initialize (Lnet/minecraft/unmapped/C_jmnzlycd;Lnet/minecraft/unmapped/C_jiailwzt;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_lsmqixfx;)Lnet/minecraft/unmapped/C_lsmqixfx;
-		ARG 1 world
 		ARG 2 difficulty
 		ARG 4 entityData
 	METHOD m_pfxzmaik cannotDespawn ()Z

--- a/mappings/net/minecraft/entity/mob/PathAwareEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PathAwareEntity.mapping
@@ -7,5 +7,5 @@ CLASS net/minecraft/unmapped/C_hqdayibh net/minecraft/entity/mob/PathAwareEntity
 	METHOD m_omcdcxbz getPathfindingFavor (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_eemzphbi;)F
 		ARG 1 pos
 		ARG 2 world
-	METHOD m_pimoyepk runsFromLeash ()Z
+	METHOD m_pimoyepk followsLeashHolder ()Z
 	METHOD m_qhakgnrd isPanicking ()Z

--- a/mappings/net/minecraft/entity/mob/PatrolEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PatrolEntity.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/unmapped/C_lywhhcqo net/minecraft/entity/mob/PatrolEntity
 	FIELD f_gabjxeyc patrolLeader Z
+	FIELD f_jfmpzuqq DEFAULT_PATROLLING Z
 	FIELD f_moatzrpo patrolling Z
+	FIELD f_nlgcmeur DEFAULT_PATROL_LEADER Z
 	FIELD f_qgaaxvgt patrolTarget Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_adxqfnwy getPatrolTarget ()Lnet/minecraft/unmapped/C_hynzadkk;
 		COMMENT Returns the position this patrol entity is walking to.

--- a/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
@@ -93,12 +93,13 @@ CLASS net/minecraft/unmapped/C_mxpeolkc net/minecraft/entity/mob/PiglinBrain
 		ARG 0 brain
 	METHOD m_jfdxonuw addAvoidActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
-	METHOD m_jighuprm create (Lnet/minecraft/unmapped/C_lkhqndnb;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_jighuprm init (Lnet/minecraft/unmapped/C_lkhqndnb;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 		ARG 0 piglin
-		ARG 1 brain
 	METHOD m_jqalumps shouldRunAwayFromHoglins (Lnet/minecraft/unmapped/C_lkhqndnb;)Z
 		ARG 0 piglin
 	METHOD m_klnzftun hasPiglinSafeArmor (Lnet/minecraft/unmapped/C_usxaxydn;)Z
+	METHOD m_klzvcuuu (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_lkhqndnb;)Z
+		ARG 1 piglin
 	METHOD m_kmcguhbn drop (Lnet/minecraft/unmapped/C_lkhqndnb;Ljava/util/List;Lnet/minecraft/unmapped/C_vgpupfxx;)V
 		ARG 0 piglin
 		ARG 1 items
@@ -177,7 +178,7 @@ CLASS net/minecraft/unmapped/C_mxpeolkc net/minecraft/entity/mob/PiglinBrain
 	METHOD m_wsfnykkq canRideHoglin (Lnet/minecraft/unmapped/C_lkhqndnb;)Z
 		ARG 0 piglin
 	METHOD m_wuohqgic addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-		ARG 0 piglin
+		ARG 0 brain
 	METHOD m_wuzxlluu canGather (Lnet/minecraft/unmapped/C_lkhqndnb;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 0 piglin
 		ARG 1 stack

--- a/mappings/net/minecraft/entity/mob/PiglinBruteBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinBruteBrain.mapping
@@ -14,9 +14,8 @@ CLASS net/minecraft/unmapped/C_dgxcirov net/minecraft/entity/mob/PiglinBruteBrai
 	METHOD m_fttpkqml addIdleActivities (Lnet/minecraft/unmapped/C_mpoupnon;Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 piglinBrute
 		ARG 1 brain
-	METHOD m_gwqlcabf create (Lnet/minecraft/unmapped/C_mpoupnon;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_gwqlcabf init (Lnet/minecraft/unmapped/C_mpoupnon;Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 		ARG 0 piglinBrute
-		ARG 1 brain
 	METHOD m_jyqvwnde setCurrentPosAsHome (Lnet/minecraft/unmapped/C_mpoupnon;)V
 		ARG 0 piglinBrute
 	METHOD m_kzwpbjhh updateActivity (Lnet/minecraft/unmapped/C_mpoupnon;)V
@@ -29,6 +28,8 @@ CLASS net/minecraft/unmapped/C_dgxcirov net/minecraft/entity/mob/PiglinBruteBrai
 		ARG 1 piglin
 		ARG 2 entity
 	METHOD m_qnbpbljr createIdleLookTask ()Lnet/minecraft/unmapped/C_njrxsvng;
+	METHOD m_rizlwbwo (Lnet/minecraft/unmapped/C_mpoupnon;Lnet/minecraft/unmapped/C_gqmpgxlw;)V
+		ARG 1 activity
 	METHOD m_usglrfib playAngrySoundIfFighting (Lnet/minecraft/unmapped/C_mpoupnon;)V
 		ARG 0 piglinBrute
 	METHOD m_xkiojnyt setAngryAt (Lnet/minecraft/unmapped/C_mpoupnon;Lnet/minecraft/unmapped/C_usxaxydn;)V

--- a/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_lkhqndnb net/minecraft/entity/mob/PiglinEntity
 	FIELD f_anmnqnjv BABY_SPAWN_PROBABILITY F
 	FIELD f_bmortxcl BABY_SPEED_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_brkyxhnn DEFAULT_IS_BABY Z
 	FIELD f_dicqsfvy DANCING Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_dvmxvvkj HOGLIN_MAX_PASSENGERS I
 	FIELD f_grlrcjra cannotHunt Z
@@ -8,6 +9,7 @@ CLASS net/minecraft/unmapped/C_lkhqndnb net/minecraft/entity/mob/PiglinEntity
 	FIELD f_ivxgmnqx FIGHTING_MOVEMENT_SPEED F
 	FIELD f_jchvuysg ARMOR_ITEM_CHANCE F
 	FIELD f_lqzurrbs SENSOR_TYPES Lcom/google/common/collect/ImmutableList;
+	FIELD f_ozguolvs DEFAULT_CANNOT_HUNT Z
 	FIELD f_qmuktilb MAX_HEALTH I
 	FIELD f_slqxoygl ATTACK_DAMAGE I
 	FIELD f_smtnduuu BABY_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;

--- a/mappings/net/minecraft/entity/mob/RavagerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/RavagerEntity.mapping
@@ -2,12 +2,15 @@ CLASS net/minecraft/unmapped/C_gijvkrwk net/minecraft/entity/mob/RavagerEntity
 	FIELD f_bgyajqwo CLIENT_ROAR_TARGET Ljava/util/function/Predicate;
 	FIELD f_bhqoehky STUNNED_COLOR_GREEN F
 	FIELD f_ctkcjtee NO_MOB_GRIEFING_ROAR_TARGET Ljava/util/function/Predicate;
+	FIELD f_ezbmphte DEFAULT_ROAR_TICK I
+	FIELD f_fqxsnumc DEFAULT_ATTACK_TICK I
 	FIELD f_hkyuymfz STUNNED_COLOR I
 	FIELD f_jzawnpsw ATTACK_DURATION I
 	FIELD f_khsyeshe BASE_MOVEMENT_SPEED D
 	FIELD f_lbysefin ATTACK_MOVEMENT_SPEED D
 	FIELD f_llpktooz stunTick I
 	FIELD f_orlcgfvr roarTick I
+	FIELD f_pifoaxyg DEFAULT_STUN_TICK I
 	FIELD f_pingjrzi STUNNED_COLOR_BLUE F
 	FIELD f_usreyzam STUN_DURATION I
 	FIELD f_vfyjxpaq STUNNED_COLOR_RED F
@@ -21,5 +24,7 @@ CLASS net/minecraft/unmapped/C_gijvkrwk net/minecraft/entity/mob/RavagerEntity
 	METHOD m_mauphpzg getRoarTick ()I
 	METHOD m_pditdeje getStunTick ()I
 	METHOD m_ubdxijxp buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_wavcwpbq applyClientRoarKnockback ()V
 	METHOD m_xmzarguc getAttackTick ()I
+	METHOD m_zgmmsois addRoarParticles ()V
 	METHOD m_zlxlwdra roar ()V

--- a/mappings/net/minecraft/entity/mob/SkeletonEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/SkeletonEntity.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/unmapped/C_fihnfnjv net/minecraft/entity/mob/SkeletonEntity
 	FIELD f_ozkypytk CONVERSION_TIME I
 	FIELD f_tpdkjord STRAY_CONVERSION_TIME_KEY Ljava/lang/String;
 	FIELD f_uoucirix conversionTime I
+	FIELD f_xfeznybn NOT_CONVERTING_TIME I
 	METHOD m_flnlbkfh isConverting ()Z
 		COMMENT Returns whether this skeleton is currently converting to a stray.
 	METHOD m_gqyduqex setConverting (Z)V
@@ -12,3 +13,5 @@ CLASS net/minecraft/unmapped/C_fihnfnjv net/minecraft/entity/mob/SkeletonEntity
 		ARG 1 time
 	METHOD m_nnptovll convertToStray ()V
 		COMMENT Converts this skeleton to a stray and plays a sound if it is not silent.
+	METHOD m_qjepxuhe (Lnet/minecraft/unmapped/C_yjhqjjap;)V
+		ARG 1 stray

--- a/mappings/net/minecraft/entity/mob/SkeletonHorseEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/SkeletonHorseEntity.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/unmapped/C_nghhbunv net/minecraft/entity/mob/SkeletonHorseEntity
 	FIELD f_anirquyh DESPAWN_AGE I
+	FIELD f_dqnyazuv DEFAULT_TRAPPED Z
 	FIELD f_jvczuvga BABY_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_mgcfmckl trapTime I
+	FIELD f_qquszcsv DEFAULT_TRAP_TIME I
 	FIELD f_tceqckbo trapTriggerGoal Lnet/minecraft/unmapped/C_aeyqpoyu;
 	FIELD f_wvkkshuw trapped Z
 	METHOD m_adtbowub canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z

--- a/mappings/net/minecraft/entity/mob/SlimeEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/SlimeEntity.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_evgtelyd net/minecraft/entity/mob/SlimeEntity
 	FIELD f_qozbfsgd MAX_SIZE I
 	FIELD f_rnsczbkp SLIME_SIZE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_tlixjesw lastStretch F
+	FIELD f_wcsytfms DEFAULT_ON_GROUND_LAST_TICK Z
 	FIELD f_zmydqfwp targetStretch F
 	METHOD m_emqhstrv getParticles ()Lnet/minecraft/unmapped/C_nqucohct;
 	METHOD m_gialyfnr getJumpSound ()Lnet/minecraft/unmapped/C_avavozay;
@@ -27,6 +28,8 @@ CLASS net/minecraft/unmapped/C_evgtelyd net/minecraft/entity/mob/SlimeEntity
 		ARG 1 target
 	METHOD m_vnkngsfw updateStretch ()V
 	METHOD m_xkluqsee getTicksUntilNextJump ()I
+	METHOD m_ycqtzdqa (IFFLnet/minecraft/unmapped/C_evgtelyd;)V
+		ARG 4 slime
 	CLASS C_assbvjxs SwimmingGoal
 		FIELD f_yvfwztdd slime Lnet/minecraft/unmapped/C_evgtelyd;
 		METHOD <init> (Lnet/minecraft/unmapped/C_evgtelyd;)V

--- a/mappings/net/minecraft/entity/mob/SpellcastingIllagerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/SpellcastingIllagerEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_fiyglykq net/minecraft/entity/mob/SpellcastingIllagerEntity
 	FIELD f_fukdxhio spellTicks I
 	FIELD f_gkkjpjwa spell Lnet/minecraft/unmapped/C_fiyglykq$C_rjdfyixx;
+	FIELD f_mcplytqs DEFAULT_SPELL_TICKS I
 	FIELD f_vkvffaot SPELL Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD m_dashmqip isSpellcasting ()Z
 	METHOD m_foojocrc setSpell (Lnet/minecraft/unmapped/C_fiyglykq$C_rjdfyixx;)V

--- a/mappings/net/minecraft/entity/mob/VindicatorEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/VindicatorEntity.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_xjtdqvdi net/minecraft/entity/mob/VindicatorEntit
 	FIELD f_lhsxtqdl johnny Z
 	FIELD f_lojphhvi JOHNNY_KEY Ljava/lang/String;
 	FIELD f_oqstvpcd DIFFICULTY_ALLOWS_DOOR_BREAKING_PREDICATE Ljava/util/function/Predicate;
+	FIELD f_yokrawdn DEFAULT_JOHNNY Z
 	METHOD m_avcopngp (Lnet/minecraft/unmapped/C_mpbjgxic;)Z
 		ARG 0 difficulty
 	METHOD m_merkiddq buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;

--- a/mappings/net/minecraft/entity/mob/ZoglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZoglinEntity.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/unmapped/C_lsverzlu net/minecraft/entity/mob/ZoglinEntity
 	FIELD f_wnqomjgj ATTACK_INTERVAL I
 	FIELD f_xhfbgcsu ATTACK_KNOCKBACK I
 	FIELD f_xvetfygr BABY_ATTACK_DAMAGE F
+	FIELD f_ygcpuybn DEFAULT_BABY Z
 	FIELD f_zxmchuac MAX_HEALTH I
 	METHOD m_cakwalfg playAngrySound ()V
 	METHOD m_ctvfpbin addCoreTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
@@ -25,6 +26,8 @@ CLASS net/minecraft/unmapped/C_lsverzlu net/minecraft/entity/mob/ZoglinEntity
 	METHOD m_mthpnbyl addFightTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
 	METHOD m_nywadqut getHoglinTarget (Lnet/minecraft/unmapped/C_bdwnwhiu;)Ljava/util/Optional;
+	METHOD m_pnljjcig (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_lsverzlu;)Ljava/util/Optional;
+		ARG 1 zoglin
 	METHOD m_qrcxmcgz shouldAttack (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 2 entity
 	METHOD m_slaoybhe updateActivity ()V

--- a/mappings/net/minecraft/entity/mob/ZombieEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieEntity.mapping
@@ -8,7 +8,10 @@ CLASS net/minecraft/unmapped/C_hlzqkibq net/minecraft/entity/mob/ZombieEntity
 	FIELD f_ffsrjhzo REINFORCEMENT_CALLER_CHARGE_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_ftlgfqrm BABY_SPEED_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
 	FIELD f_htmnnmvg REINFORCEMENT_MAX_RANGE I
+	FIELD f_ievualzi DEFAULT_IN_WATER_TIME I
+	FIELD f_iqefbnas DEFAULT_CAN_BREAK_DOORS Z
 	FIELD f_kplgseir REINFORCEMENT_CALLEE_CHARGE_MODIFIER Lnet/minecraft/unmapped/C_hdbqsqsm;
+	FIELD f_ljfnpnxe DEFAULT_BABY Z
 	FIELD f_luzrnhym REINFORCEMENT_MIN_RANGE I
 	FIELD f_oxqoblan BABY_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_pwwkwurn ZOMBIE_TYPE Lnet/minecraft/unmapped/C_rinmcaxy;
@@ -20,6 +23,7 @@ CLASS net/minecraft/unmapped/C_hlzqkibq net/minecraft/entity/mob/ZombieEntity
 	FIELD f_upyoimqe ticksUntilWaterConversion I
 	FIELD f_xkowrfdx BABY_SPEED_BONUS Lnet/minecraft/unmapped/C_hdbqsqsm;
 	FIELD f_yvivhgvq ZOMBIE_RANDOM_SPAWN_BONUS_MODIFIER_ID Lnet/minecraft/unmapped/C_ncpywfca;
+	FIELD f_yzflhcdb NOT_CONVERTING_TIME I
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;)V
 		ARG 1 world
 	METHOD m_byfmkeyh shouldBeBaby (Lnet/minecraft/unmapped/C_rlomrsco;)Z
@@ -50,6 +54,10 @@ CLASS net/minecraft/unmapped/C_hlzqkibq net/minecraft/entity/mob/ZombieEntity
 	METHOD m_zcxforui setTicksUntilWaterConversion (I)V
 		ARG 1 ticks
 	METHOD m_zfhqmnbl canBreakDoors ()Z
+	METHOD m_zihprlsp (Lnet/minecraft/unmapped/C_hlzqkibq;)V
+		ARG 0 zombie
+	METHOD m_zrntabte (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_yatelzvm;)V
+		ARG 3 zombieVillager
 	CLASS C_abgqtxqj ZombieData
 		FIELD f_bwrjberv baby Z
 		FIELD f_shsgomfv tryChickenJockey Z

--- a/mappings/net/minecraft/entity/mob/ZombieVillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieVillagerEntity.mapping
@@ -1,15 +1,17 @@
 CLASS net/minecraft/unmapped/C_yatelzvm net/minecraft/entity/mob/ZombieVillagerEntity
+	FIELD f_edrtkbsg DEFAULT_XP I
 	FIELD f_ffdxgjln converter Ljava/util/UUID;
 	FIELD f_hrdqwuvp SPECIAL_BLOCK_RADIUS I
-	FIELD f_ldvhprmr conversionTimer I
-	FIELD f_myjlsebp gossipData Lnet/minecraft/unmapped/C_okajgatv;
+	FIELD f_ldvhprmr conversionTime I
+	FIELD f_myjlsebp gossips Lnet/minecraft/unmapped/C_okajgatv;
 	FIELD f_njalnysi CONVERTING Lnet/minecraft/unmapped/C_rinmcaxy;
-	FIELD f_qbyvanlw offerData Lnet/minecraft/unmapped/C_eygsjfgm;
+	FIELD f_qbyvanlw offers Lnet/minecraft/unmapped/C_eygsjfgm;
 	FIELD f_qjoghspx xp I
 	FIELD f_qmjqplif VILLAGER_DATA Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_qvlcllcd MAX_CONVERSION_WAIT I
 	FIELD f_qyxdhvww MIN_CONVERSION_WAIT I
 	FIELD f_ttchdblc MAX_SPECIAL_BLOCKS I
+	FIELD f_vpkhpnxx NOT_CONVERTING_TIME I
 	METHOD m_beetymyj isConverting ()Z
 	METHOD m_fnjxyjfl setConverting (Ljava/util/UUID;I)V
 		ARG 1 uuid
@@ -18,9 +20,12 @@ CLASS net/minecraft/unmapped/C_yatelzvm net/minecraft/entity/mob/ZombieVillagerE
 		ARG 1 world
 	METHOD m_gutnbnvs setXp (I)V
 		ARG 1 xp
+	METHOD m_lbfmgvjw (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;)V
+		ARG 2 villager
 	METHOD m_nbnjxdaj setConversionTimer (I)V
 		ARG 1 time
 	METHOD m_nhlbvskt setGossipData (Lnet/minecraft/unmapped/C_okajgatv;)V
+		ARG 1 gossips
 	METHOD m_sbyyymlp getXp ()I
 	METHOD m_sognvwrz getConversionRate ()I
 	METHOD m_xxmfzhuc setOfferData (Lnet/minecraft/unmapped/C_eygsjfgm;)V

--- a/mappings/net/minecraft/entity/mob/warden/WardenBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/warden/WardenBrain.mapping
@@ -23,6 +23,10 @@ CLASS net/minecraft/unmapped/C_kazynfri net/minecraft/entity/mob/warden/WardenBr
 		ARG 2 target
 	METHOD m_fonjlkrr addInvestigateActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
+	METHOD m_heirhfob (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
+		ARG 1 target
+	METHOD m_hxlwcdcd (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 1 digCooldown
 	METHOD m_hzlxpncw addRoarActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
 	METHOD m_mtmbaofi create (Lnet/minecraft/unmapped/C_fynaplbn;Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/unmapped/C_rjqjaxef;
@@ -30,6 +34,9 @@ CLASS net/minecraft/unmapped/C_kazynfri net/minecraft/entity/mob/warden/WardenBr
 		ARG 1 dynamic
 	METHOD m_nrecwyeg addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
+	METHOD m_oqbzpezq (Lnet/minecraft/unmapped/C_rcqaryar$C_loqvwuht;Lnet/minecraft/unmapped/C_ujlmiamh;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_fynaplbn;J)Z
+		ARG 3 warden
+		ARG 4 time
 	METHOD m_rhgyjggv isTarget (Lnet/minecraft/unmapped/C_fynaplbn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 warden
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/passive/AllayBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayBrain.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/unmapped/C_horgckzp net/minecraft/entity/passive/AllayBrain
 		ARG 0 allay
 	METHOD m_yllecjoz addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
-	METHOD m_ynsluhvw create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_ynsluhvw init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 		ARG 0 brain
 	METHOD m_yxvqlfdg getLikedPlayerPos (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/util/Optional;
 		ARG 0 allay

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_jghxqudq MAX_NOTE_BLOCK_DISTANCE I
 	FIELD f_jxnwapwy THROWN_ITEM_PITCHES Lcom/google/common/collect/ImmutableList;
 	FIELD f_lgixkfsj spinningAnimationTicks F
+	FIELD f_liqwtaqm DEFAULT_DUPLICATION_COOLDOWN I
 	FIELD f_mqaniyob DUPLICATION_HEART_COUNT I
 	FIELD f_mtjnjlex DUPLICATION_COOLDOWN I
 	FIELD f_myblopii previousHoldingItemAnimationTicks F
@@ -23,7 +24,10 @@ CLASS net/minecraft/unmapped/C_ueeoxhql net/minecraft/entity/passive/AllayEntity
 	FIELD f_vcfrsywi holdingItemAnimationTicks F
 	FIELD f_xaexqzwn SENSORS Lcom/google/common/collect/ImmutableList;
 	METHOD m_amirmypp buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_bvvneqvl setDuplicationCooldown (J)V
+		ARG 1 cooldown
 	METHOD m_bywwptpx getSpinningAnimationProgress (F)F
+	METHOD m_ckrzbtpe isLikedPlayer (Lnet/minecraft/unmapped/C_astfners;)Z
 	METHOD m_evgblctp itemsMatch (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 left
 		ARG 2 right

--- a/mappings/net/minecraft/entity/passive/AnimalEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AnimalEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_tprvtfff net/minecraft/entity/passive/AnimalEntity
 	FIELD f_ghnlbrrv BREEDING_COOLDOWN I
 	FIELD f_mavnccyt lovingPlayer Lnet/minecraft/unmapped/C_xolbcmjn;
+	FIELD f_qckglulw DEFAULT_LOVE_TICKS I
 	FIELD f_wodqdutt loveTicks I
 	METHOD m_ajdkrylg canEat ()Z
 	METHOD m_bthblwno breed (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_tprvtfff;Lnet/minecraft/unmapped/C_jvojbnla;)V

--- a/mappings/net/minecraft/entity/passive/ArmadilloBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/ArmadilloBrain.mapping
@@ -11,17 +11,22 @@ CLASS net/minecraft/unmapped/C_ltyoslay net/minecraft/entity/passive/ArmadilloBr
 	FIELD f_vlqbnmki DEFAULT_TEMPTED_STOP_DISTANCE D
 	FIELD f_xelkvisz PANICKING_SPEED_MULTIPLIER F
 	METHOD m_gkoqcwvt createProfile ()Lnet/minecraft/unmapped/C_rjqjaxef$C_liifzsnq;
+	METHOD m_gujzymjq (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_isgylmfr;J)Z
+		ARG 1 armadillo
+		ARG 2 time
 	METHOD m_igczctmu (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/lang/Double;
 		ARG 0 armadillo
 	METHOD m_ktvtqjjf addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	METHOD m_pqtzvlen addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-	METHOD m_rdimaumz create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_rdimaumz init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_tpunwxsp (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/lang/Float;
 		ARG 0 armadillo
 	METHOD m_uewdbttp updateActivities (Lnet/minecraft/unmapped/C_isgylmfr;)V
 		ARG 0 armadillo
 	METHOD m_vubeeahl getBreedingIngredient ()Ljava/util/function/Predicate;
 	METHOD m_ybruukea addPanicActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
+	METHOD m_zzqpykeg (Lnet/minecraft/unmapped/C_ujlmiamh;)Lnet/minecraft/unmapped/C_smovfozc;
+		ARG 0 dangerDetectedRecently
 	CLASS C_aarekvlk RollUpTask
 		FIELD f_cvljtutm ticksUntilPeek I
 		FIELD f_fyhhdspw RUN_TIME_TICKS I

--- a/mappings/net/minecraft/entity/passive/ArmadilloEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/ArmadilloEntity.mapping
@@ -12,6 +12,8 @@ CLASS net/minecraft/unmapped/C_isgylmfr net/minecraft/entity/passive/ArmadilloEn
 	FIELD f_rdqvauxx MAX_HEAD_ROTATION F
 	FIELD f_tosmnlkl scuteSheddingCooldown I
 	METHOD m_aifauzlj unroll ()V
+	METHOD m_blmmbdab (Ljava/lang/Integer;)V
+		ARG 1 cooldown
 	METHOD m_bnhlbtvq onBrushed ()Z
 	METHOD m_dueaesvy shouldSwitchToScaredState ()Z
 	METHOD m_gfpmjxza canStayRolledUp ()Z
@@ -40,4 +42,5 @@ CLASS net/minecraft/unmapped/C_isgylmfr net/minecraft/entity/passive/ArmadilloEn
 		METHOD m_iofbcnyp getId ()I
 		METHOD m_lgowlnpl getDuration ()I
 		METHOD m_vcmbmqck shouldRollUp (J)Z
+			ARG 1 stateTicks
 		METHOD m_zmxoergx isThreatened ()Z

--- a/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
@@ -58,8 +58,7 @@ CLASS net/minecraft/unmapped/C_rhoguswm net/minecraft/entity/passive/AxolotlBrai
 		ARG 0 axolotl
 	METHOD m_kcgwbqgj getChaseSpeed (Lnet/minecraft/unmapped/C_usxaxydn;)F
 		ARG 0 entity
-	METHOD m_kdbiocpr create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_kdbiocpr init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_lzqpmyvp getFollowAdultSpeed (Lnet/minecraft/unmapped/C_usxaxydn;)F
 		ARG 0 entity
 	METHOD m_nfhswdfk addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V

--- a/mappings/net/minecraft/entity/passive/AxolotlEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AxolotlEntity.mapping
@@ -45,6 +45,7 @@ CLASS net/minecraft/unmapped/C_dkiorddu net/minecraft/entity/passive/AxolotlEnti
 	FIELD f_pkxjhfey POTION_HYDRATION I
 	FIELD f_sgbckvjh FROM_BUCKET Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_spzzgyvj POSE_ANIMATION_TICKS I
+	FIELD f_tmuytkcs DEFAULT_FROM_BUCKET Z
 	FIELD f_udgpdxdv VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_udkoqrte SENSORS Lcom/google/common/collect/ImmutableList;
 	FIELD f_vfvanicn BUFF_RANGE D
@@ -55,6 +56,8 @@ CLASS net/minecraft/unmapped/C_dkiorddu net/minecraft/entity/passive/AxolotlEnti
 	METHOD m_bhbdygsg buffPlayer (Lnet/minecraft/unmapped/C_jzrpycqo;)V
 		ARG 1 player
 	METHOD m_cwsafewj tickAnimations ()V
+	METHOD m_dcthqhvw (Lnet/minecraft/unmapped/C_hhlwcnih;Ljava/lang/Long;)V
+		ARG 2 cooldown
 	METHOD m_eoqtlnrq canSpawnOn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_jmnzlycd;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
 		ARG 0 entityType
 		ARG 1 world
@@ -71,6 +74,8 @@ CLASS net/minecraft/unmapped/C_dkiorddu net/minecraft/entity/passive/AxolotlEnti
 	METHOD m_rfvoxscv isPlayingDead ()Z
 	METHOD m_skeygjqv shouldBabyBeDifferent (Lnet/minecraft/unmapped/C_rlomrsco;)Z
 		ARG 0 random
+	METHOD m_yiztatxd (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 1 nbt
 	METHOD m_yyexhklb buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_zmicqlkl tickAir (Lnet/minecraft/unmapped/C_bdwnwhiu;I)V
 		ARG 2 air

--- a/mappings/net/minecraft/entity/passive/BatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BatEntity.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_dexcydtn net/minecraft/entity/passive/BatEntity
 		COMMENT #isRoosting() roosting}.
 	FIELD f_pqzgefwb ROOSTING_FLAG I
 	FIELD f_pvilqenm TICKS_PER_FLAP F
+	FIELD f_pwoelugz DEFAULT_BAT_FLAGS B
 	FIELD f_vryrnjbd flyingState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_wflaiwbf roostingState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_zkwphbmj CLOSE_PLAYER_PREDICATE Lnet/minecraft/unmapped/C_cjtyhinh;

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -19,11 +19,14 @@ CLASS net/minecraft/unmapped/C_hgfgxpql net/minecraft/entity/passive/BeeEntity
 	FIELD f_jlzhazod pollinateGoal Lnet/minecraft/unmapped/C_hgfgxpql$C_hstezuru;
 	FIELD f_jrbdvmhv LOCATING_NEW_HIVE_COOLDOWN I
 	FIELD f_jsypygyo MIN_RETRY_FINDING_FLOWER_COOLDOWN I
+	FIELD f_kjorzbwt DEFAULT_TICKS_SINCE_POLLINATION I
 	FIELD f_lpvsbgtm HIVE_SEARCH_RANGE I
 	FIELD f_mdrowaus HIVE_POS_KEY Ljava/lang/String;
 	FIELD f_mfeadoih ANGER Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_myxhamja HARD_DIFFICULTY_STING_POISON_DURATION I
+	FIELD f_nficoesn DEFAULT_HAS_NECTAR Z
 	FIELD f_oieuxrcc ANGER_TIME_RANGE Lnet/minecraft/unmapped/C_hvilmtvi;
+	FIELD f_ookivocl DEFAULT_HAS_STUNG Z
 	FIELD f_pfkojmow lastPitch F
 	FIELD f_pgbnsptu TOO_FAR_DISTANCE I
 		COMMENT The minimum distance that bees lose their hive or flower position at.
@@ -42,6 +45,7 @@ CLASS net/minecraft/unmapped/C_hgfgxpql net/minecraft/entity/passive/BeeEntity
 	FIELD f_vbzxsdle NEAR_TARGET_FLAG I
 	FIELD f_vgpnrcpq ticksInsideWater I
 	FIELD f_vwwkdehr cannotEnterHiveTicks I
+	FIELD f_wexvsfza DEFAULT_CROPS_GROWN_SINCE_POLLINATION I
 	FIELD f_whtbodsz MIN_ATTACK_DISTANCE I
 	FIELD f_wuqtubpu targetUuid Ljava/util/UUID;
 	FIELD f_xjbjocrt CANNOT_ENTER_HIVE_TICKS_KEY Ljava/lang/String;
@@ -49,6 +53,7 @@ CLASS net/minecraft/unmapped/C_hgfgxpql net/minecraft/entity/passive/BeeEntity
 	FIELD f_xyzgfgra HAS_STUNG_KEY Ljava/lang/String;
 	FIELD f_ycjsovuu moveToFlowerGoal Lnet/minecraft/unmapped/C_hgfgxpql$C_svuqecsc;
 	FIELD f_yqhwyhuf STING_DEATH_COUNTDOWN I
+	FIELD f_yqjgwxcg DEFAULT_CANNOT_ENTER_HIVE_TICKS I
 	FIELD f_ysyjkfoe ticksSincePollination I
 	METHOD m_awlbhvcb getHivePos ()Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_beiolhwp setBeeFlag (IZ)V
@@ -59,6 +64,7 @@ CLASS net/minecraft/unmapped/C_hgfgxpql net/minecraft/entity/passive/BeeEntity
 	METHOD m_cihpsqgl setHasStung (Z)V
 		ARG 1 hasStung
 	METHOD m_glfxznpj getPossibleHives ()Ljava/util/List;
+	METHOD m_hfeiojym isAttractive (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 	METHOD m_hxcrhdeh buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_ifoynezy canEnterHive ()Z
 	METHOD m_ikwzmvgi getMoveGoalTicks ()I

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -57,7 +57,7 @@ CLASS net/minecraft/unmapped/C_hgfgxpql net/minecraft/entity/passive/BeeEntity
 	FIELD f_ysyjkfoe ticksSincePollination I
 	METHOD m_awlbhvcb getHivePos ()Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_beiolhwp setBeeFlag (IZ)V
-		ARG 1 bit
+		ARG 1 flag
 		ARG 2 value
 	METHOD m_biootsai getHive ()Lnet/minecraft/unmapped/C_cyniebsl;
 	METHOD m_bypgkjae updateBodyPitch ()V

--- a/mappings/net/minecraft/entity/passive/CamelBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelBrain.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/unmapped/C_hfncvwem net/minecraft/entity/passive/CamelBrain
 	METHOD m_khzenzux initialize (Lnet/minecraft/unmapped/C_lzclwwts;Lnet/minecraft/unmapped/C_rlomrsco;)V
 		ARG 0 camel
 	METHOD m_mnpldpmw addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-	METHOD m_nazibwzs create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_nazibwzs init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_niqxtuzs createProfile ()Lnet/minecraft/unmapped/C_rjqjaxef$C_liifzsnq;
 	METHOD m_yicbfvkd getTemptIngredient ()Ljava/util/function/Predicate;
 	CLASS C_lldjxdvs RandomSitTask

--- a/mappings/net/minecraft/entity/passive/CamelEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelEntity.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/unmapped/C_lzclwwts net/minecraft/entity/passive/CamelEntity
 	FIELD f_wzqlfmll idleState Lnet/minecraft/unmapped/C_kxntavoz;
 	FIELD f_xmgampyz jumpCooldown I
 	FIELD f_xzatonhg sitState Lnet/minecraft/unmapped/C_kxntavoz;
+	FIELD f_ynoxpkcf DEFAULT_LAST_ANIMATION_TICK J
 	FIELD f_ytksaucz SIT_DOWN_DURATION_TICKS I
 	METHOD m_agopwmxz buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_cthfkhfv isVisuallySittingDown ()Z
@@ -35,6 +36,7 @@ CLASS net/minecraft/unmapped/C_lzclwwts net/minecraft/entity/passive/CamelEntity
 		ARG 1 tick
 	METHOD m_owyxwavp canChangePose ()Z
 	METHOD m_pbhdpmux isVisuallySitting ()Z
+	METHOD m_pwnljinr canSpawnAt (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
 	METHOD m_rckrnmzp setDashing (Z)V
 		ARG 1 dashing
 	METHOD m_sfjibwvn setupAnimationStates ()V

--- a/mappings/net/minecraft/entity/passive/CatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CatEntity.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/unmapped/C_rxtmregr net/minecraft/entity/passive/CatEntity
 	FIELD f_hqvkpijz fleeGoal Lnet/minecraft/unmapped/C_rxtmregr$C_jlusltvy;
 	FIELD f_iywwshas sleepAnimationProgress F
 	FIELD f_jycwwapx VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_kjrplxkg DEFAULT_COLLAR_COLOR Lnet/minecraft/unmapped/C_arllgqae;
 	FIELD f_krqstxdp headDownAnimationProgress F
 	FIELD f_lfmjmddd COLLAR_COLOR Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_lsvomhnh SPRINTING_SPEED D

--- a/mappings/net/minecraft/entity/passive/ChickenEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/ChickenEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_bpvltclb net/minecraft/entity/passive/ChickenEntity
+	FIELD f_bfyzpbff DEFAULT_JOCKEY Z
 	FIELD f_dehllfdy flapProgress F
 	FIELD f_funqjbva eggLayTime I
 	FIELD f_oiccwsmi maxWingDeviation F
@@ -16,3 +17,5 @@ CLASS net/minecraft/unmapped/C_bpvltclb net/minecraft/entity/passive/ChickenEnti
 	METHOD m_sqsanurl setVariant (Lnet/minecraft/unmapped/C_cjzoxshv;)V
 		ARG 1 variant
 	METHOD m_virwmcqx hasJockey ()Z
+	METHOD m_vtcflyvd (Ljava/lang/Integer;)V
+		ARG 1 time

--- a/mappings/net/minecraft/entity/passive/DolphinEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/DolphinEntity.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/unmapped/C_ucpoxhfy net/minecraft/entity/passive/DolphinEnti
 	FIELD f_kriyywfw MOISTNESS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_nlpajyrn CAN_TAKE Ljava/util/function/Predicate;
 	FIELD f_qiqilmke MAX_MOISTNESS I
+	FIELD f_uhhxtloe DEFAULT_HAS_FISH Z
 	FIELD f_vzcfzugn BABY_SCALE F
 	FIELD f_wnftchzc TOTAL_AIR_SUPPLY I
 	METHOD m_jlxlczsj getMoistness ()I

--- a/mappings/net/minecraft/entity/passive/FishEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FishEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_qlakwtgn net/minecraft/entity/passive/FishEntity
+	FIELD f_fmeyyilc DEFAULT_FROM_BUCKET Z
 	FIELD f_ghtlwmji FROM_BUCKET Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD m_glzkagtx getFlopSound ()Lnet/minecraft/unmapped/C_avavozay;
 	METHOD m_oxoipbnl hasSelfControl ()Z

--- a/mappings/net/minecraft/entity/passive/FoxEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FoxEntity.mapping
@@ -10,16 +10,19 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 	FIELD f_gvpwdnqm BABY_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_hqimehqj CROUCHING_FLAG I
 	FIELD f_hrbsnbst VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_jtrpxkwe DEFAULT_SLEEPING Z
 	FIELD f_lkqzfnlu WALKING_FLAG I
 	FIELD f_lmfkncww lastHeadRollProgress F
 	FIELD f_nmhvuowd eatingTime I
 	FIELD f_pnamnksn CHASING_FLAG I
+	FIELD f_qbbuxtmr DEFAULT_CROUCHING Z
 	FIELD f_tajwrmin extraRollingHeight F
 	FIELD f_upcmpkhx followFishGoal Lnet/minecraft/unmapped/C_svjebams;
 	FIELD f_vkugpcrl followChickenAndRabbitGoal Lnet/minecraft/unmapped/C_svjebams;
 	FIELD f_wshlzrjm OWNER Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_xuhsuger ROLLING_HEAD_FLAG I
 	FIELD f_ycsmhxsv OTHER_TRUSTED Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_yjgxmsps DEFAULT_SITTING Z
 	FIELD f_ymqfryvu SITTING_FLAG I
 	FIELD f_ysgxoajz MIN_TICKS_BEFORE_EATING I
 	FIELD f_zbozchcc FOX_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
@@ -34,6 +37,8 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 		ARG 1 tickDelta
 	METHOD m_deelmhsk (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_bdwnwhiu;)Z
 		ARG 0 entity
+	METHOD m_dehaypsg setVariant (Lnet/minecraft/unmapped/C_axinhusn$C_dqmtshhc;)V
+		ARG 1 variant
 	METHOD m_dgmreqad getVariant ()Lnet/minecraft/unmapped/C_axinhusn$C_dqmtshhc;
 	METHOD m_entdqhly getHeadRoll (F)F
 		ARG 1 tickDelta
@@ -54,12 +59,17 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 		ARG 1 sleeping
 	METHOD m_ljsbiiim setSitting (Z)V
 		ARG 1 sitting
+	METHOD m_mgrbgsfw (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_xolbcmjn;)Z
+		ARG 1 reference
+	METHOD m_mmuojxfd setOwnerOrTrusted (Lnet/minecraft/unmapped/C_xolbcmjn;)V
+		ARG 1 entity
 	METHOD m_nkcqsqrd (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 1 entity
 	METHOD m_nuviczfv canJumpChase (Lnet/minecraft/unmapped/C_axinhusn;Lnet/minecraft/unmapped/C_usxaxydn;)Z
 		ARG 0 fox
 		ARG 1 chasedEntity
 	METHOD m_onrungke canTrust (Lnet/minecraft/unmapped/C_usxaxydn;)Z
+	METHOD m_poswsotl setOwnerOrTrusted (Lnet/minecraft/unmapped/C_usxaxydn;)V
 	METHOD m_ptzfkeez dropItem (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 stack
 	METHOD m_rlytqius setAggressive (Z)V
@@ -68,6 +78,7 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 		ARG 1 entity
 	METHOD m_tklrsolc (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 entity
+	METHOD m_tryhdody clearTrusted ()V
 	METHOD m_uesdupqb isSitting ()Z
 	METHOD m_umwbpcmy stopSleeping ()V
 	METHOD m_uphzwtbt setWalking (Z)V
@@ -81,6 +92,7 @@ CLASS net/minecraft/unmapped/C_axinhusn net/minecraft/entity/passive/FoxEntity
 		ARG 1 bitmask
 	METHOD m_vwosazqj (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 entity
+	METHOD m_wtfplsqf streamTrusted ()Ljava/util/stream/Stream;
 	METHOD m_wvzovpqx (Lnet/minecraft/unmapped/C_uqpzijng;)Z
 		ARG 0 item
 	METHOD m_xkpkacqa setRollingHead (Z)V

--- a/mappings/net/minecraft/entity/passive/FrogBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/FrogBrain.mapping
@@ -10,11 +10,14 @@ CLASS net/minecraft/unmapped/C_gtwuaauj net/minecraft/entity/passive/FrogBrain
 	FIELD f_xrxbfjsi MAX_LONG_JUMP_DISTANCE I
 	METHOD m_fhaglmeu addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
+	METHOD m_hxcrcibv (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Ljava/util/Optional;
+		ARG 1 frog
 	METHOD m_ihwohwid addLongJumpActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-		ARG 0 brain
 	METHOD m_ioifnvht canAttack (Lnet/minecraft/unmapped/C_gcfircge;)Z
 		ARG 0 frog
 	METHOD m_iyhjlwzh (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Z
+		ARG 1 frog
+	METHOD m_jjlcnmfs (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Ljava/util/Optional;
 		ARG 1 frog
 	METHOD m_kbsketlv addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
@@ -23,15 +26,21 @@ CLASS net/minecraft/unmapped/C_gtwuaauj net/minecraft/entity/passive/FrogBrain
 		ARG 1 generator
 	METHOD m_lixpcywj reset (Lnet/minecraft/unmapped/C_gcfircge;)V
 		ARG 0 frog
-	METHOD m_lvidokhl create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_lvidokhl init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_lxhweavq addSwimActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
 	METHOD m_mtqywzuf addLaySpawnActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
+	METHOD m_postmbaf (Lnet/minecraft/unmapped/C_gcfircge;)Lnet/minecraft/unmapped/C_avavozay;
+		ARG 0 frog
 	METHOD m_thifxbji (Lnet/minecraft/unmapped/C_usxaxydn;)Ljava/lang/Float;
 		ARG 0 entity
 	METHOD m_tunjbuuy addTongueActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-		ARG 0 brain
 	METHOD m_uzrluyop getTemptItems ()Ljava/util/function/Predicate;
 	METHOD m_uzvaosgy canJumpTo (Lnet/minecraft/unmapped/C_dxkfswlz;Lnet/minecraft/unmapped/C_hynzadkk;)Z
+	METHOD m_wobhpjaa (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Z
+		ARG 1 frog
+	METHOD m_xllgjqvn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Z
+		ARG 1 frog
+	METHOD m_zcjmaumt (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)Ljava/util/Optional;
+		ARG 1 frog

--- a/mappings/net/minecraft/entity/passive/GlowSquidEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/GlowSquidEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_zelcdupv net/minecraft/entity/passive/GlowSquidEntity
 	FIELD f_abtcoxul DARK_TICKS_REMAINING Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_abvvchnx DEFAULT_DARK_TICKS_REMAINING I
 	METHOD m_idrbcxjh getDarkTicksRemaining ()I
 	METHOD m_nryfymyi setDarkTicksRemaining (I)V
 		ARG 1 ticks

--- a/mappings/net/minecraft/entity/passive/GoatBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/GoatBrain.mapping
@@ -44,8 +44,9 @@ CLASS net/minecraft/unmapped/C_igkprktp net/minecraft/entity/passive/GoatBrain
 		ARG 0 goat
 	METHOD m_wbpfqohn addRamActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
-	METHOD m_xlhgfbai create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_xgrnixxf (Lnet/minecraft/unmapped/C_rrwjjvrc;)Lnet/minecraft/unmapped/C_avavozay;
+		ARG 0 goat
+	METHOD m_xlhgfbai init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_xuzcyxnz (Lnet/minecraft/unmapped/C_rrwjjvrc;)I
 		ARG 0 goat
 	METHOD m_zzekaiph getTemptItems ()Ljava/util/function/Predicate;

--- a/mappings/net/minecraft/entity/passive/GoatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/GoatEntity.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/unmapped/C_rrwjjvrc net/minecraft/entity/passive/GoatEntity
 	FIELD f_aozcseom BABY_ATTACK_DAMAGE I
 	FIELD f_cvtslbjp FALL_DAMAGE_SUBTRACTOR I
+	FIELD f_dtbaazlp DEFAULT_SCREAMING Z
 	FIELD f_frnuhmsz HAS_LEFT_HORN Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_gszpabcy DEFAULT_HAS_LEFT_HORN Z
+	FIELD f_hbeueocq DEFAULT_HAS_RIGHT_HORN Z
 	FIELD f_ituvqpiy LONG_JUMPING_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
 	FIELD f_kduajvlr SINGLE_HORN_CHANCE D
 	FIELD f_oeqstolm SENSORS Lcom/google/common/collect/ImmutableList;
@@ -27,3 +30,5 @@ CLASS net/minecraft/unmapped/C_rrwjjvrc net/minecraft/entity/passive/GoatEntity
 	METHOD m_nzcmdgdt removeHorns ()V
 	METHOD m_wktzmqkp getMilkingSound ()Lnet/minecraft/unmapped/C_avavozay;
 	METHOD m_xpdosffp getHornItem ()Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_xppnwfof (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_sddaxwyk;
+		ARG 0 instrument

--- a/mappings/net/minecraft/entity/passive/HappyGhastBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/HappyGhastBrain.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/unmapped/C_rximmwuo net/minecraft/entity/passive/HappyGhastB
 	FIELD f_zvdjjeow SENSORS Lcom/google/common/collect/ImmutableList;
 	METHOD m_nllfmeyz setCoreTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 	METHOD m_nulhkrmn setIdleTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V
-	METHOD m_nvqlnpth initialize (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
+	METHOD m_nvqlnpth init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_ocnjkgwy resetPanicAndIdleActivities (Lnet/minecraft/unmapped/C_wzkkvkls;)V
 		ARG 0 happyGhast
 	METHOD m_wmcyrbmi setPanicTasks (Lnet/minecraft/unmapped/C_rjqjaxef;)V

--- a/mappings/net/minecraft/entity/passive/HappyGhastEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HappyGhastEntity.mapping
@@ -5,12 +5,21 @@ CLASS net/minecraft/unmapped/C_wzkkvkls net/minecraft/entity/passive/HappyGhastE
 	FIELD f_hmcyrgxz FAST_HEALING_INTERVAL I
 	FIELD f_jntojery BABY_SCALE F
 	FIELD f_mvhmpewb ropeRemovalTimer I
+	FIELD f_ocepihwm MAX_SCALE F
+	FIELD f_onisumpp LOAD_STILL_COUNTDOWN_GRACE_PERIOD I
 	FIELD f_pehaleas SMALL_WANDER_RANGE I
 	FIELD f_qdoqzjtl HAS_ROPES Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_rnovxmbk PANIC_SPEED_MULTIPLIER F
+	FIELD f_tgzfmezj MAX_STILL_TICKS I
+	FIELD f_tzpoielm STILL Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_vdxvfaiu stillCountdown I
 	FIELD f_xkpejagy IS_FOOD Ljava/util/function/Predicate;
 	FIELD f_xsicunjx WANDER_RANGE_BUFFER I
 	FIELD f_ygpcnmnn SLOW_HEALING_INTERVAL I
+	METHOD m_aayjwmie isSetStill ()Z
+	METHOD m_bremtawf syncPosition (I)V
+		ARG 1 cooldown
+	METHOD m_eeiwldcz isStill ()Z
 	METHOD m_emnrqjuu createBabyNavigation (Lnet/minecraft/unmapped/C_cdctfzbn;)Lnet/minecraft/unmapped/C_atbvfjwi;
 	METHOD m_fylccoco setHasRopes (Z)V
 		ARG 1 ropes
@@ -20,9 +29,11 @@ CLASS net/minecraft/unmapped/C_wzkkvkls net/minecraft/entity/passive/HappyGhastE
 	METHOD m_kqjdoelr (Lnet/minecraft/unmapped/C_svjebams;)Z
 		ARG 0 goal
 	METHOD m_mnpzfhmi initializeAdult ()V
+	METHOD m_namubhqp setStill ()V
 	METHOD m_nxvzsgli buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_qbfuoikt updateWanderCenter ()V
 	METHOD m_ujusixbc getControlledTargetRotation (Lnet/minecraft/unmapped/C_usxaxydn;)Lnet/minecraft/unmapped/C_krlwdsom;
+	METHOD m_uwuzmthz isPlayerAtop ()Z
 	METHOD m_veajgkbj getWanderRange ()I
 	METHOD m_wdhurxyc hasRopes ()Z
 	METHOD m_zhtgaqpz addRider (Lnet/minecraft/unmapped/C_jzrpycqo;)V

--- a/mappings/net/minecraft/entity/passive/HorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HorseEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_icbcebrx net/minecraft/entity/passive/HorseEntity
 	FIELD f_lupbdhgu VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_qztryuld BABY_DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
+	FIELD f_zgjhoutl DEFAULT_VARIANT I
 	METHOD m_inoilhbe getHorseVariant ()I
 	METHOD m_myomymcs getColor ()Lnet/minecraft/unmapped/C_pftaultf;
 	METHOD m_tjdewkmt getMarking ()Lnet/minecraft/unmapped/C_izltrckh;

--- a/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/unmapped/C_jzrmkmyj net/minecraft/entity/passive/LlamaEntity
 	METHOD m_amqliahl isFollowing ()Z
 	METHOD m_bttxnaek isTrader ()Z
 	METHOD m_fdwfwkvl stopFollowing ()V
+	METHOD m_gbdxmzzo setVariant (Lnet/minecraft/unmapped/C_jzrmkmyj$C_bamxtdwv;)V
+		ARG 1 variant
 	METHOD m_ghyitixv createNewLlama ()Lnet/minecraft/unmapped/C_jzrmkmyj;
 	METHOD m_gtymjqxz setSpit (Z)V
 		ARG 1 spit
@@ -17,6 +19,7 @@ CLASS net/minecraft/unmapped/C_jzrmkmyj net/minecraft/entity/passive/LlamaEntity
 	METHOD m_mojegzjo setStrength (I)V
 		ARG 1 strength
 	METHOD m_ndwrlywe initializeStrength (Lnet/minecraft/unmapped/C_rlomrsco;)V
+	METHOD m_prfwgdiy getVariant ()Lnet/minecraft/unmapped/C_jzrmkmyj$C_bamxtdwv;
 	METHOD m_rgwxwdhm getFollowing ()Lnet/minecraft/unmapped/C_jzrmkmyj;
 	METHOD m_sepmwwme spitAt (Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 target

--- a/mappings/net/minecraft/entity/passive/OcelotEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/OcelotEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_unelhaab net/minecraft/entity/passive/OcelotEntity
 	FIELD f_gtrnkbaa temptGoal Lnet/minecraft/unmapped/C_unelhaab$C_ztibqhbe;
 	FIELD f_jtbfgiqw WALKING_SPEED_MODIFIER D
+	FIELD f_ngavkwep DEFAULT_TRUSTING Z
 	FIELD f_npvrrxxt CROUCHING_SPEED_MODIFIER D
 	FIELD f_qtubyzfn SPRINTING_SPEED_MODIFIER D
 	FIELD f_uagbmukz TRUSTING Lnet/minecraft/unmapped/C_rinmcaxy;

--- a/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
@@ -30,11 +30,16 @@ CLASS net/minecraft/unmapped/C_ombdzkxc net/minecraft/entity/passive/ParrotEntit
 	METHOD m_yeswsuun imitateNearbyMob (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 0 world
 		ARG 1 parrot
+	CLASS C_otwutkqf
+		METHOD test (Ljava/lang/Object;)Z
+			ARG 1 entity
 	CLASS C_vrrzomrk Variant
 		FIELD f_ionelagg BY_ID Ljava/util/function/IntFunction;
+		FIELD f_jyuowzfm LEGACY_CODEC Lcom/mojang/serialization/Codec;
 		FIELD f_lyjclikp name Ljava/lang/String;
 		FIELD f_plgymzwe id I
 		FIELD f_vgfcuyii CODEC Lcom/mojang/serialization/Codec;
+		FIELD f_wbezhwth DEFAULT Lnet/minecraft/unmapped/C_ombdzkxc$C_vrrzomrk;
 		METHOD m_jquwagcv byId (I)Lnet/minecraft/unmapped/C_ombdzkxc$C_vrrzomrk;
 			ARG 0 id
 		METHOD m_mhaphmct getId ()I

--- a/mappings/net/minecraft/entity/passive/PufferfishEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PufferfishEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/unmapped/C_jrmyptau net/minecraft/entity/passive/PufferfishE
 	FIELD f_ezedlqkq inflateTicks I
 	FIELD f_fokyjgsx FULLY_PUFFED I
 	FIELD f_nawnbraa BLOW_UP_TARGET_PREDICATE Lnet/minecraft/unmapped/C_cjtyhinh;
+	FIELD f_qmburmcc DEFAULT_PUFF_STATE I
 	FIELD f_rpideidk PUFF_STATE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ufhfudig deflateTicks I
 	FIELD f_xzrlmgxa NOT_PUFFED I

--- a/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
@@ -14,6 +14,7 @@ CLASS net/minecraft/unmapped/C_zejlzfny net/minecraft/entity/passive/RabbitEntit
 	FIELD f_oiwzxafx ticksUntilJump I
 	FIELD f_pnfxqusz MORE_CARROTS_DELAY I
 	FIELD f_tariwbdb ATTACK_SPEED_MODIFIER D
+	FIELD f_ueubcmlq DEFAULT_MORE_CARROT_TICKS I
 	FIELD f_yryctyqy DEFAULT_ATTACK_DAMAGE I
 	FIELD f_zkceqqzm lastOnGround Z
 	METHOD m_dwqfhmua wantsCarrots ()Z
@@ -51,8 +52,10 @@ CLASS net/minecraft/unmapped/C_zejlzfny net/minecraft/entity/passive/RabbitEntit
 			ARG 1 enabled
 	CLASS C_hyrbilka Variant
 		FIELD f_jvhahmvu id I
+		FIELD f_knocyncn CODEC Lcom/mojang/serialization/Codec;
 		FIELD f_renvtffi DEFAULT Lnet/minecraft/unmapped/C_zejlzfny$C_hyrbilka;
 		FIELD f_smlixbbp key Ljava/lang/String;
+		FIELD f_tbdwxhwb LEGACY_CODEC Lcom/mojang/serialization/Codec;
 		FIELD f_zavpujzk VARIANTS Ljava/util/function/IntFunction;
 		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
 			ARG 3 id

--- a/mappings/net/minecraft/entity/passive/SalmonEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/SalmonEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_upwlqigj net/minecraft/entity/passive/SalmonEntity
+	FIELD f_ecamarfz VARIANT_KEY Ljava/lang/String;
 	FIELD f_qjpbfsdr VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD m_cqxelxhs setVariant (Lnet/minecraft/unmapped/C_upwlqigj$C_oepggenf;)V
 		ARG 1 variant

--- a/mappings/net/minecraft/entity/passive/SheepColors.mapping
+++ b/mappings/net/minecraft/entity/passive/SheepColors.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/unmapped/C_sevtglho net/minecraft/entity/passive/SheepColors
+	FIELD f_iuztcncz TEMPERATE_COLORS Lnet/minecraft/unmapped/C_sevtglho$C_zecysbkl;
+	FIELD f_mrzfocff WARM_COLORS Lnet/minecraft/unmapped/C_sevtglho$C_zecysbkl;
+	FIELD f_snqybxtg COLD_COLORS Lnet/minecraft/unmapped/C_sevtglho$C_zecysbkl;
+	METHOD m_bedlzdnq createDirectSelector (Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_sevtglho$C_qwhlwhji;
+		ARG 0 color
+	METHOD m_rgavtajn createSelector (Lnet/minecraft/unmapped/C_bvkdjias;)Lnet/minecraft/unmapped/C_sevtglho$C_qwhlwhji;
+		ARG 0 colors
+	METHOD m_rnnofkwl createSelectorWithRarePink (Lnet/minecraft/unmapped/C_arllgqae;)Lnet/minecraft/unmapped/C_sevtglho$C_qwhlwhji;
+		ARG 0 commonColor
+	METHOD m_skdqzpbk getColors (Lnet/minecraft/unmapped/C_cjzoxshv;)Lnet/minecraft/unmapped/C_sevtglho$C_zecysbkl;
+		ARG 0 biome
+	METHOD m_yiuwddxw colorsBuilder ()Lnet/minecraft/unmapped/C_bvkdjias$C_ykcycqkc;
+	METHOD m_yogyixcr selectColor (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_rlomrsco;)Lnet/minecraft/unmapped/C_arllgqae;
+	CLASS C_qwhlwhji ColorSelector
+	CLASS C_zecysbkl ColorsWrapper

--- a/mappings/net/minecraft/entity/passive/SheepEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/SheepEntity.mapping
@@ -1,16 +1,19 @@
 CLASS net/minecraft/unmapped/C_xhsufrff net/minecraft/entity/passive/SheepEntity
+	FIELD f_dglgcays DEFAULT_SHEARED Z
 	FIELD f_diffbcus COLOR Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_onljvpcz EAT_ANIMATION_TICKS I
 	FIELD f_ufchpxcv eatGrassTimer I
 	FIELD f_vclipzab eatGrassGoal Lnet/minecraft/unmapped/C_krmsprar;
+	FIELD f_wefofqjl DEFAULT_COLOR Lnet/minecraft/unmapped/C_arllgqae;
 	METHOD m_cwpbmdbg setSheared (Z)V
 		ARG 1 sheared
-	METHOD m_iannlubv generateDefaultColor (Lnet/minecraft/unmapped/C_jmnzlycd;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_arllgqae;
+	METHOD m_iannlubv selectColor (Lnet/minecraft/unmapped/C_jmnzlycd;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_arllgqae;
 	METHOD m_ngkjntpv isSheared ()Z
 	METHOD m_pbnjltwz getHeadAngle (F)F
 		ARG 1 delta
 	METHOD m_qsurahxi buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_rgkmjdvy setColor (Lnet/minecraft/unmapped/C_arllgqae;)V
 		ARG 1 color
+	METHOD m_vrrvyxik getColor ()Lnet/minecraft/unmapped/C_arllgqae;
 	METHOD m_zqcilmda getNeckAngle (F)F
 		ARG 1 delta

--- a/mappings/net/minecraft/entity/passive/SnifferBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/SnifferBrain.mapping
@@ -15,8 +15,7 @@ CLASS net/minecraft/unmapped/C_hgdyvgvp net/minecraft/entity/passive/SnifferBrai
 		ARG 0 sniffer
 	METHOD m_tryjeuac resetPossibleActivities (Lnet/minecraft/unmapped/C_frelvdpe;)V
 		ARG 0 entity
-	METHOD m_tslvdvsu addActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_tslvdvsu init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_tsmhqquh addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
 	METHOD m_uvontxoo addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V

--- a/mappings/net/minecraft/entity/passive/SnowGolemEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/SnowGolemEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_xrqscfui net/minecraft/entity/passive/SnowGolemEntity
 	FIELD f_byhgvvxg SNOW_GOLEM_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ipugoiyg HAS_PUMPKIN_FLAG B
+	FIELD f_pjvgefkr DEFAULT_HAS_PUMPKIN Z
 	METHOD m_fmiwquac hasPumpkin ()Z
 	METHOD m_fpjeetox buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_jlekihlj setHasPumpkin (Z)V

--- a/mappings/net/minecraft/entity/passive/TadpoleBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/TadpoleBrain.mapping
@@ -4,8 +4,7 @@ CLASS net/minecraft/unmapped/C_ywwmuctu net/minecraft/entity/passive/TadpoleBrai
 	FIELD f_spzfgioq TEMPT_SPEED F
 	METHOD m_foinebps reset (Lnet/minecraft/unmapped/C_gdxvnoho;)V
 		ARG 0 entity
-	METHOD m_qiscqhmo create (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
-		ARG 0 brain
+	METHOD m_qiscqhmo init (Lnet/minecraft/unmapped/C_rjqjaxef;)Lnet/minecraft/unmapped/C_rjqjaxef;
 	METHOD m_rfovsnvu addIdleActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 0 brain
 	METHOD m_yihwtarh addCoreActivities (Lnet/minecraft/unmapped/C_rjqjaxef;)V

--- a/mappings/net/minecraft/entity/passive/TadpoleEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TadpoleEntity.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/unmapped/C_gdxvnoho net/minecraft/entity/passive/TadpoleEnti
 	FIELD f_jzehaawm HITBOX_HEIGHT F
 	FIELD f_lhkulahc MODULES Lcom/google/common/collect/ImmutableList;
 	FIELD f_rfntsubn SENSORS Lcom/google/common/collect/ImmutableList;
+	FIELD f_vcyckwck DEFAULT_TADPOLE_AGE I
 	FIELD f_weptgqet HITBOX_WIDTH F
 	METHOD m_dsreleic decrementStack (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 player
@@ -12,9 +13,13 @@ CLASS net/minecraft/unmapped/C_gdxvnoho net/minecraft/entity/passive/TadpoleEnti
 		ARG 1 stack
 	METHOD m_fpexwmxb setAge (I)V
 		ARG 1 age
+	METHOD m_gmnyrexh (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_gcfircge;)V
+		ARG 2 frog
 	METHOD m_iieprzwi growthSeconds (I)V
 		ARG 1 seconds
 	METHOD m_jlrrvacd getTadpoleAge ()I
+	METHOD m_lbtvesnr (Lnet/minecraft/unmapped/C_hhlwcnih;)V
+		ARG 1 nbt
 	METHOD m_nktwhaku timeUntilGrown ()I
 	METHOD m_owndoqec buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_pkfuobvm growIntoFrog ()V

--- a/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TamableMountEntity.mapping
@@ -104,6 +104,7 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/TamableMoun
 		ARG 2 flag
 	METHOD m_qhxpjozn generateSpeedBonus (Ljava/util/function/DoubleSupplier;)D
 		ARG 0 randomizer
+	METHOD m_qqcjagbh setNotAngry ()V
 	METHOD m_rebcmcfu getEatSound ()Lnet/minecraft/unmapped/C_avavozay;
 	METHOD m_rnxhdlpt equipBodyArmor (Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 	METHOD m_rrbiqiat getInventoryColumns ()I
@@ -119,6 +120,7 @@ CLASS net/minecraft/unmapped/C_ktznyhaj net/minecraft/entity/passive/TamableMoun
 	METHOD m_uzaawbaz getMaxTemper ()I
 	METHOD m_vnhkinwe getTemper ()I
 	METHOD m_vrlngusg setAngry (I)V
+		ARG 1 ticks
 	METHOD m_wbgoobdc setTemper (I)V
 		ARG 1 temper
 	METHOD m_xcdgjriw getEatingGrassAnimationProgress (F)F

--- a/mappings/net/minecraft/entity/passive/TraderLlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TraderLlamaEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_oudbnauu net/minecraft/entity/passive/TraderLlamaEntity
 	FIELD f_jyxcngqf despawnDelay I
+	FIELD f_yhlvuncp DEFAULT_DESPAWN_DELAY I
 	METHOD m_cdkrybrf canDespawn ()Z
 	METHOD m_qbetekrq setDespawnDelay (I)V
 		ARG 1 despawnDelay

--- a/mappings/net/minecraft/entity/passive/TropicalFishEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/TropicalFishEntity.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/unmapped/C_mibzatdf net/minecraft/entity/passive/TropicalFis
 	FIELD f_kufkhwpz COMMON_VARIANTS Ljava/util/List;
 	FIELD f_pmzlbyhs commonSpawn Z
 	FIELD f_qbnpifvc VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_vdqxnvsl DEFAULT_VARIANT Lnet/minecraft/unmapped/C_mibzatdf$C_kcnhsswx;
 	METHOD m_bfgtpcox getToolTipForVariant (I)Ljava/lang/String;
 		ARG 0 variant
 	METHOD m_chlqwazt getVariantId ()I
@@ -9,6 +10,8 @@ CLASS net/minecraft/unmapped/C_mibzatdf net/minecraft/entity/passive/TropicalFis
 	METHOD m_eenipdqr getVariety (I)Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;
 		ARG 0 variety
 	METHOD m_flptkphs getVariety ()Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;
+	METHOD m_hdsvrfib setBaseColor (Lnet/minecraft/unmapped/C_arllgqae;)V
+		ARG 1 color
 	METHOD m_itvxyiwa getPatternDyeColor (I)Lnet/minecraft/unmapped/C_arllgqae;
 		ARG 0 variant
 	METHOD m_jhctuwse canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
@@ -22,7 +25,10 @@ CLASS net/minecraft/unmapped/C_mibzatdf net/minecraft/entity/passive/TropicalFis
 		ARG 2 patternColor
 	METHOD m_ugwtjmcb setVariantId (I)V
 		ARG 1 id
+	METHOD m_uwryiyoy setVariety (Lnet/minecraft/unmapped/C_mibzatdf$C_gdvfbafo;)V
 	METHOD m_vbwibvxz getPatternDyeColor ()Lnet/minecraft/unmapped/C_arllgqae;
+	METHOD m_wlggkmfl setPatternColor (Lnet/minecraft/unmapped/C_arllgqae;)V
+		ARG 1 color
 	CLASS C_gdvfbafo Variety
 		FIELD f_bmdqbrvq text Lnet/minecraft/unmapped/C_rdaqiwdt;
 		FIELD f_eqtyyhhi key Ljava/lang/String;

--- a/mappings/net/minecraft/entity/passive/VariantHelper.mapping
+++ b/mappings/net/minecraft/entity/passive/VariantHelper.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/unmapped/C_ypwmugue net/minecraft/entity/passive/VariantHelper
+	FIELD f_otkvxbgu VARIANT_KEY Ljava/lang/String;
+	METHOD m_afonierk (Lnet/minecraft/unmapped/C_kespdwpv;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 key
+	METHOD m_bvxgsfhm writeVariant (Lnet/minecraft/unmapped/C_kespdwpv;Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 0 writer
+		ARG 1 variant
+	METHOD m_euusxgyy readVariant (Lnet/minecraft/unmapped/C_djkzhngg;Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/Optional;
+		ARG 0 reader
+		ARG 1 registry
+	METHOD m_fdovbcqc selectVariant (Lnet/minecraft/unmapped/C_rgpspxvt;Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/Optional;
+		ARG 1 registry
+	METHOD m_icvbadln getAny (Lnet/minecraft/unmapped/C_wqxmvzdq;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 1 registry
+	METHOD m_sbskfeyy getValueOrAny (Lnet/minecraft/unmapped/C_wqxmvzdq;Lnet/minecraft/unmapped/C_xhhleach;)Lnet/minecraft/unmapped/C_cjzoxshv;
+		ARG 1 key

--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -78,7 +78,7 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 	METHOD m_lebhfnus getGossips ()Lnet/minecraft/unmapped/C_okajgatv;
 	METHOD m_llrjmaju levelUp ()V
 	METHOD m_mjduxnka isNatural ()Z
-	METHOD m_mpxabify updateDemandBonus ()V
+	METHOD m_mpxabify updateDemandBonuses ()V
 		COMMENT Updates the demand bonus of all the trade offers of this villager.
 	METHOD m_nhfaurjc hasSeedToPlant ()Z
 	METHOD m_nxfvdvix reinitializeBrain (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
@@ -117,7 +117,7 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 	METHOD m_wptaprwe releaseAllTickets ()V
 	METHOD m_wugbdqxs (Lnet/minecraft/unmapped/C_rsloiwzx;Ljava/util/Map$Entry;)I
 		ARG 1 entry
-	METHOD m_xdqprxfh restockAndUpdateDemandBonus ()V
+	METHOD m_xdqprxfh doDailyRestockImpl ()V
 	METHOD m_xgtnqlqm readGossipDataNbt (Lnet/minecraft/unmapped/C_okajgatv;)V
 	METHOD m_ypommskk initBrain (Lnet/minecraft/unmapped/C_rjqjaxef;)V
 		ARG 1 brain

--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 	FIELD f_audpvcxh lastRestockTime J
 	FIELD f_aweloyby experience I
 	FIELD f_bferfmkz natural Z
+	FIELD f_cewmqezq DEFAULT_EXPERIENCE I
 	FIELD f_dzkfxuwi GOLEM_COMMUNICATION_DISTANCE I
 		COMMENT How far away the villager should "talk" about golems with other villagers.
 	FIELD f_epcheowx BREEDING_FOOD_REQUIRED I
@@ -13,7 +14,10 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 		COMMENT How many villagers should agree for a golem to be spawned.
 	FIELD f_gxkrfvtt foodLevel I
 	FIELD f_hfjucsil SENSORS Lcom/google/common/collect/ImmutableList;
+	FIELD f_ijabgtsg DEFAULT_LAST_RESTOCK_TIME I
+	FIELD f_jecrxpwh DEFAULT_FOOD_LEVEL B
 	FIELD f_jhoygheo ITEM_FOOD_VALUES Ljava/util/Map;
+	FIELD f_kvuulktx DEFAULT_RESTOCKS_TODAY I
 	FIELD f_lkhjiicp MAX_GOSSIP_TOPICS I
 	FIELD f_mnprlolx chasing Z
 	FIELD f_mqjxuzni POINTS_OF_INTEREST Ljava/util/Map;
@@ -21,20 +25,25 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 	FIELD f_ounqokay restocksToday I
 	FIELD f_qjglwcyl GOSSIP_DECAY_INTERVAL I
 	FIELD f_qlajekfm levelingUp Z
+	FIELD f_rcekzksm DEFAULT_LAST_GOSSIP_DECAY_TIME I
 	FIELD f_sbabdvav lastGossipDecayTime J
 	FIELD f_suhwvkte lastRestockCheckTime J
 	FIELD f_tafdryps levelUpTimer I
 	FIELD f_usmdemxw GOSSIP_COOLDOWN I
+	FIELD f_wgaiuofy DEFAULT_NATURAL Z
 	FIELD f_xbuwxivj lastCustomer Lnet/minecraft/unmapped/C_jzrpycqo;
 	FIELD f_xisxjtqv VILLAGER_DATA Lnet/minecraft/unmapped/C_rinmcaxy;
-	FIELD f_yutmdxcy gossip Lnet/minecraft/unmapped/C_okajgatv;
+	FIELD f_yutmdxcy gossips Lnet/minecraft/unmapped/C_okajgatv;
 	FIELD f_zxhrpcmq LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_cjzoxshv;)V
 		ARG 1 entityType
 		ARG 3 villagerType
+	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 3 villagerType
 	METHOD m_adawsril eatForBreeding ()V
 	METHOD m_alogmwvo (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 0 villager
+		ARG 1 type
 	METHOD m_ckcvyxav talkWithVillager (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_pdtkdbte;J)V
 		ARG 1 world
 		ARG 2 villager
@@ -44,22 +53,29 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 		ARG 1 worldTime
 	METHOD m_cwatgxjj restock ()V
 	METHOD m_czadnfrf updateTradeOffers ()V
+	METHOD m_czlwfhhs (JLnet/minecraft/unmapped/C_pdtkdbte;)Z
+		ARG 2 villager
 	METHOD m_dnarwtec clearSpecialPrices ()V
 		COMMENT Resets the special price of all the trade offers of this villager.
 	METHOD m_dnuarqhe depleteFood (I)V
 		ARG 1 amount
 	METHOD m_eawuyvut (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 0 villager
+		ARG 1 type
 	METHOD m_haedgvxm setExperience (I)V
 		ARG 1 amount
 	METHOD m_hdwuynny buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_hnipyvgh setOffers (Lnet/minecraft/unmapped/C_eygsjfgm;)V
 		ARG 1 offers
 	METHOD m_jjwcuxsi playWorkSound ()V
+	METHOD m_jlxhehxs (JLjava/lang/Long;)Z
+		ARG 2 lastSlept
 	METHOD m_kiobdwbz releaseTicketFor (Lnet/minecraft/unmapped/C_vbbyoqyw;)V
 		ARG 1 memoryType
 	METHOD m_kqnyepur canRestock ()Z
-	METHOD m_lebhfnus getGossip ()Lnet/minecraft/unmapped/C_okajgatv;
+	METHOD m_kutkmeqm (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_luonewow;)V
+		ARG 2 witch
+	METHOD m_lebhfnus getGossips ()Lnet/minecraft/unmapped/C_okajgatv;
 	METHOD m_llrjmaju levelUp ()V
 	METHOD m_mjduxnka isNatural ()Z
 	METHOD m_mpxabify updateDemandBonus ()V
@@ -79,12 +95,16 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 	METHOD m_pagkeccz getAvailableFood ()I
 	METHOD m_pihkvsrk (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 0 villager
+		ARG 1 type
 	METHOD m_pwctnevz lacksFood ()Z
 	METHOD m_rftgjnmb needsRestock ()Z
 		COMMENT Returns whether this villager needs restock.
 		COMMENT
 		COMMENT <p>Checks if at least one of its trade offers has been used.
+	METHOD m_snfsoars (Lnet/minecraft/unmapped/C_jnfhmjij;)Z
+		ARG 0 gossip
 	METHOD m_tawsehpr wantsToStartBreeding ()Z
+	METHOD m_uudbadxe createDefaultData ()Lnet/minecraft/unmapped/C_zuqrzrur;
 	METHOD m_uyreuuxj consumeAvailableFood ()V
 	METHOD m_vtyepvne canBreed ()Z
 	METHOD m_vvktbnvx getReputation (Lnet/minecraft/unmapped/C_jzrpycqo;)I
@@ -93,7 +113,10 @@ CLASS net/minecraft/unmapped/C_pdtkdbte net/minecraft/entity/passive/VillagerEnt
 		ARG 1 player
 	METHOD m_wppblhsv (Lnet/minecraft/unmapped/C_pdtkdbte;Lnet/minecraft/unmapped/C_cjzoxshv;)Z
 		ARG 0 villager
+		ARG 1 type
 	METHOD m_wptaprwe releaseAllTickets ()V
+	METHOD m_wugbdqxs (Lnet/minecraft/unmapped/C_rsloiwzx;Ljava/util/Map$Entry;)I
+		ARG 1 entry
 	METHOD m_xdqprxfh restockAndUpdateDemandBonus ()V
 	METHOD m_xgtnqlqm readGossipDataNbt (Lnet/minecraft/unmapped/C_okajgatv;)V
 	METHOD m_ypommskk initBrain (Lnet/minecraft/unmapped/C_rjqjaxef;)V

--- a/mappings/net/minecraft/entity/passive/WanderingTraderEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WanderingTraderEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/unmapped/C_kiprlgty net/minecraft/entity/passive/WanderingTraderEntity
 	FIELD f_cofciqsy wanderTarget Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_panxmudh DEFAULT_DESPAWN_DELAY I
 	FIELD f_yundkzci despawnDelay I
 	METHOD m_erzkfklh getDespawnDelay ()I
 	METHOD m_kyqjbjby getWanderTarget ()Lnet/minecraft/unmapped/C_hynzadkk;

--- a/mappings/net/minecraft/entity/passive/WolfEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WolfEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_xokssljs net/minecraft/entity/passive/WolfEntity
 	COMMENT Bark.
 	FIELD f_aftpehwe ANGER_TIME Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_aupgaywc SOUND_VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_bgdwgbfu lastShakeProgress F
 	FIELD f_bhmevkqm COLLAR_COLOR Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_glkqojhp furWet Z
@@ -11,15 +12,21 @@ CLASS net/minecraft/unmapped/C_xokssljs net/minecraft/entity/passive/WolfEntity
 	FIELD f_opljwcgc DEFAULT_TAIL_ANGLE F
 	FIELD f_oyucjpiv FOLLOW_TAMED_PREDICATE Lnet/minecraft/unmapped/C_cjtyhinh$C_cqgaarcf;
 	FIELD f_rqsgdixb targetUuid Ljava/util/UUID;
+	FIELD f_rxoseaii DEFAULT_COLLAR_COLOR Lnet/minecraft/unmapped/C_arllgqae;
 	FIELD f_svqisfdy BEGGING Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_thwpaxgq shakeProgress F
 	FIELD f_uuhetxwo ANGER_TIME_RANGE Lnet/minecraft/unmapped/C_hvilmtvi;
 	FIELD f_wjmkqevm begAnimationProgress F
 	FIELD f_xkqfciml VARIANT Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ycekgyxv TAMED_MAX_HEALTH F
+	METHOD m_aeidllfu setVariant (Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 1 variant
 	METHOD m_aliqaiom getTailAngle ()F
 	METHOD m_dnvpayop setCollarColor (Lnet/minecraft/unmapped/C_arllgqae;)V
 		ARG 1 color
+	METHOD m_doevcvud getSoundVariant ()Lnet/minecraft/unmapped/C_cjzoxshv;
+	METHOD m_etfkfatj (Lnet/minecraft/unmapped/C_kespdwpv;Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 sound
 	METHOD m_goouxlmt shouldArmorAbsorbDamage (Lnet/minecraft/unmapped/C_sbxfkpyv;)Z
 		ARG 1 source
 	METHOD m_gvyvpuqi getBegAnimationProgress (F)F
@@ -37,9 +44,14 @@ CLASS net/minecraft/unmapped/C_xokssljs net/minecraft/entity/passive/WolfEntity
 	METHOD m_netinndt getCollarColor ()Lnet/minecraft/unmapped/C_arllgqae;
 	METHOD m_pcjygden setBegging (Z)V
 		ARG 1 begging
+	METHOD m_pgjuajil setSoundVariant (Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 1 variant
+	METHOD m_plstbpji (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/Optional;
+		ARG 1 sound
 	METHOD m_ptczuqbl resetShake ()V
 	METHOD m_qflbjcwd isBegging ()Z
 	METHOD m_siguawkr buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
+	METHOD m_uzzktagh getVariant ()Lnet/minecraft/unmapped/C_cjzoxshv;
 	METHOD m_vozawutp canSpawn (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_vdvbsyle;Lnet/minecraft/unmapped/C_bhyaesep;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_rlomrsco;)Z
 		ARG 0 type
 		ARG 1 world

--- a/mappings/net/minecraft/entity/player/HungerManager.mapping
+++ b/mappings/net/minecraft/entity/player/HungerManager.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_lvaukqjj net/minecraft/entity/player/HungerManager
+	FIELD f_djmdxpgi DEFAULT_FOOD_TICK_TIMER I
 	FIELD f_gjtpjdvl foodLevel I
+	FIELD f_lyctoubw DEFAULT_EXHAUSTION F
 	FIELD f_sdyzdnmj exhaustion F
 	FIELD f_urubumqi foodTickTimer I
 	FIELD f_zeivleti foodSaturationLevel F

--- a/mappings/net/minecraft/entity/player/InputFlags.mapping
+++ b/mappings/net/minecraft/entity/player/InputFlags.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/unmapped/C_lkjruazd net/minecraft/entity/player/InputFlags
-	FIELD f_antictat LEFT_BIT B
-	FIELD f_haoiyenj BACKWARD_BIT B
-	FIELD f_ixsmpoup SHIFT_BIT B
+	FIELD f_antictat LEFT_FLAG B
+	FIELD f_haoiyenj BACKWARD_FLAG B
+	FIELD f_ixsmpoup SHIFT_FLAG B
 	FIELD f_kkrffazv defaultFlags Lnet/minecraft/unmapped/C_lkjruazd;
-	FIELD f_mjwyouai FORWARD_BIT B
-	FIELD f_tukxzbcu RIGHT_BIT B
-	FIELD f_unxfzkam JUMP_BIT B
-	FIELD f_xlidivoq SPRINT_BIT B
+	FIELD f_mjwyouai FORWARD_FLAG B
+	FIELD f_tukxzbcu RIGHT_FLAG B
+	FIELD f_unxfzkam JUMP_FLAG B
+	FIELD f_xlidivoq SPRINT_FLAG B

--- a/mappings/net/minecraft/entity/player/InputFlags.mapping
+++ b/mappings/net/minecraft/entity/player/InputFlags.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/unmapped/C_lkjruazd net/minecraft/entity/player/InputFlags
+	FIELD f_antictat LEFT_BIT B
+	FIELD f_haoiyenj BACKWARD_BIT B
+	FIELD f_ixsmpoup SHIFT_BIT B
+	FIELD f_kkrffazv defaultFlags Lnet/minecraft/unmapped/C_lkjruazd;
+	FIELD f_mjwyouai FORWARD_BIT B
+	FIELD f_tukxzbcu RIGHT_BIT B
+	FIELD f_unxfzkam JUMP_BIT B
+	FIELD f_xlidivoq SPRINT_BIT B

--- a/mappings/net/minecraft/entity/player/PlayerAbilities.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerAbilities.mapping
@@ -1,14 +1,25 @@
 CLASS net/minecraft/unmapped/C_tlquukty net/minecraft/entity/player/PlayerAbilities
 	FIELD f_crqotssz allowModifyWorld Z
 	FIELD f_crtzioym allowFlying Z
+	FIELD f_dhzcgkaq DEFAULT_FLYING Z
 	FIELD f_epxjrpys flying Z
 	FIELD f_eullkouj creativeMode Z
+	FIELD f_ewxvykpu DEFAULT_WALK_SPEED F
 	FIELD f_fuetdzyo flySpeed F
 	FIELD f_hejaclbp invulnerable Z
+	FIELD f_laktvajo DEFAULT_CREATIVE_MODE Z
+	FIELD f_nbrqlrfq DEFAULT_FLY_SPEED F
 	FIELD f_npoapvix walkSpeed F
+	FIELD f_tjknmdmy DEFAULT_ALLOW_FLYING Z
+	FIELD f_tnswtknf DEFAULT_INVULNERABLE Z
+	FIELD f_ugjxnfss DEFAULT_ALLOW_MODIFY_WORLD Z
+	METHOD m_akmygaej pack ()Lnet/minecraft/unmapped/C_tlquukty$C_ptcdtjuq;
 	METHOD m_esxrpcaq setFlySpeed (F)V
 		ARG 1 flySpeed
+	METHOD m_rgmngwtu unpack (Lnet/minecraft/unmapped/C_tlquukty$C_ptcdtjuq;)V
+		ARG 1 packed
 	METHOD m_sjcafufe getFlySpeed ()F
 	METHOD m_srjewxrl getWalkSpeed ()F
 	METHOD m_xxgfdzbo setWalkSpeed (F)V
 		ARG 1 walkSpeed
+	CLASS C_ptcdtjuq Packed

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	FIELD f_boemmrdb selectedItem Lnet/minecraft/unmapped/C_sddaxwyk;
 	FIELD f_ccughjwx DEFAULT_EXPLOSION_RESET_GRACE_TIME I
 	FIELD f_ctdqwbpn totalExperience I
+	FIELD f_dgaswbcm clientLoaded Z
 	FIELD f_dgorlwne currentScreenHandler Lnet/minecraft/unmapped/C_mkrkudpa;
 	FIELD f_dhduzhea CRAFTING_SLOT_OFFSET I
 	FIELD f_dizzhcnp itemCooldownManager Lnet/minecraft/unmapped/C_kqeizhow;
@@ -16,6 +17,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	FIELD f_eqwqvgxn sleepTimer I
 	FIELD f_ewryjmpt defaultFlySpeed F
 	FIELD f_fkxntzwu abilities Lnet/minecraft/unmapped/C_tlquukty;
+	FIELD f_gresouge DEFAULT_SELECTED_SLOT I
 	FIELD f_hboiufsa RIGHT_SHOULDER_ENTITY Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_hcmdnhoe HELD_ITEM_SLOT I
 	FIELD f_hcpbjhic DEFAULT_VEHICLE_ATTACHMENT_POS Lnet/minecraft/unmapped/C_vgpupfxx;
@@ -23,16 +25,21 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	FIELD f_hudytuza CROUCH_BOUNDING_BOX_HEIGHT F
 	FIELD f_hwmnbaye gameProfile Lcom/mojang/authlib/GameProfile;
 	FIELD f_hxiepioz lastDeathPos Ljava/util/Optional;
+	FIELD f_ikmemzgy CLIENT_TIMEOUT_TICKS I
 	FIELD f_issiyxve prevStrideDistance F
 	FIELD f_jieotywx MAX_HEALTH I
 	FIELD f_koamdtto enderChestInventory Lnet/minecraft/unmapped/C_bzdxclxt;
 	FIELD f_lchiympu shoulderEntityAddedTime J
+	FIELD f_libioojj DEFAULT_SLEEP_TIMER S
 	FIELD f_lvmnsmon strideDistance F
+	FIELD f_meexszww DEFAULT_IGNORE_FALL_DAMAGE_FROM_CURRENT_EXPLOSION Z
+	FIELD f_mesjsdey DEFAULT_CURRENT_EXPLOSION_RESET_GRACE_TIME I
 	FIELD f_mpthcbws SLEEP_DURATION I
 	FIELD f_mwdihiqu prevCapeZ D
 	FIELD f_nvgvtbzg damageTiltStrength F
 	FIELD f_ogxdvcny MAIN_ARM Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_ollhfjel currentExplosionImpactPos Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_oxedtdnh clientTimeoutCountdown I
 	FIELD f_pcimjnvg prevCapeX D
 	FIELD f_pefjkyjf ENDER_CHEST_SLOT_OFFSET I
 	FIELD f_qnhqsdsh abilityResyncCountdown I
@@ -44,21 +51,26 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	FIELD f_tasedguh fishHook Lnet/minecraft/unmapped/C_bgaroumb;
 	FIELD f_teeqifol capeX D
 	FIELD f_thxasilg ABSORPTION_AMOUNT Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_tqgtykfz DEFAULT_EXPERIENCE_PROGRESS F
 	FIELD f_tvvqavsh enchantmentTableSeed I
 	FIELD f_uqzizwxj PLAYER_MODEL_PARTS Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_vpbheglm SCORE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_vspcmecf SWIMMING_BOUNDING_BOX_HEIGHT F
 	FIELD f_wbvwjgll capeY D
+	FIELD f_wedffwna DEFAULT_EXPERIENCE_LEVEL I
 	FIELD f_wsfwxuev capeZ D
 	FIELD f_wzkmvzss LEFT_SHOULDER_ENTITY Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_xeyqefzp DEFAULT_TOTAL_EXPERIENCE I
 	FIELD f_xhwyzbkq inventory Lnet/minecraft/unmapped/C_sxzqocrm;
 	FIELD f_xopzpppk DEFAULT_ENTITY_INTERACTION_RANGE F
 	FIELD f_xvlfpipb playerScreenHandler Lnet/minecraft/unmapped/C_wgehrbdx;
 	FIELD f_xythaqij DEFAULT_ARM Lnet/minecraft/unmapped/C_njjnizsa;
 	FIELD f_yavwtotq POSE_DIMENSIONS Ljava/util/Map;
+	FIELD f_yojskywh DEFAULT_SCORE I
 	FIELD f_ywdzyesv DEFAULT_EYE_HEIGHT F
 	FIELD f_yyyxasdx DEFAULT_BLOCK_INTERACTION_RANGE F
 	FIELD f_zmjqpvqo lastPlayedLevelUpSoundTime I
+	FIELD f_zzsjfljy NO_ENCHANTMENT_TABLE_SEED I
 	METHOD m_arcbriga getPermissionLevel ()I
 	METHOD m_arduainz isCreativeLevelTwoOp ()Z
 	METHOD m_aubfsqlm setReducedDebugInfo (Z)V
@@ -68,9 +80,10 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_bjasxujf getBlockBreakingSpeed (Lnet/minecraft/unmapped/C_txtbiemp;)F
 		ARG 1 block
 	METHOD m_bkuilldt unlockRecipes (Ljava/util/List;)V
-		ARG 1 recipeIds
+		ARG 1 recipes
 	METHOD m_bmpnkfvx setShoulderEntityRight (Lnet/minecraft/unmapped/C_hhlwcnih;)V
 		ARG 1 entityNbt
+	METHOD m_bwhngseo openScreen (Lnet/minecraft/unmapped/C_yxyvgcqr;)V
 	METHOD m_bxwvklcy buildAttributes ()Lnet/minecraft/unmapped/C_sdjuuzrz$C_tehwrjus;
 	METHOD m_cbytqozy playSound (Lnet/minecraft/unmapped/C_avavozay;Lnet/minecraft/unmapped/C_pqzizukq;FF)V
 		ARG 1 event
@@ -78,6 +91,8 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 		ARG 3 volume
 		ARG 4 pitch
 	METHOD m_ccuymcth checkFallFlying ()Z
+	METHOD m_cgitfxqj openDialog (Lnet/minecraft/unmapped/C_cjzoxshv;)V
+		ARG 1 dialog
 	METHOD m_cvlwevdb addExperienceLevels (I)V
 		ARG 1 levels
 	METHOD m_cxsmkgul addExhaustion (F)V
@@ -87,6 +102,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 		ARG 1 pos
 	METHOD m_dbuvscbh openStructureBlockScreen (Lnet/minecraft/unmapped/C_bfrzytnu;)V
 		ARG 1 structureBlock
+	METHOD m_dgfpdfsh getDebugString ()Ljava/lang/String;
 	METHOD m_dhkbsjyf getEnchantedDamage (Lnet/minecraft/unmapped/C_astfners;FLnet/minecraft/unmapped/C_sbxfkpyv;)F
 		ARG 1 target
 		ARG 2 baseDamage
@@ -121,6 +137,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 			COMMENT the item stack on the player's cursor
 		ARG 2 slotStack
 			COMMENT the item stack in the clicked slot
+		ARG 3 type
 	METHOD m_gozwojpw sendMessage (Lnet/minecraft/unmapped/C_rdaqiwdt;Z)V
 		ARG 1 message
 		ARG 2 actionBar
@@ -144,6 +161,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_jnzfvwue isMainPlayer ()Z
 		COMMENT @return {@code true} if on a client and this is that client's player,
 		COMMENT or {@code false} otherwise
+	METHOD m_kgjirvmg openScreen (Lnet/minecraft/unmapped/C_ionovaet;)V
 	METHOD m_kgvhhcun tickRegeneration ()V
 	METHOD m_knabeuog vanishCursedItems ()V
 	METHOD m_kvorjuof preventsBlockDrops ()Z
@@ -159,6 +177,8 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 		ARG 1 pose
 	METHOD m_lmevcwqf openCommandBlockMinecartScreen (Lnet/minecraft/unmapped/C_ufmydvnm;)V
 		ARG 1 commandBlockExecutor
+	METHOD m_lovyxner setClientLoaded (Z)V
+		ARG 1 loaded
 	METHOD m_lrmmkood applyEnchantmentCosts (Lnet/minecraft/unmapped/C_sddaxwyk;I)V
 		ARG 1 enchantedItem
 		ARG 2 experienceLevels
@@ -168,6 +188,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_mbymelmc addTellClickEvent (Lnet/minecraft/unmapped/C_npqneive;)Lnet/minecraft/unmapped/C_npqneive;
 		ARG 1 component
 	METHOD m_mgdicokk shouldRotateWithMinecart ()Z
+	METHOD m_mpfaloeq tickClientTimeout ()V
 	METHOD m_mvgxwslk spawnSweepAttackParticles ()V
 	METHOD m_nlpighqe dropShoulderEntities ()V
 	METHOD m_nodjejyg increaseStat (Lnet/minecraft/unmapped/C_ncpywfca;I)V
@@ -238,6 +259,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 		ARG 1 level
 	METHOD m_srbgfavo requestRespawn ()V
 	METHOD m_srzttqeq shouldDismount ()Z
+	METHOD m_svrucdua selectPose ()Lnet/minecraft/unmapped/C_ufdjspmk;
 	METHOD m_tbdjuqar tryResetCurrentExplosion ()V
 	METHOD m_tblbycwa canInteractWithBlockAt (Lnet/minecraft/unmapped/C_hynzadkk;D)Z
 		ARG 2 additionalRange
@@ -260,6 +282,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_wbynhygu hasSpaceBelow (DDD)Z
 		ARG 1 xOffset
 		ARG 3 zOffset
+		ARG 5 amountBelow
 	METHOD m_whbjjnjc startFallFlying ()V
 	METHOD m_wjlgxwvh canHarvest (Lnet/minecraft/unmapped/C_txtbiemp;)Z
 		COMMENT Determines whether the player is able to harvest drops from the specified block state.
@@ -275,6 +298,7 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_wttbsqsm getGameProfile ()Lcom/mojang/authlib/GameProfile;
 	METHOD m_wudyvmod setMainArm (Lnet/minecraft/unmapped/C_njjnizsa;)V
 		ARG 1 arm
+	METHOD m_xcpgmjkq isClientLoaded ()Z
 	METHOD m_xjswonqp resetStat (Lnet/minecraft/unmapped/C_sibrxbfy;)V
 		ARG 1 stat
 	METHOD m_xnugqgdd getHungerManager ()Lnet/minecraft/unmapped/C_lvaukqjj;
@@ -291,6 +315,10 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 	METHOD m_yiuyfgxw giveItemStack (Lnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 stack
 	METHOD m_yljkgzmc getEnchantmentTableSeed ()I
+	METHOD m_yobhkagx dropStack (Lnet/minecraft/unmapped/C_sddaxwyk;Z)Lnet/minecraft/unmapped/C_uqpzijng;
+		COMMENT {@linkplain net.minecraft.entity.LivingEntity#dropStack(net.minecraft.item.ItemStack, boolean, boolean) Drops}
+		COMMENT the passed {@code stack} without randomizing velocity.
+		ARG 2 setThrower
 	METHOD m_yoqvnsaz addEnchantedHitParticles (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 target
 	METHOD m_ypptjcsn canInteractWithEntity (Lnet/minecraft/unmapped/C_astfners;D)Z
@@ -304,6 +332,8 @@ CLASS net/minecraft/unmapped/C_jzrpycqo net/minecraft/entity/player/PlayerEntity
 		ARG 1 stepHeight
 	METHOD m_zlrabaci getScore ()I
 	METHOD m_znrmlhap shouldCancelInteraction ()Z
+	METHOD m_zohimnyh (Ljava/lang/String;Lnet/minecraft/unmapped/C_cpwnhism;)Lnet/minecraft/unmapped/C_cpwnhism;
+		ARG 2 style
 	CLASS C_wdhcnmsn SleepFailureReason
 		FIELD f_xgwynlaa text Lnet/minecraft/unmapped/C_rdaqiwdt;
 		METHOD <init> (Ljava/lang/String;ILnet/minecraft/unmapped/C_rdaqiwdt;)V

--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -1,11 +1,14 @@
 CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInventory
+	FIELD f_aqxlbnia SADDLE_SLOT I
 	FIELD f_atsclqcy main Lnet/minecraft/unmapped/C_rnrfftze;
+	FIELD f_chuuzmwb BODY_SLOT I
 	FIELD f_ddlbxbuu MAIN_SIZE I
 		COMMENT The number of slots ({@value}) in the main (non-hotbar) section of the inventory.
 	FIELD f_efjgtpgx NOT_FOUND I
 		COMMENT The slot index ({@value}) used to indicate no result
 		COMMENT (item not present / no available space) when querying the inventory's contents
 		COMMENT or to indicate no preference when inserting an item into the inventory.
+	FIELD f_epogyqll EQUIPMENT_SLOTS_BY_ID Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD f_hhxlkrup selectedSlot I
 	FIELD f_muifvbni player Lnet/minecraft/unmapped/C_jzrpycqo;
 	FIELD f_qmvikygt ITEM_USAGE_COOLDOWN I
@@ -18,6 +21,7 @@ CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInvent
 		COMMENT The number of columns ({@value}) in the inventory.
 		COMMENT
 		COMMENT <p>The same value dictates the size of the player's hotbar, excluding the offhand slot.</p>
+	FIELD f_txsgxayq equippedStacks Lnet/minecraft/unmapped/C_okmgcumg;
 	FIELD f_zhaszfsy changeCount I
 	METHOD m_agfxrwtb contains (Lnet/minecraft/unmapped/C_ednuhnnn;)Z
 		ARG 1 key
@@ -51,12 +55,16 @@ CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInvent
 	METHOD m_joxvrlyb insertStack (ILnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 slot
 		ARG 2 stack
-	METHOD m_julzohay writeNbt (Lnet/minecraft/unmapped/C_kespdwpv$C_hmmmpget;)V
+	METHOD m_julzohay write (Lnet/minecraft/unmapped/C_kespdwpv$C_hmmmpget;)V
+		ARG 1 writer
+	METHOD m_kymsgeht setSelectedStack (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_lhflraib createUpdatePacket (I)Lnet/minecraft/unmapped/C_yjakgqnt;
 		ARG 1 slot
+	METHOD m_lttgttvo getMain ()Lnet/minecraft/unmapped/C_rnrfftze;
 	METHOD m_mqaefcrf getOccupiedSlotWithRoomForStack (Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 1 stack
-	METHOD m_owslrmqz swapSlotWithHotbar (I)V
+	METHOD m_nrtgegwt getSelectedSlot ()I
+	METHOD m_owslrmqz swapWithHotbar (I)V
 		ARG 1 slot
 	METHOD m_qstschyr getMatchingSlot (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 1 item
@@ -65,14 +73,20 @@ CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInvent
 		ARG 2 stack
 	METHOD m_sqstcgyz getSlotWithStack (Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 1 stack
+	METHOD m_tjnqwbhx setSelectedSlot (I)V
+		COMMENT @throws IllegalArgumentException if the passed {@code slot} is not a
+		COMMENT {@linkplain #isValidHotbarSlot(int) valid hotbar slot}
 	METHOD m_upysxszu getChangeCount ()I
 	METHOD m_wfyaqwua getHotbarSize ()I
-	METHOD m_wisvsnby readNbt (Lnet/minecraft/unmapped/C_djkzhngg$C_knzjfpbq;)V
+	METHOD m_wisvsnby read (Lnet/minecraft/unmapped/C_djkzhngg$C_knzjfpbq;)V
+		ARG 1 reader
 	METHOD m_wtjgxszd dropAll ()V
 	METHOD m_wxyieztp offer (Lnet/minecraft/unmapped/C_sddaxwyk;Z)V
 		ARG 1 stack
 		ARG 2 notifiesClient
-	METHOD m_xbduwkdk isValidHotbarIndex (I)Z
+	METHOD m_xbduwkdk isValidHotbarSlot (I)Z
 		ARG 0 slot
 	METHOD m_xukgmrex addStack (Lnet/minecraft/unmapped/C_sddaxwyk;)I
 		ARG 1 stack
+	METHOD m_ydlcxxjs moveToHotbar (Lnet/minecraft/unmapped/C_sddaxwyk;)V
+	METHOD m_zrkzxrbk getSelectedStack ()Lnet/minecraft/unmapped/C_sddaxwyk;

--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -55,7 +55,7 @@ CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInvent
 	METHOD m_joxvrlyb insertStack (ILnet/minecraft/unmapped/C_sddaxwyk;)Z
 		ARG 1 slot
 		ARG 2 stack
-	METHOD m_julzohay write (Lnet/minecraft/unmapped/C_kespdwpv$C_hmmmpget;)V
+	METHOD m_julzohay writeMain (Lnet/minecraft/unmapped/C_kespdwpv$C_hmmmpget;)V
 		ARG 1 writer
 	METHOD m_kymsgeht setSelectedStack (Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_lhflraib createUpdatePacket (I)Lnet/minecraft/unmapped/C_yjakgqnt;
@@ -78,7 +78,7 @@ CLASS net/minecraft/unmapped/C_sxzqocrm net/minecraft/entity/player/PlayerInvent
 		COMMENT {@linkplain #isValidHotbarSlot(int) valid hotbar slot}
 	METHOD m_upysxszu getChangeCount ()I
 	METHOD m_wfyaqwua getHotbarSize ()I
-	METHOD m_wisvsnby read (Lnet/minecraft/unmapped/C_djkzhngg$C_knzjfpbq;)V
+	METHOD m_wisvsnby readMain (Lnet/minecraft/unmapped/C_djkzhngg$C_knzjfpbq;)V
 		ARG 1 reader
 	METHOD m_wtjgxszd dropAll ()V
 	METHOD m_wxyieztp offer (Lnet/minecraft/unmapped/C_sddaxwyk;Z)V

--- a/mappings/net/minecraft/entity/projectile/ArrowEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/ArrowEntity.mapping
@@ -10,6 +10,9 @@ CLASS net/minecraft/unmapped/C_otvmxtwh net/minecraft/entity/projectile/ArrowEnt
 		ARG 1 effect
 	METHOD m_eiscdqiq setPotionContents (Lnet/minecraft/unmapped/C_xpqegwnr;)V
 	METHOD m_iefuffrx getPotionContents ()Lnet/minecraft/unmapped/C_xpqegwnr;
+	METHOD m_rgehmosa (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_wpfizwve;)V
+		ARG 2 effect
 	METHOD m_tqbdancd spawnParticles (I)V
 		ARG 1 amount
 	METHOD m_xqohcsmn initColor ()V
+	METHOD m_yosoiouh getPotionDurationScale ()F

--- a/mappings/net/minecraft/entity/projectile/FireballEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/FireballEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_snrjksoh net/minecraft/entity/projectile/FireballEntity
+	FIELD f_jyhvkwtk DEFAULT_EXPLOSION_POWER B
 	FIELD f_njraicxi explosionPower I
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_vgpupfxx;I)V
 		ARG 2 owner

--- a/mappings/net/minecraft/entity/projectile/FireworkRocketEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/FireworkRocketEntity.mapping
@@ -1,7 +1,10 @@
 CLASS net/minecraft/unmapped/C_huldsolp net/minecraft/entity/projectile/FireworkRocketEntity
+	FIELD f_irxhlaea DEFAULT_LIFE_TIME I
 	FIELD f_jnghemum ITEM Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_jsrguonp lifeTime I
+	FIELD f_ldklnlgg DEFAULT_LIFE I
 	FIELD f_seqyipmr SHOOTER_ENTITY_ID Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_srpajevb DEFAULT_SHOT_AT_ANGLE Z
 	FIELD f_ssiwkaxw life I
 	FIELD f_vrrbrmuu SHOT_AT_ANGLE Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_wyqxskfa shooter Lnet/minecraft/unmapped/C_usxaxydn;
@@ -37,6 +40,8 @@ CLASS net/minecraft/unmapped/C_huldsolp net/minecraft/entity/projectile/Firework
 		ARG 1 world
 		ARG 2 stack
 		ARG 3 shooter
+	METHOD m_btbrbrfy (I)V
+		ARG 1 id
 	METHOD m_evuvwgwj explodeAndRemove (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
 	METHOD m_fhvapnlf createFireworkRocketStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_hqxwjjzr explode (Lnet/minecraft/unmapped/C_bdwnwhiu;)V

--- a/mappings/net/minecraft/entity/projectile/FishingBobberEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/FishingBobberEntity.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/unmapped/C_bgaroumb net/minecraft/entity/projectile/FishingB
 	FIELD f_gjgnfsus waitCountdown I
 	FIELD f_hrzzosjn velocityRandom Lnet/minecraft/unmapped/C_rlomrsco;
 	FIELD f_mhwmkuif hookCountdown I
+	FIELD f_mozsnfqv interpolator Lnet/minecraft/unmapped/C_sdgyrixf;
 	FIELD f_nmjotgmk HOOK_ENTITY_ID Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_plkhgjqe caughtFish Z
 	FIELD f_racbrfjp lureLevel I
@@ -21,6 +22,9 @@ CLASS net/minecraft/unmapped/C_bgaroumb net/minecraft/entity/projectile/FishingB
 		ARG 2 world
 		ARG 3 luckOfTheSeaLevel
 		ARG 4 lureLevel
+	METHOD m_akflgqwl (Lnet/minecraft/unmapped/C_bgaroumb$C_tbdoydtz;Lnet/minecraft/unmapped/C_bgaroumb$C_tbdoydtz;)Lnet/minecraft/unmapped/C_bgaroumb$C_tbdoydtz;
+		ARG 0 result
+		ARG 1 type
 	METHOD m_ddiqhjqh removeIfInvalid (Lnet/minecraft/unmapped/C_jzrpycqo;)Z
 		ARG 1 player
 	METHOD m_dtqatmph isInOpenWater ()Z

--- a/mappings/net/minecraft/entity/projectile/PersistentProjectileEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/PersistentProjectileEntity.mapping
@@ -47,6 +47,7 @@ CLASS net/minecraft/unmapped/C_gstiksvs net/minecraft/entity/projectile/Persiste
 		ARG 1 sound
 	METHOD m_ijqsvqvi getDefaultItemStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_isgasunb applyKnockback (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sbxfkpyv;)V
+		ARG 1 knockee
 	METHOD m_izcgrjes setDamage (D)V
 		ARG 1 damage
 	METHOD m_kntlthra getSound ()Lnet/minecraft/unmapped/C_avavozay;

--- a/mappings/net/minecraft/entity/projectile/PersistentProjectileEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/PersistentProjectileEntity.mapping
@@ -8,16 +8,21 @@ CLASS net/minecraft/unmapped/C_gstiksvs net/minecraft/entity/projectile/Persiste
 	FIELD f_hdbcayjq WATER_DRAG F
 	FIELD f_igmdnyfz pickupType Lnet/minecraft/unmapped/C_gstiksvs$C_pbhnbeyk;
 	FIELD f_juvjveta piercedEntities Lit/unimi/dsi/fastutil/ints/IntOpenHashSet;
+	FIELD f_mngxbtew DEFAULT_PIERCE_LEVEL B
 	FIELD f_ncskhrlt inBlockState Lnet/minecraft/unmapped/C_txtbiemp;
 	FIELD f_orpxztyk weapon Lnet/minecraft/unmapped/C_sddaxwyk;
 	FIELD f_pnuxpkjk CRITICAL_FLAG I
 	FIELD f_pqiurqmt PIERCE_LEVEL Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_qazfvpcx BASE_ARROW_DAMAGE D
 	FIELD f_rnapwtld SHAKE_TICKS I
+	FIELD f_snnyjqyd DEFAULT_IN_GROUND Z
 	FIELD f_umpvtnwi PROJECTILE_FLAGS Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_vqcewxuv DEFAULT_CRITICAL Z
 	FIELD f_wcrdrutf stack Lnet/minecraft/unmapped/C_sddaxwyk;
 	FIELD f_wgfwlrwg shake I
+	FIELD f_wshsuhjd DEFAULT_LIFE S
 	FIELD f_wuzchbwg damage D
+	FIELD f_xolavzrb DEFAULT_SHAKE B
 	FIELD f_yqrknjkl IN_GROUND Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;DDDLnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 type
@@ -53,8 +58,8 @@ CLASS net/minecraft/unmapped/C_gstiksvs net/minecraft/entity/projectile/Persiste
 		ARG 1 player
 	METHOD m_qmtcwgrn setStack (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 	METHOD m_qnxttchu setProjectileFlag (IZ)V
-		ARG 1 index
-		ARG 2 flag
+		ARG 1 flag
+		ARG 2 value
 	METHOD m_rjnoixne (Lnet/minecraft/unmapped/C_vorddnax;)V
 		ARG 1 item
 	METHOD m_sepatgdc age ()V
@@ -67,7 +72,7 @@ CLASS net/minecraft/unmapped/C_gstiksvs net/minecraft/entity/projectile/Persiste
 		ARG 1 critical
 	METHOD m_whtcpczr onHit (Lnet/minecraft/unmapped/C_usxaxydn;)V
 		ARG 1 target
-	METHOD m_wrkmrnze getDragInWater ()F
+	METHOD m_wrkmrnze getWaterDrag ()F
 	METHOD m_wznrraqn getStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_xmbclleg setInGround (Z)V
 	METHOD m_xnefdmre isCritical ()Z
@@ -77,3 +82,5 @@ CLASS net/minecraft/unmapped/C_gstiksvs net/minecraft/entity/projectile/Persiste
 	CLASS C_pbhnbeyk PickupPermission
 		METHOD m_eoybyvvn fromOrdinal (I)Lnet/minecraft/unmapped/C_gstiksvs$C_pbhnbeyk;
 			ARG 0 ordinal
+		METHOD m_goehwory (Lnet/minecraft/unmapped/C_gstiksvs$C_pbhnbeyk;)Ljava/lang/Byte;
+			ARG 0 permission

--- a/mappings/net/minecraft/entity/projectile/ProjectileEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileEntity.mapping
@@ -39,10 +39,12 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 	METHOD m_ikxgjanw (DDDFFLnet/minecraft/unmapped/C_ltpsyvhj;)V
 		ARG 8 projectile
 	METHOD m_iosroylp setOwner (Lnet/minecraft/unmapped/C_astfners;)V
+		ARG 1 owner
 	METHOD m_jmdjqqjc canHit (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 entity
 	METHOD m_joqridfr spawn (Lnet/minecraft/unmapped/C_ltpsyvhj$C_kpzjrlxz;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_usxaxydn;FFF)Lnet/minecraft/unmapped/C_ltpsyvhj;
 		ARG 0 factory
+		ARG 3 owner
 		ARG 4 roll
 		ARG 5 speed
 		ARG 6 divergence
@@ -74,6 +76,7 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 		ARG 3 beforeSpawn
 	METHOD m_tzwvduph spawn (Lnet/minecraft/unmapped/C_ltpsyvhj$C_kpzjrlxz;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_usxaxydn;DDDFF)Lnet/minecraft/unmapped/C_ltpsyvhj;
 		ARG 0 factory
+		ARG 3 owner
 		ARG 4 x
 		ARG 6 y
 		ARG 8 z
@@ -94,3 +97,5 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 	METHOD m_zvjsrghh (Lnet/minecraft/unmapped/C_ltpsyvhj;DDDFFLnet/minecraft/unmapped/C_ltpsyvhj;)V
 		ARG 9 ignored
 	CLASS C_kpzjrlxz ProjectileEntityFactory
+		METHOD create (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)Lnet/minecraft/unmapped/C_ltpsyvhj;
+			ARG 2 owner

--- a/mappings/net/minecraft/entity/projectile/ProjectileEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileEntity.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/ProjectileEntity
+	FIELD f_bmiwbvwe owner Lnet/minecraft/unmapped/C_xolbcmjn;
+	FIELD f_btpbvcac DEFAULT_LEFT_OWNER Z
 	FIELD f_eglzfbfb lastDeflectedBy Lnet/minecraft/unmapped/C_astfners;
 	FIELD f_pfurkhwc shot Z
+	FIELD f_uajgidrl DEFAULT_SHOT Z
 	FIELD f_uofnxxot leftOwner Z
 	METHOD m_aicjbexr onBroken (Lnet/minecraft/unmapped/C_vorddnax;)V
 		ARG 1 item
@@ -29,6 +32,13 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 		ARG 8 divergence
 	METHOD m_ggjsldmr onBlockHit (Lnet/minecraft/unmapped/C_jdakttms;)V
 		ARG 1 blockHitResult
+	METHOD m_gmynnbqo (Lnet/minecraft/unmapped/C_vorddnax;)V
+		ARG 0 ignored
+	METHOD m_goirgemx (Lnet/minecraft/unmapped/C_ltpsyvhj;)V
+		ARG 0 ignored
+	METHOD m_ikxgjanw (DDDFFLnet/minecraft/unmapped/C_ltpsyvhj;)V
+		ARG 8 projectile
+	METHOD m_iosroylp setOwner (Lnet/minecraft/unmapped/C_astfners;)V
 	METHOD m_jmdjqqjc canHit (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 entity
 	METHOD m_joqridfr spawn (Lnet/minecraft/unmapped/C_ltpsyvhj$C_kpzjrlxz;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_usxaxydn;FFF)Lnet/minecraft/unmapped/C_ltpsyvhj;
@@ -60,7 +70,7 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 		ARG 1 target
 		ARG 2 source
 	METHOD m_siviquov spawn (Lnet/minecraft/unmapped/C_ltpsyvhj;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Ljava/util/function/Consumer;)Lnet/minecraft/unmapped/C_ltpsyvhj;
-		ARG 0 projectileEntity
+		ARG 0 projectile
 		ARG 3 beforeSpawn
 	METHOD m_tzwvduph spawn (Lnet/minecraft/unmapped/C_ltpsyvhj$C_kpzjrlxz;Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_usxaxydn;DDDFF)Lnet/minecraft/unmapped/C_ltpsyvhj;
 		ARG 0 factory
@@ -69,6 +79,10 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 		ARG 8 z
 		ARG 10 power
 		ARG 11 divergence
+	METHOD m_ukewxrnc setOwner (Lnet/minecraft/unmapped/C_xolbcmjn;)V
+		ARG 1 owner
+	METHOD m_uvkkadiy (Lnet/minecraft/unmapped/C_usxaxydn;FFFLnet/minecraft/unmapped/C_ltpsyvhj;)V
+		ARG 4 projectile
 	METHOD m_vxsjwvrq updateRotation ()V
 	METHOD m_xlvwraww onCollision (Lnet/minecraft/unmapped/C_eetoegzn;)V
 		ARG 1 hitResult
@@ -77,4 +91,6 @@ CLASS net/minecraft/unmapped/C_ltpsyvhj net/minecraft/entity/projectile/Projecti
 		ARG 2 deflectingEntity
 		ARG 3 owner
 		ARG 4 fromAttack
+	METHOD m_zvjsrghh (Lnet/minecraft/unmapped/C_ltpsyvhj;DDDFFLnet/minecraft/unmapped/C_ltpsyvhj;)V
+		ARG 9 ignored
 	CLASS C_kpzjrlxz ProjectileEntityFactory

--- a/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/unmapped/C_xyszkcti net/minecraft/entity/projectile/Projecti
 		ARG 0 entity
 		ARG 1 item
 	METHOD m_yrxrxfsc getExpandingEntityCollision (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_ltpsyvhj;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_wokbhynj;
-		COMMENT Gets entity collisions, expanding the checked area with the passed
+		COMMENT Gets an entity collision, expanding the checked area with the passed
 		COMMENT {@code projectile}'s {@link net.minecraft.entity.Entity#age age}.
 		ARG 1 projectile
 	METHOD m_zcbsymub getCollision (Lnet/minecraft/unmapped/C_astfners;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_eetoegzn;

--- a/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/unmapped/C_xyszkcti net/minecraft/entity/projectile/Projecti
 		ARG 1 stack
 		ARG 2 damageModifier
 		ARG 3 weapon
+	METHOD m_ijmpiujg getBoundsExpansion (Lnet/minecraft/unmapped/C_astfners;)F
 	METHOD m_ntapkzlc getEntityCollision (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Ljava/util/function/Predicate;F)Lnet/minecraft/unmapped/C_wokbhynj;
 		ARG 0 world
 		ARG 1 entity
@@ -22,7 +23,7 @@ CLASS net/minecraft/unmapped/C_xyszkcti net/minecraft/entity/projectile/Projecti
 		ARG 3 max
 		ARG 4 box
 		ARG 5 predicate
-		ARG 6 value
+		ARG 6 boundsExpansion
 	METHOD m_onfmasdg raycast (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Ljava/util/function/Predicate;D)Lnet/minecraft/unmapped/C_wokbhynj;
 		ARG 0 entity
 		ARG 1 min
@@ -37,4 +38,8 @@ CLASS net/minecraft/unmapped/C_xyszkcti net/minecraft/entity/projectile/Projecti
 	METHOD m_wtslapuz getHandPossiblyHolding (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_vorddnax;)Lnet/minecraft/unmapped/C_laxmzoqs;
 		ARG 0 entity
 		ARG 1 item
+	METHOD m_yrxrxfsc getExpandingEntityCollision (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_ltpsyvhj;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hbcjzgoe;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_wokbhynj;
+		COMMENT Gets entity collisions, expanding the checked area with the passed
+		COMMENT {@code projectile}'s {@link net.minecraft.entity.Entity#age age}.
+		ARG 1 projectile
 	METHOD m_zcbsymub getCollision (Lnet/minecraft/unmapped/C_astfners;Ljava/util/function/Predicate;)Lnet/minecraft/unmapped/C_eetoegzn;

--- a/mappings/net/minecraft/entity/projectile/SpectralArrowEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/SpectralArrowEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_pclnyvja net/minecraft/entity/projectile/SpectralArrowEntity
 	FIELD f_imlylwuv duration I
+	FIELD f_lqkfplrt DEFAULT_DURATION I
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;DDDLnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 world

--- a/mappings/net/minecraft/entity/projectile/TridentEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/TridentEntity.mapping
@@ -1,12 +1,18 @@
 CLASS net/minecraft/unmapped/C_fdaeabmj net/minecraft/entity/projectile/TridentEntity
 	FIELD f_bdiezjfn dealtDamage Z
+	FIELD f_giedgevm WATER_DRAG F
 	FIELD f_iiroymhq LOYALTY Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_mndvrfka returnTimer I
 	FIELD f_vqfmqabi ENCHANTED Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_xnprzhlv DEFAULT_DEALT_DAMAGE Z
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 world
 		ARG 2 owner
 		ARG 3 stack
+	METHOD m_chyygacp (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vorddnax;)V
+		ARG 2 ignored
 	METHOD m_fxqomwss isEnchanted ()Z
 	METHOD m_npjzerbc getLoyalty (Lnet/minecraft/unmapped/C_sddaxwyk;)B
+	METHOD m_sjyhmrio (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_vorddnax;)V
+		ARG 2 ignored
 	METHOD m_tlimoycr isOwnerAlive ()Z

--- a/mappings/net/minecraft/entity/projectile/WindChargeProjectileEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/WindChargeProjectileEntity.mapping
@@ -5,3 +5,4 @@ CLASS net/minecraft/unmapped/C_kpiytlyx net/minecraft/entity/projectile/WindChar
 		ARG 1 type
 		ARG 3 entity
 	METHOD m_sljbcxrp createExplosion (Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 1 pos

--- a/mappings/net/minecraft/entity/projectile/WitherSkullEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/WitherSkullEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/unmapped/C_vzureqzt net/minecraft/entity/projectile/WitherSkullEntity
+	FIELD f_larfkbyt DEFAULT_CHARGED Z
 	FIELD f_vjaaowts CHARGED Lnet/minecraft/unmapped/C_rinmcaxy;
 	METHOD m_lzdaljfl isCharged ()Z
 	METHOD m_zrdahfgu setCharged (Z)V

--- a/mappings/net/minecraft/entity/projectile/thrown/EggEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/EggEntity.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/unmapped/C_afrevlxb net/minecraft/entity/projectile/thrown/EggEntity
 	FIELD f_yshetbat DIMENSIONS Lnet/minecraft/unmapped/C_sszpscpo;
+	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 2 owner

--- a/mappings/net/minecraft/entity/projectile/thrown/EnderPearlEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/EnderPearlEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_xmtgsyuv net/minecraft/entity/projectile/thrown/EnderPearlEntity
 	FIELD f_hbarhomd chunkLoadTicks J
 	METHOD m_cndeplmp removeFromOwner ()V
+	METHOD m_rvcgrrwg getEntity (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/util/UUID;)Lnet/minecraft/unmapped/C_astfners;
 	METHOD m_srsswowl addToOwner ()V
 	METHOD m_xkeukfpd playSound (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_vgpupfxx;)V
 		ARG 2 pos

--- a/mappings/net/minecraft/entity/projectile/thrown/EnderPearlEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/EnderPearlEntity.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_xmtgsyuv net/minecraft/entity/projectile/thrown/EnderPearlEntity
 	FIELD f_hbarhomd chunkLoadTicks J
+	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 2 owner
 	METHOD m_cndeplmp removeFromOwner ()V
 	METHOD m_rvcgrrwg getEntity (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/util/UUID;)Lnet/minecraft/unmapped/C_astfners;
 	METHOD m_srsswowl addToOwner ()V

--- a/mappings/net/minecraft/entity/projectile/thrown/ExperienceBottleEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/ExperienceBottleEntity.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/unmapped/C_qjcilmrj net/minecraft/entity/projectile/thrown/ExperienceBottleEntity
+	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 2 owner

--- a/mappings/net/minecraft/entity/projectile/thrown/EyeOfEnderEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/EyeOfEnderEntity.mapping
@@ -1,16 +1,29 @@
 CLASS net/minecraft/unmapped/C_juzydrbx net/minecraft/entity/projectile/thrown/EyeOfEnderEntity
 	FIELD f_azshsyjb lifespan I
 	FIELD f_dsomuhan dropsItem Z
+	FIELD f_flnzrrxh MAX_CLOSE_TARGET_DISTANCE F
 	FIELD f_ftehkous ITEM Lnet/minecraft/unmapped/C_rinmcaxy;
+	FIELD f_ikfggvjv target Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_qfiyzhkt DISTANT_TARGET_DIRECTION_Y_OFFSET F
 	FIELD f_xqykrtsq MIN_CAMERA_DISTANCE_SQUARED F
 	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;DDD)V
 		ARG 1 world
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
+	METHOD m_fniedfyl addParticles (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 1 pos
+		ARG 2 velocity
 	METHOD m_ilhdyacs createEnderEyeStack ()Lnet/minecraft/unmapped/C_sddaxwyk;
 	METHOD m_qnneluqn initTargetPos (Lnet/minecraft/unmapped/C_vgpupfxx;)V
 		COMMENT Sets where the eye will fly towards.
-		COMMENT If close enough, it will fly directly towards it, otherwise, it will fly upwards, in the direction of the BlockPos.
+		COMMENT <p>
+		COMMENT If close enough, it will fly directly towards it. Otherwise, it will fly upwards
+		COMMENT in the direction of the passed {@code pos}.
+		ARG 1 pos
+	METHOD m_vgmkltff adjustVelocity (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_vgpupfxx;
+		ARG 0 velocity
+		ARG 1 pos
+		ARG 2 target
 	METHOD m_ykvckpnt setItem (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 stack

--- a/mappings/net/minecraft/entity/projectile/thrown/PotionEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/PotionEntity.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/unmapped/C_hnnjbqvi net/minecraft/entity/projectile/thrown/P
 	FIELD f_cmdnpoid AFFECTED_BY_WATER Ljava/util/function/Predicate;
 	FIELD f_mufoapwv SPLASH_RANGE D
 	FIELD f_uuujdpbd SPLASH_RANGE_SQUARED D
+	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 3 owner
 	METHOD m_cjfwvxzo onCollisionHoldingWater (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
 	METHOD m_fohiwxxb onPotionCollision (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_eetoegzn;)V
 		ARG 3 hitResult

--- a/mappings/net/minecraft/entity/projectile/thrown/SnowballEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/SnowballEntity.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/unmapped/C_pxyfxaho net/minecraft/entity/projectile/thrown/SnowballEntity
+	METHOD <init> (Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 2 owner
 	METHOD m_zhggzqug getParticleParameters ()Lnet/minecraft/unmapped/C_nqucohct;

--- a/mappings/net/minecraft/entity/projectile/thrown/ThrownItemEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/thrown/ThrownItemEntity.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/unmapped/C_jksomjgm net/minecraft/entity/projectile/thrown/ThrownItemEntity
 	FIELD f_vnlwwvmn ITEM Lnet/minecraft/unmapped/C_rinmcaxy;
+	METHOD <init> (Lnet/minecraft/unmapped/C_ogavsvbr;Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_cdctfzbn;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 2 owner
 	METHOD m_dieyvesa getDefaultItem ()Lnet/minecraft/unmapped/C_vorddnax;
 	METHOD m_oozcxnle setItem (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 		ARG 1 item

--- a/mappings/net/minecraft/entity/raid/RaiderEntity.mapping
+++ b/mappings/net/minecraft/entity/raid/RaiderEntity.mapping
@@ -1,10 +1,14 @@
 CLASS net/minecraft/unmapped/C_iaguvmwh net/minecraft/entity/raid/RaiderEntity
 	FIELD f_biexexew raid Lnet/minecraft/unmapped/C_szefbyex;
+	FIELD f_boxrvtni DEFAULT_WAVE I
 	FIELD f_ecbzydno ableToJoinRaid Z
 	FIELD f_hszqhamp outOfRaidCounter I
+	FIELD f_kapqrbwc DEFAULT_CAN_JOIN_RAID Z
 	FIELD f_ncoaofla OBTAINABLE_OMINOUS_BANNER_PREDICATE Ljava/util/function/Predicate;
 	FIELD f_rktqrheh CELEBRATING Lnet/minecraft/unmapped/C_rinmcaxy;
 	FIELD f_zkxivcsk wave I
+	METHOD m_aoaeshli (Lnet/minecraft/unmapped/C_kespdwpv;I)V
+		ARG 1 id
 	METHOD m_bewyufgq getOutOfRaidCounter ()I
 	METHOD m_bfgvwscq setCelebrating (Z)V
 		ARG 1 celebrating
@@ -18,6 +22,7 @@ CLASS net/minecraft/unmapped/C_iaguvmwh net/minecraft/entity/raid/RaiderEntity
 		ARG 1 ableToJoinRaid
 	METHOD m_onpzsxkg addBonusForWave (Lnet/minecraft/unmapped/C_bdwnwhiu;IZ)V
 		ARG 2 wave
+		ARG 3 ignored
 	METHOD m_pvlitune getRaid ()Lnet/minecraft/unmapped/C_szefbyex;
 	METHOD m_ravxtbtq (Lnet/minecraft/unmapped/C_uqpzijng;)Z
 		ARG 0 itemEntity
@@ -28,10 +33,14 @@ CLASS net/minecraft/unmapped/C_iaguvmwh net/minecraft/entity/raid/RaiderEntity
 	METHOD m_xyumoqnj canJoinRaid ()Z
 	METHOD m_ypwbvbpo setOutOfRaidCounter (I)V
 		ARG 1 counter
+	METHOD m_zwxuijao (Lnet/minecraft/unmapped/C_bdwnwhiu;Ljava/lang/Integer;)V
+		ARG 2 id
 	CLASS C_dingymoh PatrolApproachGoal
 		FIELD f_ccjohomu closeRaiderPredicate Lnet/minecraft/unmapped/C_cjtyhinh;
 		FIELD f_kbsyzlhy raider Lnet/minecraft/unmapped/C_iaguvmwh;
 		FIELD f_tbbrhtuy squaredDistance F
+		METHOD <init> (Lnet/minecraft/unmapped/C_tupngryd;F)V
+			ARG 2 distance
 	CLASS C_eixofpsc CelebrateGoal
 		FIELD f_lnlkrwfy raider Lnet/minecraft/unmapped/C_iaguvmwh;
 		METHOD <init> (Lnet/minecraft/unmapped/C_iaguvmwh;Lnet/minecraft/unmapped/C_iaguvmwh;)V
@@ -49,6 +58,8 @@ CLASS net/minecraft/unmapped/C_iaguvmwh net/minecraft/entity/raid/RaiderEntity
 			ARG 4 distance
 		METHOD m_boiwccle tryFindHome ()Z
 		METHOD m_hnatgpmn purgeMemory ()V
+		METHOD m_kenkuedl (Lnet/minecraft/unmapped/C_cjzoxshv;)Z
+			ARG 0 poiType
 		METHOD m_pjypreaf isRaiding ()Z
 		METHOD m_snbezfbo canLootHome (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 			ARG 1 pos

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -205,6 +205,8 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 		ARG 1 damage
 	METHOD m_rmdiknvo getMaxCount ()I
 	METHOD m_rvfytoek isItemBarVisible ()Z
+	METHOD m_saymlnod forEachModifier (Lnet/minecraft/unmapped/C_yuycoehb;Ljava/util/function/BiConsumer;)V
+		ARG 2 action
 	METHOD m_sfmosozi getItemBarColor ()I
 		COMMENT {@return the color of the filled section of the durability bar}
 	METHOD m_sjztniec isStackable ()Z
@@ -284,6 +286,9 @@ CLASS net/minecraft/unmapped/C_sddaxwyk net/minecraft/item/ItemStack
 	METHOD m_yprgpdac takesDamageFrom (Lnet/minecraft/unmapped/C_sbxfkpyv;)Z
 		ARG 1 damageSource
 	METHOD m_yrbtnzbt getRarity ()Lnet/minecraft/unmapped/C_mqmixksm;
+	METHOD m_yvfkzlxj (Lorg/apache/commons/lang3/function/TriConsumer;Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hdbqsqsm;)V
+		ARG 1 attribute
+		ARG 2 modifier
 	METHOD m_ywdqmcbk getTooltip (Lnet/minecraft/unmapped/C_vorddnax$C_rdhfmrgz;Lnet/minecraft/unmapped/C_jzrpycqo;Lnet/minecraft/unmapped/C_taebrtdw;)Ljava/util/List;
 		ARG 1 context
 		ARG 2 player

--- a/mappings/net/minecraft/network/HashedComponentPatchSplit.mapping
+++ b/mappings/net/minecraft/network/HashedComponentPatchSplit.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/unmapped/C_rptylujn net/minecraft/network/HashedComponentPatchSplit
+	FIELD f_lmgesehe removed Ljava/util/Set;
+	FIELD f_njhrskys added Ljava/util/Map;
+	METHOD m_agijzhkv added ()Ljava/util/Map;
+	METHOD m_mlfklfox of (Lnet/minecraft/unmapped/C_jqyoylib;Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;)Lnet/minecraft/unmapped/C_rptylujn;
+		ARG 0 patch
+		ARG 1 hasher
+	METHOD m_njctycbx matches (Lnet/minecraft/unmapped/C_jqyoylib;Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;)Z
+		ARG 1 patch
+		ARG 2 hasher
+	METHOD m_rjkdrzba (Ljava/util/Map;Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;Lnet/minecraft/unmapped/C_qkjwbfhx;)V
+		ARG 2 component
+	METHOD m_zgwuwdxn removed ()Ljava/util/Set;
+	CLASS C_fljkkgwu Hasher

--- a/mappings/net/minecraft/network/HashedItemStack.mapping
+++ b/mappings/net/minecraft/network/HashedItemStack.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/unmapped/C_uvqoolzs net/minecraft/network/HashedItemStack
+	FIELD f_qxahxvoj EMPTY Lnet/minecraft/unmapped/C_uvqoolzs;
+	METHOD m_dlcxqpqr (Lnet/minecraft/unmapped/C_uvqoolzs;)Ljava/util/Optional;
+		ARG 0 stack
+	METHOD m_ebvgajdz matches (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;)Z
+		ARG 2 hasher
+	METHOD m_kyoxdfnk of (Lnet/minecraft/unmapped/C_sddaxwyk;Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;)Lnet/minecraft/unmapped/C_uvqoolzs;
+	METHOD m_zjaphbzh (Ljava/util/Optional;)Lnet/minecraft/unmapped/C_uvqoolzs;
+		ARG 0 nonEmpty
+	CLASS C_xhxfepdk NonEmpty

--- a/mappings/net/minecraft/network/TrackedSlot.mapping
+++ b/mappings/net/minecraft/network/TrackedSlot.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/unmapped/C_kqfxjzge net/minecraft/network/TrackedSlot
+	FIELD f_smtdtquf DUMMY Lnet/minecraft/unmapped/C_kqfxjzge;
+	METHOD m_bptvrlqw matches (Lnet/minecraft/unmapped/C_sddaxwyk;)Z
+	METHOD m_cmrixakd setStack (Lnet/minecraft/unmapped/C_sddaxwyk;)V
+	METHOD m_svodfzmj setStack (Lnet/minecraft/unmapped/C_uvqoolzs;)V
+		ARG 1 stack
+	CLASS C_jswkpmfl Synchronized
+		FIELD f_ozzkofxz hasher Lnet/minecraft/unmapped/C_rptylujn$C_fljkkgwu;
+		FIELD f_tntbmmfs hashed Lnet/minecraft/unmapped/C_uvqoolzs;
+		METHOD m_tpbrohxo copyFrom (Lnet/minecraft/unmapped/C_kqfxjzge$C_jswkpmfl;)V
+			ARG 1 other

--- a/mappings/net/minecraft/network/listener/ClientCommonPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientCommonPacketListener.mapping
@@ -8,5 +8,6 @@ CLASS net/minecraft/unmapped/C_sjvciiwk net/minecraft/network/listener/ClientCom
 	METHOD m_rypoqduh onDisconnect (Lnet/minecraft/unmapped/C_xcpuaily;)V
 	METHOD m_sggenrss onCustomPayload (Lnet/minecraft/unmapped/C_spbiyfem;)V
 	METHOD m_wypozfsc onAddResourcePack (Lnet/minecraft/unmapped/C_zhbijmex;)V
+	METHOD m_xifuzlgi onShowDialog (Lnet/minecraft/unmapped/C_jyszwcez;)V
 	METHOD m_xlfgdnee onKeepConnectionAlive (Lnet/minecraft/unmapped/C_bwdhswrk;)V
 	METHOD m_zagznocx onTransfer (Lnet/minecraft/unmapped/C_azcofhim;)V

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -66,6 +66,7 @@ CLASS net/minecraft/unmapped/C_rbfddnlp net/minecraft/network/listener/ClientPla
 	METHOD m_nkywqjlj onTeamUpdate (Lnet/minecraft/unmapped/C_yxooxvgv;)V
 	METHOD m_nvvaujxx onSimulationDistanceUpdate (Lnet/minecraft/unmapped/C_bpiaeqfq;)V
 	METHOD m_otouqqlf onDeathMessage (Lnet/minecraft/unmapped/C_lkozehxy;)V
+	METHOD m_pbydvbfl onRecipeBookRemoval (Lnet/minecraft/unmapped/C_jqraxkur;)V
 	METHOD m_pcurpaku onEntityPositionUpdate (Lnet/minecraft/unmapped/C_qlsxyesm;)V
 	METHOD m_phjtliyc onWrittenBookOpen (Lnet/minecraft/unmapped/C_jrsyoqon;)V
 	METHOD m_pjnjwbgv onPlayerRespawn (Lnet/minecraft/unmapped/C_jvhuimuc;)V
@@ -90,7 +91,9 @@ CLASS net/minecraft/unmapped/C_rbfddnlp net/minecraft/network/listener/ClientPla
 	METHOD m_ummkjdxr onStatisticsUpdate (Lnet/minecraft/unmapped/C_hcmoxswq;)V
 	METHOD m_vaumidxl onChunkDeltaUpdate (Lnet/minecraft/unmapped/C_gxacpmvt;)V
 	METHOD m_vffbdjnc onScreenClose (Lnet/minecraft/unmapped/C_hxlvmzww;)V
+	METHOD m_vghkufeu onRecipeBookAddition (Lnet/minecraft/unmapped/C_fiyoolld;)V
 	METHOD m_vmjtkjip onScreenHandlerPropertyUpdate (Lnet/minecraft/unmapped/C_aezbuhxe;)V
+	METHOD m_vmxxdocv onRecipeBookOptions (Lnet/minecraft/unmapped/C_uepzhiii;)V
 	METHOD m_wevvcgwp onVelocityUpdate (Lnet/minecraft/unmapped/C_chysixjg;)V
 	METHOD m_wvebqzpd onWorldBorderWarningTimeUpdate (Lnet/minecraft/unmapped/C_vnmhauxd;)V
 	METHOD m_wxaxogqp onEntitySpawned (Lnet/minecraft/unmapped/C_qdqrqwvy;)V

--- a/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/unmapped/C_eetcdhxt net/minecraft/network/listener/ServerPlayPacketListener
 	COMMENT A server side packet listener where play stage packets from a client are processed.
 	METHOD m_atacehxz onDifficultyLockUpdate (Lnet/minecraft/unmapped/C_txzbrcbs;)V
+	METHOD m_auhschpg onSetTestBlock (Lnet/minecraft/unmapped/C_xzvognww;)V
 	METHOD m_axbiujnr onPlayerInteractionWithItem (Lnet/minecraft/unmapped/C_mnaqbeyf;)V
 	METHOD m_bkhjrtgh onSelectedSlotUpdate (Lnet/minecraft/unmapped/C_zjzfpaba;)V
 	METHOD m_cofvhcmo onChunkBatchAcknowledgement (Lnet/minecraft/unmapped/C_jmmijfmi;)V

--- a/mappings/net/minecraft/network/packet/c2s/play/SetTestBlockC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/SetTestBlockC2SPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_xzvognww net/minecraft/network/packet/c2s/play/SetTestBlockC2SPacket
+	FIELD f_bukymhlb pos Lnet/minecraft/unmapped/C_hynzadkk;
+	METHOD m_lpeoljcx pos ()Lnet/minecraft/unmapped/C_hynzadkk;

--- a/mappings/net/minecraft/network/packet/s2c/play/PlayerListS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/PlayerListS2CPacket.mapping
@@ -30,10 +30,14 @@ CLASS net/minecraft/unmapped/C_lmoadlft net/minecraft/network/packet/s2c/play/Pl
 			ARG 4 writer
 		METHOD m_ahklondx (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
 			ARG 0 builder
+		METHOD m_bzwbgddn (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
+			ARG 1 entry
 		METHOD m_ehzvdani (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
 			ARG 0 builder
 		METHOD m_gnxpxpxe (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
 			ARG 1 entry
+		METHOD m_ibkmprif (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
+			ARG 0 builder
 		METHOD m_msxipqnu (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
 			ARG 0 builder
 		METHOD m_nfkvezii (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
@@ -42,9 +46,13 @@ CLASS net/minecraft/unmapped/C_lmoadlft net/minecraft/network/packet/s2c/play/Pl
 			ARG 0 builder
 		METHOD m_osetncqf (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
 			ARG 1 builder
+		METHOD m_qfefpqio (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
+			ARG 1 entry
 		METHOD m_qkvbyqle (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
 			ARG 0 builder
 		METHOD m_rmuakouw (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
+			ARG 0 builder
+		METHOD m_sleqlils (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
 			ARG 0 builder
 		METHOD m_sqkwqjzb (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
 			ARG 1 entry
@@ -53,18 +61,23 @@ CLASS net/minecraft/unmapped/C_lmoadlft net/minecraft/network/packet/s2c/play/Pl
 		METHOD m_wdwpewqk (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
 			ARG 1 entry
 		CLASS C_ldrsfpcw Writer
+			METHOD write (Lnet/minecraft/unmapped/C_bngyzsts;Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;)V
+				ARG 2 entry
 		CLASS C_uugflzau Reader
+			METHOD read (Lnet/minecraft/unmapped/C_lmoadlft$C_ttvoxjqr;Lnet/minecraft/unmapped/C_bngyzsts;)V
+				ARG 1 builder
 	CLASS C_ttvoxjqr EntryBuilder
 		FIELD f_afvtowyz chatSession Lnet/minecraft/unmapped/C_sdodhjzp$C_igdefirc;
+		FIELD f_bhwnosfm showHat Z
 		FIELD f_bxnmotcp displayName Lnet/minecraft/unmapped/C_rdaqiwdt;
 		FIELD f_ceucvwav gameMode Lnet/minecraft/unmapped/C_lghcpyvl;
 		FIELD f_fvfsxnhl uuid Ljava/util/UUID;
 		FIELD f_lqifphaj listed Z
 		FIELD f_nswipqus latency I
+		FIELD f_qinhpodp listOrder I
 		FIELD f_wbgwmhcd profile Lcom/mojang/authlib/GameProfile;
 		METHOD <init> (Ljava/util/UUID;)V
 			ARG 1 uuid
 		METHOD m_touccbhn build ()Lnet/minecraft/unmapped/C_lmoadlft$C_ywzccojo;
 	CLASS C_ywzccojo Entry
 		METHOD <init> (Lnet/minecraft/unmapped/C_mxrobsgg;)V
-			ARG 1 entity

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/unmapped/C_fiyoolld net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket
+	CLASS C_akcqghxx Entry
+		FIELD f_mkfqhoar TO_BE_DISPLAYED_BIT B
+		FIELD f_uhuupgqe value Lnet/minecraft/unmapped/C_dsptsoym;
+		FIELD f_vsmavszc SHOW_NOTIFICATION_BIT B
+		METHOD <init> (Lnet/minecraft/unmapped/C_dsptsoym;ZZ)V
+			ARG 1 value
+			ARG 2 showNotification
+			ARG 3 toBeDisplayed
+		METHOD m_brtzaeuv value ()Lnet/minecraft/unmapped/C_dsptsoym;
+		METHOD m_dcnowoaf showsNotification ()Z
+		METHOD m_yhfefzoj isToBeDisplayed ()Z

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/unmapped/C_fiyoolld net/minecraft/network/packet/s2c/play/RecipeBookAdditionS2CPacket
 	CLASS C_akcqghxx Entry
-		FIELD f_mkfqhoar TO_BE_DISPLAYED_BIT B
+		FIELD f_mkfqhoar TO_BE_DISPLAYED_FLAG B
 		FIELD f_uhuupgqe value Lnet/minecraft/unmapped/C_dsptsoym;
-		FIELD f_vsmavszc SHOW_NOTIFICATION_BIT B
+		FIELD f_vsmavszc SHOW_NOTIFICATION_FLAG B
 		METHOD <init> (Lnet/minecraft/unmapped/C_dsptsoym;ZZ)V
 			ARG 1 value
 			ARG 2 showNotification

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookOptionsS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookOptionsS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_uepzhiii net/minecraft/network/packet/s2c/play/RecipeBookOptionsS2CPacket
+	FIELD f_dafttfiw options Lnet/minecraft/unmapped/C_krpwsfph;
+	METHOD m_ccfjzuqh options ()Lnet/minecraft/unmapped/C_krpwsfph;

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookRemovalS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookRemovalS2CPacket.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_jqraxkur net/minecraft/network/packet/s2c/play/RecipeBookRemovalS2CPacket

--- a/mappings/net/minecraft/network/packet/s2c/play/ShowDialogS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ShowDialogS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_jyszwcez net/minecraft/network/packet/s2c/play/ShowDialogS2CPacket
+	FIELD f_mljlanzs CODEC Lnet/minecraft/unmapped/C_qsrmwluu;
+	FIELD f_rtyefvtk REGISTRY_CODEC Lnet/minecraft/unmapped/C_qsrmwluu;

--- a/mappings/net/minecraft/network/packet/s2c/play/UpdateCursorStackS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/UpdateCursorStackS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/unmapped/C_zqywhkdo net/minecraft/network/packet/s2c/play/UpdateCursorStackS2CPacket
+	FIELD f_pkdmygzr stack Lnet/minecraft/unmapped/C_sddaxwyk;
+	METHOD m_soumesvp stack ()Lnet/minecraft/unmapped/C_sddaxwyk;

--- a/mappings/net/minecraft/recipe/RecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/RecipeManager.mapping
@@ -77,7 +77,7 @@ CLASS net/minecraft/unmapped/C_hjseusrb net/minecraft/recipe/RecipeManager
 		COMMENT returned set do not affect this manager.
 	METHOD m_wzltkytn forEachDisplay (Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Consumer;)V
 		ARG 1 key
-		ARG 2 consumer
+		ARG 2 action
 	METHOD m_yaytthyj (Lnet/minecraft/unmapped/C_hjseusrb$C_oqjlukte;)Lnet/minecraft/unmapped/C_xhhleach;
 		ARG 0 display
 	METHOD m_ycuyimxd (Lnet/minecraft/unmapped/C_awrmdwqd;)Ljava/util/Optional;

--- a/mappings/net/minecraft/scoreboard/Scoreboard.mapping
+++ b/mappings/net/minecraft/scoreboard/Scoreboard.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/unmapped/C_ymwyplge net/minecraft/scoreboard/Scoreboard
 		ARG 6 format
 	METHOD m_cfzvdwxh forEachScore (Lnet/minecraft/unmapped/C_adsgsrpw;Lnet/minecraft/unmapped/C_hswmfudr;Ljava/util/function/Consumer;)V
 		ARG 1 criterion
-		ARG 2 score
+		ARG 2 holder
 		ARG 3 action
 	METHOD m_cipkdtdz addObjective (Lnet/minecraft/unmapped/C_tlhwodcf$C_nmhfrsfm;)V
 		ARG 1 packed

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
@@ -23,9 +23,13 @@ CLASS net/minecraft/unmapped/C_adsgsrpw net/minecraft/scoreboard/ScoreboardCrite
 		ARG 2 defaultRenderType
 	METHOD m_jndgzjoc getOrCreateStatCriterion (Ljava/lang/String;)Ljava/util/Optional;
 		ARG 0 name
+	METHOD m_mumuhnmk (Ljava/lang/String;ILnet/minecraft/unmapped/C_qwzfcpmd;)Ljava/util/Optional;
+		ARG 2 type
 	METHOD m_pfrouplm getOrCreateStatCriterion (Lnet/minecraft/unmapped/C_qwzfcpmd;Lnet/minecraft/unmapped/C_ncpywfca;)Ljava/util/Optional;
 		ARG 0 statType
 		ARG 1 id
+	METHOD m_vcmhudzi (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 name
 	METHOD m_xqsugmns getDefaultRenderType ()Lnet/minecraft/unmapped/C_adsgsrpw$C_ianbxnvz;
 	METHOD m_ylywqwbz getName ()Ljava/lang/String;
 	METHOD m_ynfxoksk getCustomCriteriaNames ()Ljava/util/Set;

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -166,11 +166,13 @@ CLASS net/minecraft/unmapped/C_mkrkudpa net/minecraft/screen/ScreenHandler
 		ARG 0 slots
 		ARG 1 mode
 	METHOD m_xucrqdwn checkPropertyUpdates (II)V
-		ARG 1 id
+		ARG 1 index
 		ARG 2 value
 	METHOD m_ydpykrle onButtonClick (Lnet/minecraft/unmapped/C_jzrpycqo;I)Z
 		ARG 1 player
 		ARG 2 id
 	METHOD m_yduzhebn addProperty (Lnet/minecraft/unmapped/C_xzbkunds;)Lnet/minecraft/unmapped/C_xzbkunds;
 		ARG 1 property
+	METHOD m_yjsgbolt (ILnet/minecraft/unmapped/C_uvqoolzs;)V
+		ARG 2 stack
 	METHOD m_zipsjvkj canUse (Lnet/minecraft/unmapped/C_jzrpycqo;)Z

--- a/mappings/net/minecraft/screen/ScreenHandlerListener.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerListener.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/unmapped/C_juruncbf net/minecraft/screen/ScreenHandlerListener
 	METHOD m_ifdythrh onPropertyUpdate (Lnet/minecraft/unmapped/C_mkrkudpa;II)V
+		ARG 1 handler
+		ARG 2 id
+		ARG 3 value
 	METHOD m_yfrjwezo onSlotUpdate (Lnet/minecraft/unmapped/C_mkrkudpa;ILnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 1 handler
+		ARG 2 slot

--- a/mappings/net/minecraft/screen/ScreenHandlerSynchronizer.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerSynchronizer.mapping
@@ -1,5 +1,15 @@
-CLASS net/minecraft/unmapped/C_ccogdvwm net/minecraft/screen/ScreenHandlerSyncHandler
+CLASS net/minecraft/unmapped/C_ccogdvwm net/minecraft/screen/ScreenHandlerSynchronizer
 	METHOD m_hncjmndt updateProperty (Lnet/minecraft/unmapped/C_mkrkudpa;II)V
+		ARG 1 handler
+		ARG 2 id
+		ARG 3 value
 	METHOD m_odhdcqbe updateSlot (Lnet/minecraft/unmapped/C_mkrkudpa;ILnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 1 handler
+		ARG 2 slot
 	METHOD m_ojepxclu updateCursorStack (Lnet/minecraft/unmapped/C_mkrkudpa;Lnet/minecraft/unmapped/C_sddaxwyk;)V
+		ARG 1 handler
+	METHOD m_rgbimbnu createSlot ()Lnet/minecraft/unmapped/C_kqfxjzge;
 	METHOD m_xkpmwtgb updateState (Lnet/minecraft/unmapped/C_mkrkudpa;Ljava/util/List;Lnet/minecraft/unmapped/C_sddaxwyk;[I)V
+		ARG 1 handler
+		ARG 2 inventoryContents
+		ARG 4 trackedPropertyValues

--- a/mappings/net/minecraft/server/command/CommandOutput.mapping
+++ b/mappings/net/minecraft/server/command/CommandOutput.mapping
@@ -4,5 +4,6 @@ CLASS net/minecraft/unmapped/C_ngpvhugm net/minecraft/server/command/CommandOutp
 	METHOD m_bigwtrxt shouldReceiveFeedback ()Z
 	METHOD m_kvkvdmjl cannotBeSilenced ()Z
 	METHOD m_secybssw sendSystemMessage (Lnet/minecraft/unmapped/C_rdaqiwdt;)V
+		ARG 1 message
 	METHOD m_zfuzzzpb shouldBroadcastConsoleToOps ()Z
 	METHOD m_zyyeroen shouldTrackOutput ()Z

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -1,29 +1,39 @@
 CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlayerEntity
+	FIELD f_ahjtibay ENDER_PEARL_DIMENSION_KEY Ljava/lang/String;
 	FIELD f_aigmlatx screenHandlerSyncId I
 	FIELD f_ancsmfuf lastExperienceScore I
 	FIELD f_awxwtkbc lastLevelScore I
+	FIELD f_aypwdfqm FLY_STAT_RECORDING_SPEED I
+	FIELD f_bisatnfo VERTICAL_FOGIVENESS_RANGE I
 	FIELD f_bpaumbdz lastClientInput Lnet/minecraft/unmapped/C_lkjruazd;
 	FIELD f_capnwlvs levitationStartPos Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_cfahbfba fallStartPos Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_cosaarly ENDER_PEARLS_KEY Ljava/lang/String;
 	FIELD f_czcwatdw lastAirScore I
 	FIELD f_dqffdmpu thrownEnderPearls Ljava/util/Set;
 	FIELD f_eahsbljj screenHandlerSyncHandler Lnet/minecraft/unmapped/C_ccogdvwm;
 	FIELD f_ecegdczc notInAnyWorld Z
+	FIELD f_ecrfaigy ENDER_PEARL_TICKET_RADIUS I
+	FIELD f_etyhlpnk DEFAULT_SEEN_CREDITS Z
 	FIELD f_ewcehdmp syncedFoodLevel I
 	FIELD f_ffakgupn statHandler Lnet/minecraft/unmapped/C_cakpthuz;
 	FIELD f_fkzaomsn CREATIVE_ENTITY_INTERACTION_RANGE_MODIFIER Lnet/minecraft/unmapped/C_hdbqsqsm;
 	FIELD f_fmywgmel levitationStartTick I
 	FIELD f_glnuzcvl networkHandler Lnet/minecraft/unmapped/C_hwbabymg;
+	FIELD f_gmpmdcwt WAYPOINT_TRANSMIT_RANGE_CROUCH_MODIFIER Lnet/minecraft/unmapped/C_hdbqsqsm;
 	FIELD f_gszqcwcl disconnected Z
 	FIELD f_hdfccasf lastActionTime J
 	FIELD f_hnshkvqc syncedSaturationIsZero Z
 	FIELD f_hnwsfwxm enteredNetherPos Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_hrcpmxqf syncedHealth F
+	FIELD f_hrcxblhc spawnPoint Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;
 	FIELD f_htmanizc advancementTracker Lnet/minecraft/unmapped/C_hyeqtgvx;
+	FIELD f_hyufqyrv movement Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_jmjzglen LOGGER Lorg/slf4j/Logger;
 	FIELD f_jqhahngd sculkShriekerWarningManager Lnet/minecraft/unmapped/C_klpebnoe;
 	FIELD f_juibkpvw language Ljava/lang/String;
 	FIELD f_kanetbai inTeleportationState Z
+	FIELD f_kdrqbovn BLOCK_INTERACTION_DISTANCE_VERIFICATION_BUFFER D
 	FIELD f_kgzajahg watchedSection Lnet/minecraft/unmapped/C_zubvmeye;
 		COMMENT A chunk section position indicating where the player's client is currently
 		COMMENT watching chunks from. Used referentially for the game to update the chunks
@@ -31,29 +41,37 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		COMMENT
 		COMMENT @see #getWatchedSection()
 		COMMENT @see #setWatchedSection(ChunkSectionPos)
+	FIELD f_kojhzwsx ENTITY_INTERACTION_DISTANCE_VERIFICATION_BUFFER D
 	FIELD f_ldmwjyxg requestedViewDistance I
 	FIELD f_lqlcdtmt commandOutput Lnet/minecraft/unmapped/C_ngpvhugm;
 	FIELD f_mfajmfxx spawnExtraParticlesOnFall Z
 	FIELD f_myvtmhev raidOmenPos Lnet/minecraft/unmapped/C_hynzadkk;
+	FIELD f_nntqutkk object Ljava/lang/Object;
+	FIELD f_olaqmrvs HORIZONTAL_FORGIVENSS_RANGE I
 	FIELD f_onahzxmm interactionManager Lnet/minecraft/unmapped/C_egnasquq;
 	FIELD f_oxxbizze syncedExperience I
 	FIELD f_qcackqxh enteredLavaOnVehiclePos Lnet/minecraft/unmapped/C_vgpupfxx;
+	FIELD f_qehhxsfo DEFAULT_SPAWN_EXTRA_PARTICLES_ON_FALL Z
 	FIELD f_qrxvbodj clientChatVisibility Lnet/minecraft/unmapped/C_wafwmsvb;
+	FIELD f_rxgyrgij renderArea Lnet/minecraft/unmapped/C_niowvjqq;
 	FIELD f_selmotls lastArmorScore I
 	FIELD f_slrxmizd server Lnet/minecraft/server/MinecraftServer;
 	FIELD f_spwankpb recipeBook Lnet/minecraft/unmapped/C_ypnziuiu;
 	FIELD f_sqvynxvm lastFoodScore I
 	FIELD f_tlemovvv clientChatColorsEnabled Z
 	FIELD f_tmepkkvu textStream Lnet/minecraft/unmapped/C_ibcyuwyk;
+	FIELD f_tqyakkbm SET_SPAWN Lnet/minecraft/unmapped/C_rdaqiwdt;
 	FIELD f_uitrvqbw chatSession Lnet/minecraft/unmapped/C_sdodhjzp;
 	FIELD f_vwyacvpk allowsListing Z
 	FIELD f_wtszcwij CREATIVE_BLOCK_INTERACTION_RANGE_MODIFIER Lnet/minecraft/unmapped/C_hdbqsqsm;
 	FIELD f_wxiufufe screenHandlerListener Lnet/minecraft/unmapped/C_juruncbf;
+	FIELD f_ybeojqyy DIMENSION_KEY Ljava/lang/String;
 	FIELD f_ygoxduda seenCredits Z
 	FIELD f_ykxzgnke particlesMode Lnet/minecraft/unmapped/C_ohzhuhsr;
 	FIELD f_ynglkbif filterText Z
 	FIELD f_zkfgljmz lastHealthScore F
 	FIELD f_zwmomqsu cameraEntity Lnet/minecraft/unmapped/C_astfners;
+	METHOD m_afrhtnjp copySpawnPoint (Lnet/minecraft/unmapped/C_mxrobsgg;)V
 	METHOD m_akgkagnq forgiveMobAnger ()V
 	METHOD m_ausyrzvm setWatchedSection (Lnet/minecraft/unmapped/C_zubvmeye;)V
 		COMMENT Sets the chunk section position the player's client is currently watching
@@ -63,6 +81,8 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		COMMENT @see #getWatchedSection()
 		ARG 1 section
 			COMMENT the updated section position
+	METHOD m_auynogad updateMovementStats (DDD)V
+	METHOD m_awcskget updateModifiers ()V
 	METHOD m_ayjhwfdn getAdvancementTracker ()Lnet/minecraft/unmapped/C_hyeqtgvx;
 	METHOD m_bapgikfh getServerGameMode (Lnet/minecraft/unmapped/C_lghcpyvl;)Lnet/minecraft/unmapped/C_lghcpyvl;
 		COMMENT Returns the server game mode the player should be set to, namely the forced game mode.
@@ -72,7 +92,8 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		COMMENT
 		COMMENT @see MinecraftServer#getForcedGameMode
 		ARG 1 backupGameMode
-	METHOD m_bcanpraa writeGameModeNbt (Lnet/minecraft/unmapped/C_kespdwpv;)V
+	METHOD m_bbwiwvtt writeVehicle (Lnet/minecraft/unmapped/C_kespdwpv;)V
+	METHOD m_bcanpraa writeGameMode (Lnet/minecraft/unmapped/C_kespdwpv;)V
 	METHOD m_bmcjwhux getCameraEntity ()Lnet/minecraft/unmapped/C_astfners;
 	METHOD m_bshhomos setCameraEntity (Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 entity
@@ -80,24 +101,45 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		ARG 1 anchorPoint
 		ARG 2 targetEntity
 		ARG 3 targetAnchor
-	METHOD m_cebghmrm updateScoreboardScore (Lnet/minecraft/unmapped/C_hswmfudr;Lnet/minecraft/unmapped/C_hswmfudr;[Lnet/minecraft/unmapped/C_adsgsrpw;)V
-		ARG 3 criterions
+	METHOD m_bvxwqsur getSpawnPoint ()Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;
+	METHOD m_cebghmrm updateKillScores (Lnet/minecraft/unmapped/C_hswmfudr;Lnet/minecraft/unmapped/C_hswmfudr;[Lnet/minecraft/unmapped/C_adsgsrpw;)V
+		ARG 2 subject
+		ARG 3 criteria
 	METHOD m_cicbiveh markHealthDirty ()V
+	METHOD m_cjdhmaqg canReceiveWaypoints ()Z
 	METHOD m_cqxrhbhc addEnderPearlTicket (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_ynrszrtu;)J
 		COMMENT Adds an ender pearl chunk ticket to the ticket manager.
 		ARG 0 world
 		ARG 1 pos
 	METHOD m_ctvsftwy getTextStream ()Lnet/minecraft/unmapped/C_ibcyuwyk;
+	METHOD m_cztqeded isCollidingIn (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_hbcjzgoe;)Z
+		ARG 2 box
 	METHOD m_dmwhgwkv sendSystemMessage (Lnet/minecraft/unmapped/C_rdaqiwdt;)V
+	METHOD m_dpqdahtb setMovement (Lnet/minecraft/unmapped/C_vgpupfxx;)V
+		ARG 1 movement
 	METHOD m_dzllwyda copyFrom (Lnet/minecraft/unmapped/C_mxrobsgg;Z)V
 		ARG 1 oldPlayer
 		ARG 2 alive
 	METHOD m_eenhzbrz sendServerMetadata (Lnet/minecraft/unmapped/C_bwttende;)V
 		ARG 1 metadata
 	METHOD m_ehhcdgvv setRaidOmenPos (Lnet/minecraft/unmapped/C_hynzadkk;)V
+	METHOD m_epmlkdds setLastClientInput (Lnet/minecraft/unmapped/C_lkjruazd;)V
+		ARG 1 input
 	METHOD m_esetupfd playerTick ()V
+	METHOD m_etsgudiw readVehicle (Lnet/minecraft/unmapped/C_djkzhngg;)V
+	METHOD m_evedvxjw (Lnet/minecraft/unmapped/C_xhhleach;)Ljava/util/stream/Stream;
+		ARG 1 recipe
+	METHOD m_evmlwyoy (Lnet/minecraft/unmapped/C_djdmkjpx;)V
+		ARG 1 unit
+	METHOD m_ewivonmy updateVehicleMovementStats (DDD)V
 	METHOD m_fawxnykw setGameMode (Lnet/minecraft/unmapped/C_djkzhngg;)V
+	METHOD m_fjhuwazb (Lnet/minecraft/unmapped/C_xhhleach;)Z
+		ARG 1 recipe
+	METHOD m_fkkjbhxa (Lnet/minecraft/unmapped/C_ypnziuiu$C_vqmaadjr;)V
+		ARG 1 book
 	METHOD m_fwokftay allowsListing ()Z
+	METHOD m_gwuckbqk (ILnet/minecraft/unmapped/C_qwlnyyss;)V
+		ARG 1 scoreAccess
 	METHOD m_gylcrlba loadEnderPearl (Lnet/minecraft/unmapped/C_xmtgsyuv;)J
 		COMMENT Loads the ender pearl's current chunk and adds it to the player's set of ender pearls.
 		ARG 1 enderPearl
@@ -112,6 +154,7 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		COMMENT
 		COMMENT @see #watchedSection
 		COMMENT @see #setWatchedSection(ChunkSectionPos)
+	METHOD m_hkmzxron readEnderPearls (Lnet/minecraft/unmapped/C_djkzhngg;)V
 	METHOD m_hkspsypv getPlayerListName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_hmjyuwow getClientChatVisibility ()Lnet/minecraft/unmapped/C_wafwmsvb;
 	METHOD m_hoiwaxpe onTeleportationDone ()V
@@ -123,15 +166,26 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		ARG 1 overlay
 	METHOD m_itdwcvgj worldChanged (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
 		ARG 1 origin
+	METHOD m_izruuyul onWon ()V
 	METHOD m_jdnfjiqa createCommandSource ()Lnet/minecraft/unmapped/C_pennblrk;
+	METHOD m_jhyjhfyn (Lnet/minecraft/unmapped/C_sxzqocrm;I)V
+		ARG 2 slot
 	METHOD m_jjdnefmi getLastClientMovementIntent ()Lnet/minecraft/unmapped/C_vgpupfxx;
+	METHOD m_jpjsvuqt respawn (ZLnet/minecraft/unmapped/C_sqhjwpkh$C_saosxlyx;)Lnet/minecraft/unmapped/C_sqhjwpkh;
+		ARG 2 transition
 	METHOD m_juidebgy tickFallStartPos ()V
+	METHOD m_jzwrbooz (ILnet/minecraft/unmapped/C_qwlnyyss;)V
+		ARG 1 score
+	METHOD m_kahhlttm readEnderPearl (Lnet/minecraft/unmapped/C_djkzhngg;)V
 	METHOD m_kbplwriu calculateSpawnOffsetMultiplier (I)I
 		ARG 1 horizontalSpawnArea
+	METHOD m_kqhsyghp getLastClientInput ()Lnet/minecraft/unmapped/C_lkjruazd;
 	METHOD m_krzsingq setExperiencePoints (I)V
 		ARG 1 points
 	METHOD m_lmerldlu isDisconnected ()Z
-	METHOD m_lrtlnong writeEnderPearlsNbt (Lnet/minecraft/unmapped/C_kespdwpv;)V
+	METHOD m_lrtlnong writeEnderPearls (Lnet/minecraft/unmapped/C_kespdwpv;)V
+	METHOD m_lymzipkb (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_mxrobsgg$C_edsacgfr;
+		ARG 1 wakeUpPos
 	METHOD m_mionnykm setServerWorld (Lnet/minecraft/unmapped/C_bdwnwhiu;)V
 	METHOD m_mmpafyms sendSystemMessage (Lnet/minecraft/unmapped/C_rdaqiwdt;Z)V
 		ARG 1 message
@@ -144,14 +198,29 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	METHOD m_oacdnmbp setClientSettings (Lnet/minecraft/unmapped/C_elrtgpva;)V
 		ARG 1 info
 	METHOD m_obnaqvtb getStatHandler ()Lnet/minecraft/unmapped/C_cakpthuz;
+	METHOD m_pbwwtvam (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Consumer;)V
+		ARG 1 recipe
+		ARG 2 adder
+	METHOD m_pontikuw (Lnet/minecraft/unmapped/C_hlqarogo;)Z
+		ARG 1 hostile
 	METHOD m_ppkclwkr isBedTooFarAway (Lnet/minecraft/unmapped/C_hynzadkk;)Z
 		ARG 1 pos
 	METHOD m_pyfbhche setSpawnPoint (Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;Z)V
-		ARG 2 spawnPointSet
+		ARG 1 point
+		ARG 2 sendMessageOnChange
 	METHOD m_qaobxrty incrementScreenHandlerSyncId ()V
+	METHOD m_qebwrwfm wasStationary (DDD)Z
+		ARG 0 dx
+		ARG 2 dy
+		ARG 4 dz
+	METHOD m_qlrqxklu (Lnet/minecraft/unmapped/C_rdaqiwdt;Lnet/minecraft/unmapped/C_cpwnhism;)Lnet/minecraft/unmapped/C_cpwnhism;
+		ARG 1 style
+	METHOD m_qrafccti setRenderArea (Lnet/minecraft/unmapped/C_niowvjqq;)V
+		ARG 1 area
 	METHOD m_qtkqrrlq areClientChatColorsEnabled ()Z
 	METHOD m_rfxbxqjm onSpawn (Lnet/minecraft/unmapped/C_mkrkudpa;)V
 		ARG 1 screenHandler
+	METHOD m_rmsklpll trySendMapMarkerUpdates (Lnet/minecraft/unmapped/C_sddaxwyk;)V
 	METHOD m_rtkbvrqw createClientInfo ()Lnet/minecraft/unmapped/C_elrtgpva;
 	METHOD m_rxryenyl isBedTooFarAway (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_xpuuihxf;)Z
 		ARG 1 pos
@@ -161,11 +230,17 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	METHOD m_taedfzyx shouldFilterMessagesSentTo (Lnet/minecraft/unmapped/C_mxrobsgg;)Z
 		ARG 1 player
 	METHOD m_tbpwsjiy getChatSession ()Lnet/minecraft/unmapped/C_sdodhjzp;
+	METHOD m_tcgfsciw findSpawnDest (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;Z)Ljava/util/Optional;
+		ARG 1 point
+		ARG 2 died
+	METHOD m_tkqcbqjg (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_vgpupfxx;)Lnet/minecraft/unmapped/C_mxrobsgg$C_edsacgfr;
+		ARG 1 dest
 	METHOD m_tsbczhxe isInTeleportationState ()Z
 	METHOD m_ttfujhny sendChatMessage (Lnet/minecraft/unmapped/C_glgnifxw;ZLnet/minecraft/unmapped/C_hasnsypd$C_iocvgdxe;)V
 		ARG 1 message
 		ARG 2 filterMaskEnabled
 		ARG 3 parameters
+	METHOD m_ucwfkaov getRenderArea ()Lnet/minecraft/unmapped/C_niowvjqq;
 	METHOD m_ujyxsuep onDisconnect ()V
 	METHOD m_ulcuzxzs updateScores (Lnet/minecraft/unmapped/C_adsgsrpw;I)V
 		ARG 1 criterion
@@ -173,6 +248,7 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	METHOD m_uxjbfcwl getRaidOmenPos ()Lnet/minecraft/unmapped/C_hynzadkk;
 	METHOD m_vrtyhqjd setChatSession (Lnet/minecraft/unmapped/C_sdodhjzp;)V
 		ARG 1 chatSession
+	METHOD m_waafemhd getPlayerListOrder ()I
 	METHOD m_wgyjvvco resetRaidOmenPos ()V
 	METHOD m_wnaewudz isPvpEnabled ()Z
 	METHOD m_wrxsxpkn setExperienceLevel (I)V
@@ -181,6 +257,7 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	METHOD m_wujubsor createCommonPlayerSpawnInfo (Lnet/minecraft/unmapped/C_bdwnwhiu;)Lnet/minecraft/unmapped/C_zsjubkei;
 	METHOD m_xkkpozuc changeGameMode (Lnet/minecraft/unmapped/C_lghcpyvl;)Z
 		ARG 1 gameMode
+	METHOD m_xvawkxcc getRequestedViewDistance ()I
 	METHOD m_xxjfeuye getCommandOutput ()Lnet/minecraft/unmapped/C_ngpvhugm;
 	METHOD m_ygkpsrag getRecipeBook ()Lnet/minecraft/unmapped/C_ypnziuiu;
 	METHOD m_yhuimfko gameModeFromNbt (Lnet/minecraft/unmapped/C_djkzhngg;Ljava/lang/String;)Lnet/minecraft/unmapped/C_lghcpyvl;
@@ -189,3 +266,26 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 		ARG 1 enderPearl
 	METHOD m_zyhxcats removeEnderPearl (Lnet/minecraft/unmapped/C_xmtgsyuv;)V
 		ARG 1 enderPearl
+	CLASS C_edsacgfr SpawnDestination
+		METHOD m_danijxoo getFacingPointYaw (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hynzadkk;)F
+			ARG 0 dest
+			ARG 1 spawnPoint
+		METHOD m_ebzmgewk of (Lnet/minecraft/unmapped/C_vgpupfxx;Lnet/minecraft/unmapped/C_hynzadkk;)Lnet/minecraft/unmapped/C_mxrobsgg$C_edsacgfr;
+			ARG 0 dest
+			ARG 1 spawnPoint
+	CLASS C_ldooqqdw
+		FIELD f_tekolpea componentHashCache Lcom/google/common/cache/LoadingCache;
+		METHOD m_lgvaefas updatePropertyImpl (Lnet/minecraft/unmapped/C_mkrkudpa;II)V
+			ARG 1 handler
+			ARG 2 id
+			ARG 3 value
+		CLASS C_admmwvzo
+			METHOD load (Ljava/lang/Object;)Ljava/lang/Object;
+				ARG 1 component
+			METHOD m_flxkjqie (Lnet/minecraft/unmapped/C_qkjwbfhx;Ljava/lang/String;)Ljava/lang/IllegalArgumentException;
+				ARG 1 error
+	CLASS C_rbotfxsd SpawnPoint
+		METHOD m_houlqbnz getDimension (Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;)Lnet/minecraft/unmapped/C_xhhleach;
+			ARG 0 point
+		METHOD m_safzimyb locationMatches (Lnet/minecraft/unmapped/C_mxrobsgg$C_rbotfxsd;)Z
+			ARG 1 point

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/unmapped/C_mxrobsgg net/minecraft/server/network/ServerPlaye
 	FIELD f_ancsmfuf lastExperienceScore I
 	FIELD f_awxwtkbc lastLevelScore I
 	FIELD f_aypwdfqm FLY_STAT_RECORDING_SPEED I
-	FIELD f_bisatnfo VERTICAL_FOGIVENESS_RANGE I
+	FIELD f_bisatnfo VERTICAL_FORGIVENESS_RANGE I
 	FIELD f_bpaumbdz lastClientInput Lnet/minecraft/unmapped/C_lkjruazd;
 	FIELD f_capnwlvs levitationStartPos Lnet/minecraft/unmapped/C_vgpupfxx;
 	FIELD f_cfahbfba fallStartPos Lnet/minecraft/unmapped/C_vgpupfxx;

--- a/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
+++ b/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
@@ -1,13 +1,50 @@
 CLASS net/minecraft/unmapped/C_ypnziuiu net/minecraft/server/network/ServerRecipeBook
 	FIELD f_adesvwxa RECIPE_BOOK_KEY Ljava/lang/String;
+	FIELD f_dryeywza displayResolver Lnet/minecraft/unmapped/C_ypnziuiu$C_fmmllvga;
 	FIELD f_lfrrjxay LOGGER Lorg/slf4j/Logger;
+	FIELD f_mbrbvedd known Ljava/util/Set;
+	FIELD f_vwhltalv toBeDisplayed Ljava/util/Set;
+	METHOD m_cpttvoky addToBeDisplayed (Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 recipe
+	METHOD m_dktbtjvn isKnown (Lnet/minecraft/unmapped/C_xhhleach;)Z
+		ARG 1 recipe
+	METHOD m_ggtxkbdm copyFrom (Lnet/minecraft/unmapped/C_ypnziuiu$C_vqmaadjr;Ljava/util/function/Predicate;)V
+		ARG 1 packed
 	METHOD m_kjatblgn handleList (Ljava/util/List;Ljava/util/function/Consumer;Ljava/util/function/Predicate;)V
+		ARG 1 recipes
 		ARG 2 handler
+		ARG 3 recognizer
+	METHOD m_qauvkvfy (Ljava/util/List;Lnet/minecraft/unmapped/C_dsptsoym;)V
+		ARG 1 entry
 	METHOD m_qlxmdpvi lockRecipes (Ljava/util/Collection;Lnet/minecraft/unmapped/C_mxrobsgg;)I
 		ARG 1 recipes
 		ARG 2 player
 	METHOD m_rxududzw sendInitRecipesPacket (Lnet/minecraft/unmapped/C_mxrobsgg;)V
 		ARG 1 player
+	METHOD m_sjsfldor (Ljava/util/List;Lnet/minecraft/unmapped/C_dscbrwbj;Lnet/minecraft/unmapped/C_dsptsoym;)V
+		ARG 2 display
+	METHOD m_smzesdcn pack ()Lnet/minecraft/unmapped/C_ypnziuiu$C_vqmaadjr;
+	METHOD m_tdfwwcsh removeKnown (Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 recipe
+	METHOD m_tumfxcdw addKnown (Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 recipe
+	METHOD m_uioqhvae (Ljava/util/List;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_dsptsoym;)V
+		ARG 3 display
+	METHOD m_ullfvwbf removeTobeDisplayed (Lnet/minecraft/unmapped/C_xhhleach;)V
+		ARG 1 recipe
 	METHOD m_vtiywdsn unlockRecipes (Ljava/util/Collection;Lnet/minecraft/unmapped/C_mxrobsgg;)I
 		ARG 1 recipes
 		ARG 2 player
+	METHOD m_wxhsclrn copyFrom (Lnet/minecraft/unmapped/C_ypnziuiu;)V
+		ARG 1 other
+	METHOD m_zcihqsdz unpack (Lnet/minecraft/unmapped/C_ypnziuiu$C_vqmaadjr;)V
+		ARG 1 packed
+	CLASS C_fmmllvga DisplayResolver
+		METHOD displaysForRecipe resolve (Lnet/minecraft/unmapped/C_xhhleach;Ljava/util/function/Consumer;)V
+			ARG 1 recipe
+			ARG 2 adder
+	CLASS C_vqmaadjr Packed
+		FIELD f_hwajfuro toBeDisplayed Ljava/util/List;
+		FIELD f_nzkxhmpx options Lnet/minecraft/unmapped/C_krpwsfph;
+		METHOD m_buzxyrdj toBeDisplayed ()Ljava/util/List;
+		METHOD m_nsiayins options ()Lnet/minecraft/unmapped/C_krpwsfph;

--- a/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
+++ b/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/unmapped/C_ypnziuiu net/minecraft/server/network/ServerRecip
 		ARG 1 recipe
 	METHOD m_uioqhvae (Ljava/util/List;Lnet/minecraft/unmapped/C_xhhleach;Lnet/minecraft/unmapped/C_dsptsoym;)V
 		ARG 3 display
-	METHOD m_ullfvwbf removeTobeDisplayed (Lnet/minecraft/unmapped/C_xhhleach;)V
+	METHOD m_ullfvwbf removeToBeDisplayed (Lnet/minecraft/unmapped/C_xhhleach;)V
 		ARG 1 recipe
 	METHOD m_vtiywdsn unlockRecipes (Ljava/util/Collection;Lnet/minecraft/unmapped/C_mxrobsgg;)I
 		ARG 1 recipes

--- a/mappings/net/minecraft/server/world/ChunkArea.mapping
+++ b/mappings/net/minecraft/server/world/ChunkArea.mapping
@@ -1,0 +1,35 @@
+CLASS net/minecraft/unmapped/C_niowvjqq net/minecraft/server/world/ChunkArea
+	FIELD f_twzfyezx EMPTY Lnet/minecraft/unmapped/C_niowvjqq;
+	METHOD m_armurndt forEachPos (Ljava/util/function/Consumer;)V
+		ARG 1 action
+	METHOD m_hrsbrhda contains (IIZ)Z
+		ARG 1 x
+		ARG 2 z
+		ARG 3 includeEdge
+	METHOD m_kkwrudja areWithinDistance (IIIIIZ)Z
+		ARG 0 x1
+		ARG 1 z1
+		ARG 2 distance
+		ARG 3 x2
+		ARG 4 z2
+		ARG 5 includeEdge
+	METHOD m_ntfncqib contains (Lnet/minecraft/unmapped/C_ynrszrtu;)Z
+		ARG 1 pos
+	METHOD m_ocoubznz areWithinDistance (IIIII)Z
+	METHOD m_rnwtgtmv contains (II)Z
+	METHOD m_vrolinbl forEachDifference (Lnet/minecraft/unmapped/C_niowvjqq;Lnet/minecraft/unmapped/C_niowvjqq;Ljava/util/function/Consumer;Ljava/util/function/Consumer;)V
+		ARG 0 area1
+		ARG 1 area2
+		ARG 2 area2Action
+		ARG 3 area1Action
+	METHOD m_xlbjeypp containsWithoutEdge (II)Z
+		ARG 1 x
+		ARG 2 y
+	METHOD m_xwlrhmyh createViewable (Lnet/minecraft/unmapped/C_ynrszrtu;I)Lnet/minecraft/unmapped/C_niowvjqq;
+	CLASS C_nufsjoym Viewable
+		METHOD m_cplfctbc getMaxX ()I
+		METHOD m_kwoabbma getMinZ ()I
+		METHOD m_mfvrizrl getMaxZ ()I
+		METHOD m_ozkpljuq intersects (Lnet/minecraft/unmapped/C_niowvjqq$C_nufsjoym;)Z
+			ARG 1 other
+		METHOD m_vzxzdyyy getMinX ()I

--- a/mappings/net/minecraft/util/ClickType.mapping
+++ b/mappings/net/minecraft/util/ClickType.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/unmapped/C_qcuteihm net/minecraft/util/ClickType

--- a/mappings/net/minecraft/util/Cooldown.mapping
+++ b/mappings/net/minecraft/util/Cooldown.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/unmapped/C_bjnewvkq net/minecraft/util/Cooldown
+	FIELD f_lgbguewr increment I
+	FIELD f_pfoptgcd limit I
+	FIELD f_wglfskmv value I
+	METHOD m_ducfmwhw increment ()V
+	METHOD m_ghphvutq tick ()V
+	METHOD m_spctdrez allows ()Z

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -161,7 +161,7 @@ CLASS net/minecraft/unmapped/C_hynzadkk net/minecraft/util/math/BlockPos
 		ARG 3 rangeZ
 			COMMENT the maximum z difference from the center
 	METHOD m_raunemtc fromPosition (Lnet/minecraft/unmapped/C_ogbhoqwb;)Lnet/minecraft/unmapped/C_hynzadkk;
-		ARG 0 position
+		ARG 0 pos
 	METHOD m_rqxosvyc mutableCopy ()Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;
 		COMMENT Returns a mutable copy of this block position.
 		COMMENT

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -53,3 +53,5 @@ CLASS net/minecraft/unmapped/C_peaveboq net/minecraft/world/BlockView
 	METHOD m_zqixworh getStatesInBox (Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/util/stream/Stream;
 		ARG 1 box
 	CLASS C_pmqljjcz CollisionVisitor
+		METHOD visit (Lnet/minecraft/unmapped/C_hynzadkk;I)Z
+			ARG 2 iteration

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -3,15 +3,23 @@ CLASS net/minecraft/unmapped/C_vxzrjtdu net/minecraft/world/CollisionView
 		ARG 1 entity
 	METHOD m_buskdhke getWorldBorder ()Lnet/minecraft/unmapped/C_pneibfez;
 	METHOD m_byqkqxkz getBlockCollisions (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/lang/Iterable;
-		ARG 1 entity
 		ARG 2 box
 	METHOD m_cdodgqhq getChunkAsView (II)Lnet/minecraft/unmapped/C_peaveboq;
+		ARG 1 sectionX
+		ARG 2 sectionY
+	METHOD m_duoyfddy getCollisions (Lnet/minecraft/unmapped/C_pbfjvesm;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/lang/Iterable;
+		ARG 1 context
+		ARG 2 box
+	METHOD m_iomerewe isSpaceEmpty (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;Z)Z
+		ARG 2 box
+		ARG 3 includeFluids
 	METHOD m_istsheae isSpaceEmpty (Lnet/minecraft/unmapped/C_hbcjzgoe;)Z
 		ARG 1 box
 	METHOD m_kamrttpa getBorderCollision (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Lnet/minecraft/unmapped/C_zscvhwbd;
 		ARG 1 entity
 		ARG 2 box
 	METHOD m_lrisnbsp getEntityCollisions (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/util/List;
+		ARG 2 box
 	METHOD m_lvvgkmew isBlockSpaceEmpty (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Z
 		ARG 1 entity
 		ARG 2 box
@@ -22,6 +30,8 @@ CLASS net/minecraft/unmapped/C_vxzrjtdu net/minecraft/world/CollisionView
 		ARG 1 state
 		ARG 2 pos
 		ARG 3 context
+	METHOD m_oizpmzlf getBlockAndFluidCollisions (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/lang/Iterable;
+		ARG 2 box
 	METHOD m_qrigjdbl findClosestCollision (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_zscvhwbd;Lnet/minecraft/unmapped/C_vgpupfxx;DDD)Ljava/util/Optional;
 		ARG 1 entity
 		ARG 2 shape
@@ -38,8 +48,12 @@ CLASS net/minecraft/unmapped/C_vxzrjtdu net/minecraft/world/CollisionView
 	METHOD m_tdevuobh collidesWithSuffocatingBlock (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Z
 		ARG 1 entity
 		ARG 2 box
+	METHOD m_wrattngl (Lnet/minecraft/unmapped/C_hynzadkk$C_egqitdjk;Lnet/minecraft/unmapped/C_zscvhwbd;)Lnet/minecraft/unmapped/C_zscvhwbd;
+		ARG 1 shape
 	METHOD m_ykcfhdid doesNotIntersectEntities (Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 entity
 	METHOD m_ypwqnrxo getCollisions (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/lang/Iterable;
 		ARG 1 entity
+		ARG 2 box
+	METHOD m_zegcddhy (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;Lnet/minecraft/unmapped/C_vgpupfxx;)Ljava/lang/Iterable;
 		ARG 2 box

--- a/mappings/net/minecraft/world/GameMode.mapping
+++ b/mappings/net/minecraft/world/GameMode.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/unmapped/C_lghcpyvl net/minecraft/world/GameMode
 	FIELD f_jcxdddpi name Ljava/lang/String;
 	FIELD f_lewmbrwu NULL_GAME_MODE_ID I
 	FIELD f_nzmwalvo CODEC Lnet/minecraft/unmapped/C_lgkqzafw$C_nxwenkbc;
+	FIELD f_ymfhbgct LEGACY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD f_zotouesg simpleTranslatableName Lnet/minecraft/unmapped/C_rdaqiwdt;
 	METHOD m_hlwoepvs isSurvivalLike ()Z
 	METHOD m_lkyfhjye getSimpleTranslatableName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
@@ -22,8 +23,12 @@ CLASS net/minecraft/unmapped/C_lghcpyvl net/minecraft/world/GameMode
 	METHOD m_vjmiypmi setAbilities (Lnet/minecraft/unmapped/C_tlquukty;)V
 		ARG 1 abilities
 	METHOD m_wechklig getId (Lnet/minecraft/unmapped/C_lghcpyvl;)I
-		ARG 0 gameMode
+		ARG 0 mode
 	METHOD m_wjcilliq getTranslatableName ()Lnet/minecraft/unmapped/C_rdaqiwdt;
+	METHOD m_xhujbjzr isId (I)Z
+		ARG 0 id
+	METHOD m_yripyqdb (ILnet/minecraft/unmapped/C_lghcpyvl;)Z
+		ARG 1 mode
 	METHOD m_zjoqvotw byName (Ljava/lang/String;Lnet/minecraft/unmapped/C_lghcpyvl;)Lnet/minecraft/unmapped/C_lghcpyvl;
 		ARG 0 name
 		ARG 1 defaultMode

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -152,6 +152,16 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 	METHOD m_qsuwatgh updateComparators (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_mmxmpdoq;)V
 		ARG 1 pos
 		ARG 2 block
+	METHOD m_qyuqghcs addParticle (Lnet/minecraft/unmapped/C_nqucohct;ZZDDDDDD)V
+		ARG 1 effect
+		ARG 2 alwaysSpawn
+		ARG 3 important
+		ARG 4 x
+		ARG 6 y
+		ARG 8 z
+		ARG 10 velocityX
+		ARG 12 velocityY
+		ARG 14 velocityZ
 	METHOD m_qziyykad getDamageSources ()Lnet/minecraft/unmapped/C_lddxcbik;
 	METHOD m_rojxhffu addImportantParticle (Lnet/minecraft/unmapped/C_nqucohct;ZDDDDDD)V
 		ARG 1 parameters
@@ -174,9 +184,13 @@ CLASS net/minecraft/unmapped/C_cdctfzbn net/minecraft/world/World
 		ARG 4 volume
 		ARG 5 pitch
 		ARG 6 delay
+	METHOD m_szownwzs getPushableEntities (Lnet/minecraft/unmapped/C_astfners;Lnet/minecraft/unmapped/C_hbcjzgoe;)Ljava/util/List;
+		ARG 2 box
 	METHOD m_thuraolg isTopSolid (Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_astfners;)Z
 		ARG 1 pos
 		ARG 2 entity
+	METHOD m_tieezrrn getEntity (I)Lnet/minecraft/unmapped/C_astfners;
+		ARG 1 id
 	METHOD m_ufcotfaw getTickManager ()Lnet/minecraft/unmapped/C_phmnykiz;
 	METHOD m_uhrnzysl tickEntity (Ljava/util/function/Consumer;Lnet/minecraft/unmapped/C_astfners;)V
 		ARG 1 tickConsumer

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -1,6 +1,13 @@
 CLASS net/minecraft/unmapped/C_vdvbsyle net/minecraft/world/WorldAccess
 	METHOD m_alhpmuno getDifficulty ()Lnet/minecraft/unmapped/C_mpbjgxic;
 	METHOD m_bmupbnfh addParticle (Lnet/minecraft/unmapped/C_nqucohct;DDDDDD)V
+		ARG 1 effect
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 velocityX
+		ARG 10 velocityY
+		ARG 12 velocityZ
 	METHOD m_eudwfuph getProperties ()Lnet/minecraft/unmapped/C_vsicwqkk;
 	METHOD m_fnlxbhsq getServer ()Lnet/minecraft/server/MinecraftServer;
 	METHOD m_fpfswynf emitGameEvent (Lnet/minecraft/unmapped/C_cjzoxshv;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cgkchrmc$C_cjhidzon;)V

--- a/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
@@ -73,6 +73,7 @@ CLASS net/minecraft/unmapped/C_uegwgivt net/minecraft/world/poi/PointOfInterestS
 		ARG 2 pos
 	METHOD m_tjmtajvw getPosition (Ljava/util/function/Predicate;Ljava/util/function/BiPredicate;Lnet/minecraft/unmapped/C_hynzadkk;I)Ljava/util/Optional;
 		ARG 1 typePredicate
+		ARG 2 posPredicate
 		ARG 3 pos
 		ARG 4 radius
 	METHOD m_tnvijmjz (Ljava/util/function/BiConsumer;Lnet/minecraft/unmapped/C_hynzadkk;Lnet/minecraft/unmapped/C_cjzoxshv;)V

--- a/mappings/net/minecraft/world/waypoint/ServerWaypointManager.mapping
+++ b/mappings/net/minecraft/world/waypoint/ServerWaypointManager.mapping
@@ -1,2 +1,22 @@
 CLASS net/minecraft/unmapped/C_wwpuunvz net/minecraft/world/waypoint/ServerWaypointManager
+	FIELD f_ctwhhzbx connections Lcom/google/common/collect/Table;
 	FIELD f_hmvkoahr waypoints Ljava/util/Set;
+	FIELD f_upxtkmhf players Ljava/util/Set;
+	METHOD m_bkfetlpc updateConnection (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_jtpeboen;Lnet/minecraft/unmapped/C_jtpeboen$C_erspwfzf;)V
+		ARG 3 connection
+	METHOD m_efafoycf (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_jtpeboen$C_erspwfzf;)V
+		ARG 1 connection
+	METHOD m_gdfpmeva getWaypoints ()Ljava/util/Set;
+	METHOD m_guavkwgh addPlayer (Lnet/minecraft/unmapped/C_mxrobsgg;)V
+	METHOD m_lbygjrpd connect (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_jtpeboen;)V
+	METHOD m_roxqejan (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_jtpeboen;Lnet/minecraft/unmapped/C_jtpeboen$C_erspwfzf;)V
+		ARG 3 connection
+	METHOD m_sjnpgoag hasLocatorBar (Lnet/minecraft/unmapped/C_mxrobsgg;)Z
+	METHOD m_tomphtip disconnect (Lnet/minecraft/unmapped/C_mxrobsgg;)V
+	METHOD m_vpwqphhq (Lnet/minecraft/unmapped/C_mxrobsgg;Lnet/minecraft/unmapped/C_jtpeboen;Lnet/minecraft/unmapped/C_jtpeboen$C_erspwfzf;)V
+		ARG 3 newConnection
+	METHOD m_xcdzegbv updatePlayers (Lnet/minecraft/unmapped/C_jtpeboen;)V
+	METHOD m_xlaiuccw clearConnections ()V
+	METHOD m_zhjombor (Lnet/minecraft/unmapped/C_jtpeboen$C_erspwfzf;)Z
+		ARG 0 connection
+	METHOD m_zmgvzblb update (Lnet/minecraft/unmapped/C_mxrobsgg;)V

--- a/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
+++ b/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
@@ -2,9 +2,23 @@ CLASS net/minecraft/unmapped/C_jtpeboen net/minecraft/world/waypoint/WaypointSou
 	FIELD f_rjzqvvix FAR_DISTANCE I
 	METHOD m_clbppmew getWaypointIcon ()Lnet/minecraft/unmapped/C_xucdsrtl$C_ozyhcqwy;
 	METHOD m_dymsuvlh isFar (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_mxrobsgg;)Z
+	METHOD m_fekxzhwm tryConnectWaypoint (Lnet/minecraft/unmapped/C_mxrobsgg;)Ljava/util/Optional;
 	METHOD m_hbnjzlmw hasWaypoint ()Z
 	METHOD m_jqjxljme canReceive (Lnet/minecraft/unmapped/C_usxaxydn;Lnet/minecraft/unmapped/C_mxrobsgg;)Z
-	METHOD m_prxggxkd (Lnet/minecraft/unmapped/C_ynrszrtu;Lnet/minecraft/unmapped/C_mxrobsgg;)Z
+	METHOD m_prxggxkd isInRange (Lnet/minecraft/unmapped/C_ynrszrtu;Lnet/minecraft/unmapped/C_mxrobsgg;)Z
 		ARG 0 pos
-	CLASS C_vfonhpab
+	CLASS C_erspwfzf Connection
+		METHOD m_idingvvf untrack ()V
+		METHOD m_txnizdyh update ()V
+		METHOD m_utnhuood needUpdate ()Z
+		METHOD m_zdpuenst track ()V
+	CLASS C_haokhcen AxisDistanceUpdatableConnection
+		METHOD m_ktnprabw getMaxAxisDistance ()I
+	CLASS C_pzaphwuu ManhattanDistanceUpdatableConnection
+		METHOD m_bkkpduvl getManhattanDistance ()I
+	CLASS C_ukboiutf AzimuthConnection
+		FIELD f_ovasmpzc angle F
+	CLASS C_vfonhpab PositionConnection
 		FIELD f_dfbllroq icon Lnet/minecraft/unmapped/C_xucdsrtl$C_ozyhcqwy;
+	CLASS C_zsynfppf ChunkConnection
+		FIELD f_dttiibqp pos Lnet/minecraft/unmapped/C_ynrszrtu;

--- a/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
+++ b/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
@@ -12,9 +12,9 @@ CLASS net/minecraft/unmapped/C_jtpeboen net/minecraft/world/waypoint/WaypointSou
 		METHOD m_txnizdyh update ()V
 		METHOD m_utnhuood isInvalid ()Z
 		METHOD m_zdpuenst track ()V
-	CLASS C_haokhcen AxisDistanceUpdatableConnection
+	CLASS C_haokhcen AxisDistanceValidatedConnection
 		METHOD m_ktnprabw getMaxAxisDistance ()I
-	CLASS C_pzaphwuu ManhattanDistanceUpdatableConnection
+	CLASS C_pzaphwuu ManhattanDistanceValidatedConnection
 		METHOD m_bkkpduvl getManhattanDistance ()I
 	CLASS C_ukboiutf AzimuthConnection
 		FIELD f_ovasmpzc angle F

--- a/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
+++ b/mappings/net/minecraft/world/waypoint/WaypointSource.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/unmapped/C_jtpeboen net/minecraft/world/waypoint/WaypointSou
 	CLASS C_erspwfzf Connection
 		METHOD m_idingvvf untrack ()V
 		METHOD m_txnizdyh update ()V
-		METHOD m_utnhuood needUpdate ()Z
+		METHOD m_utnhuood isInvalid ()Z
 		METHOD m_zdpuenst track ()V
 	CLASS C_haokhcen AxisDistanceUpdatableConnection
 		METHOD m_ktnprabw getMaxAxisDistance ()I


### PR DESCRIPTION
- renames `Task` -> `ContinuableTask`
- renames `TaskControl` -> `Task`
- renames methods that return passed `Brain`s `create` -> `init`
- adds several simple type names
- *removes* `inherit` from `Waypoint` simple name because it's inherited by entities (I added new simple names for appropriate subclasses)