### PR TITLE
Verify before generating build number

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Generate the build number based on tags to allow per branch build numbers, not something github provides by default.
+      # Build before generating build number so the build number doesn't needlessly increase in the event of an error.
+      - name: Build
+        run: ./gradlew build javadocJar --stacktrace
+      # Generate the build number based on tags to allow per branch build numbers, not something GitHub provides by default.
       - name: Generate build number
         id: buildnumber
         uses: onyxmueller/build-tag-number@v1
         with:
           token: ${{ secrets.github_token }}
           prefix: "build/${{ github.ref }}"
-      - run: ./gradlew build javadoc javadocJar publish --stacktrace
+      - name: Publish
+        run: ./gradlew publish --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}


### PR DESCRIPTION
Separates `build javadocJar` (and removes explicit `javadoc`) from `publish` and moves them before "Generate build number" to prevent increasing the build number in the event of a build failure.

I'm not sure how to test a publish workflow; this is untested.

https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-mappings/1.21.10+build.4/
is build 4 but it's the only 1.21.10 mappings version on the maven because the publish action failed at `javadoc` several times.