### PR TITLE
Fix `world` inheritance

### DIFF
--- a/mappings/net/minecraft/entity/mob/Angerable.mapping
+++ b/mappings/net/minecraft/entity/mob/Angerable.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/unmapped/C_ceqittzp net/minecraft/entity/mob/Angerable
 	METHOD m_igzwsudv hasAngerTime ()Z
 		COMMENT Note: this can't be named {@code isAngry} because implementers use that name for
 		COMMENT getting their {@code ANGRY} tracked data.
+	METHOD m_kqxvnqqn world ()Lnet/minecraft/unmapped/C_cdctfzbn;
 	METHOD m_lazolqzm canTarget (Lnet/minecraft/unmapped/C_usxaxydn;)Z
 	METHOD m_mqgluxpv getTarget ()Lnet/minecraft/unmapped/C_usxaxydn;
 	METHOD m_mvdrcxxa forgive (Lnet/minecraft/unmapped/C_bdwnwhiu;Lnet/minecraft/unmapped/C_jzrpycqo;)V


### PR DESCRIPTION
names `Angerable::world`, fixing `AbstractMethodError` for `Angerable`s that inherit `Entities`' `Positioned::world` implementation